### PR TITLE
GPII-2833 - Add persistence to auto generated variables

### DIFF
--- a/modules/deploy/52-couchdb-secrets.erb
+++ b/modules/deploy/52-couchdb-secrets.erb
@@ -1,0 +1,13 @@
+<% require 'base64' %>
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: gpii
+  name: couchdb-secrets
+type: Opaque
+data:
+  user: <%= Base64.strict_encode64(@secrets["couchdb_user"]) %>
+  password: <%= Base64.strict_encode64(@secrets["couchdb_password"]) %>
+  erlang_cookie: <%= Base64.strict_encode64(@secrets["erlang_cookie"]) %>
+  url-preferences: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences") %>
+  url-preferences-datasource: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken") %>

--- a/modules/deploy/52-couchdb-secrets.erb
+++ b/modules/deploy/52-couchdb-secrets.erb
@@ -9,5 +9,5 @@ data:
   user: <%= Base64.strict_encode64(@secrets["couchdb_user"]) %>
   password: <%= Base64.strict_encode64(@secrets["couchdb_password"]) %>
   erlang_cookie: <%= Base64.strict_encode64(@secrets["erlang_cookie"]) %>
-  url-preferences: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences") %>
-  url-preferences-datasource: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken") %>
+  couchdb_preferences_url: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences") %>
+  preferences_datasource_url: <%= Base64.strict_encode64("http://#{@secrets["couchdb_user"]}:#{@secrets["couchdb_password"]}@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken") %>

--- a/modules/deploy/53-couchdb-statefulset.erb
+++ b/modules/deploy/53-couchdb-statefulset.erb
@@ -19,11 +19,11 @@ spec:
         image: gpii/couchdb:latest
         env:
         - name: COUCHDB_USER
-          value: <%= @secrets[:couchdb_user] %>
+          value: <%= @secrets["couchdb_user"] %>
         - name: COUCHDB_PASSWORD
-          value: <%= @secrets[:couchdb_password] %>
+          value: <%= @secrets["couchdb_password"] %>
         - name: ERLANG_COOKIE
-          value: <%= @secrets[:erlang_cookie] %>
+          value: <%= @secrets["erlang_cookie"] %>
         ports:
         - name: data
           containerPort: 5984

--- a/modules/deploy/53-couchdb-statefulset.erb
+++ b/modules/deploy/53-couchdb-statefulset.erb
@@ -19,11 +19,20 @@ spec:
         image: gpii/couchdb:latest
         env:
         - name: COUCHDB_USER
-          value: <%= @secrets["couchdb_user"] %>
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secrets
+              key: user
         - name: COUCHDB_PASSWORD
-          value: <%= @secrets["couchdb_password"] %>
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secrets
+              key: password
         - name: ERLANG_COOKIE
-          value: <%= @secrets["erlang_cookie"] %>
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secrets
+              key: erlang_cookie
         ports:
         - name: data
           containerPort: 5984

--- a/modules/deploy/65-dataloader-job.erb
+++ b/modules/deploy/65-dataloader-job.erb
@@ -14,7 +14,7 @@ spec:
         image: <%= @versions["preferences-dataloader"] %>
         env:
         - name: COUCHDB_URL
-          value: http://<%= @secrets[:couchdb_user] %>:<%= @secrets[:couchdb_password] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences
+          value: http://<%= @secrets["couchdb_user"] %>:<%= @secrets["couchdb_password"] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences
         - name: CLEAR_INDEX
           value: 'true'
       restartPolicy: OnFailure

--- a/modules/deploy/65-dataloader-job.erb
+++ b/modules/deploy/65-dataloader-job.erb
@@ -17,7 +17,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: couchdb-secrets
-              key: url-preferences
+              key: couchdb_preferences_url
         - name: CLEAR_INDEX
           value: 'true'
       restartPolicy: OnFailure

--- a/modules/deploy/65-dataloader-job.erb
+++ b/modules/deploy/65-dataloader-job.erb
@@ -14,7 +14,10 @@ spec:
         image: <%= @versions["preferences-dataloader"] %>
         env:
         - name: COUCHDB_URL
-          value: http://<%= @secrets["couchdb_user"] %>:<%= @secrets["couchdb_password"] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secrets
+              key: url-preferences
         - name: CLEAR_INDEX
           value: 'true'
       restartPolicy: OnFailure

--- a/modules/deploy/73-preferences-deploy.erb
+++ b/modules/deploy/73-preferences-deploy.erb
@@ -19,6 +19,9 @@ spec:
         - name: NODE_ENV
           value: gpii.config.preferencesServer.standalone.production
         - name: GPII_PREFERENCES_DATASOURCE_URL
-          value: http://<%= @secrets["couchdb_user"] %>:<%= @secrets["couchdb_password"] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secrets
+              key: url-preferences-datasource
         - name: GPII_PREFERENCES_LISTEN_PORT
           value: '8081'

--- a/modules/deploy/73-preferences-deploy.erb
+++ b/modules/deploy/73-preferences-deploy.erb
@@ -19,6 +19,6 @@ spec:
         - name: NODE_ENV
           value: gpii.config.preferencesServer.standalone.production
         - name: GPII_PREFERENCES_DATASOURCE_URL
-          value: http://<%= @secrets[:couchdb_user] %>:<%= @secrets[:couchdb_password] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken
+          value: http://<%= @secrets["couchdb_user"] %>:<%= @secrets["couchdb_password"] %>@couchdb-lb.gpii.svc.cluster.local:5984/preferences/%userToken
         - name: GPII_PREFERENCES_LISTEN_PORT
           value: '8081'

--- a/modules/deploy/73-preferences-deploy.erb
+++ b/modules/deploy/73-preferences-deploy.erb
@@ -22,6 +22,6 @@ spec:
           valueFrom:
             secretKeyRef:
               name: couchdb-secrets
-              key: url-preferences-datasource
+              key: preferences_datasource_url
         - name: GPII_PREFERENCES_LISTEN_PORT
           value: '8081'

--- a/modules/deploy/Rakefile
+++ b/modules/deploy/Rakefile
@@ -48,11 +48,6 @@ task :setup_secrets do
     @secrets = Hash.new
   end
 
-  puts("\n#########################\n")
-  require 'pp'
-  pp @secrets
-  puts("\n#########################\n")
-
   ['couchdb_user','couchdb_password','erlang_cookie'].each do |secret|
     unless ENV[secret.upcase].to_s.empty?
       @secrets[secret] = ENV[secret.upcase]

--- a/modules/deploy/Rakefile
+++ b/modules/deploy/Rakefile
@@ -42,38 +42,29 @@ end
 task :setup_secrets do
   saved_secrets_file_path = "secrets/#{ENV["TF_VAR_cluster_name"]}-secrets.yml"
   begin
-    @saved_secrets = YAML.load(File.read(saved_secrets_file_path))
-  rescue Errno::ENOENT => e
+    secrets_wo_syms = YAML.load(File.read(saved_secrets_file_path))
+    @secrets = secrets_wo_syms.collect{|k,v| [k.to_s.to_sym, v]}.to_h
+  rescue Errno::ENOENT
+    generate_file = true
+    @secrets = Hash.new
+  end
+
+  ['couchdb_user','couchdb_password','erlang_cookie'].each do |secret|
+    unless ENV[secret.upcase].to_s.empty?
+      @secrets[secret.to_sym] = ENV[secret.upcase]
+      # we don't want to store Environment variables
+      generate_file = false
+    end
+    @secrets[secret.to_sym] = SecureRandom.hex if @secrets[secret.to_sym].to_s.empty?
+  end
+
+  if generate_file
     puts "Secret file #{saved_secrets_file_path} for this deployment not found. I will create one."
-    @saved_secrets = Hash.new
+    File.open(saved_secrets_file_path, 'w+') do |file|
+      secrets_wo_syms = @secrets.collect{|k,v| [k.to_s, v]}.to_h
+      file.write(secrets_wo_syms.to_yaml)
+    end
   end
-
-  @secrets = Hash.new
-
-  unless [nil, ''].include?(@saved_secrets["COUCHDB_USER"])
-    @secrets[:couchdb_user] = @saved_secrets["COUCHDB_USER"]
-  end
-  unless [nil, ''].include?(ENV["COUCHDB_USER"])
-    @secrets[:couchdb_user] = ENV["COUCHDB_USER"]
-  end
-
-  unless [nil, ''].include?(@saved_secrets["COUCHDB_PASSWORD"])
-    @secrets[:couchdb_password] = @saved_secrets["COUCHDB_PASSWORD"]
-  end
-  unless [nil, ''].include?(ENV["COUCHDB_PASSWORD"])
-    @secrets[:couchdb_password] = ENV["COUCHDB_PASSWORD"]
-  end
-
-  unless[nil, ''].include?(@saved_secrets["ERLANG_COOKIE"])
-    @secrets[:erlang_cookie] = @saved_secrets["ERLANG_COOKIE"]
-  end
-  unless [nil, ''].include?(ENV["ERLANG_COOKIE"])
-    @secrets[:erlang_cookie] = ENV["ERLANG_COOKIE"]
-  end
-
-  @secrets[:couchdb_user] = "gpii" if [nil, ''].include?(@secrets[:couchdb_user])
-  @secrets[:couchdb_password] = SecureRandom.hex if [nil, ''].include?(@secrets[:couchdb_password])
-  @secrets[:erlang_cookie] = SecureRandom.hex if [nil, ''].include?(@secrets[:erlang_cookie])
 
   if ENV["ALERTMANAGER_EMAIL_AUTH_PASSWORD"].nil?
     puts "WARNING: ALERTMANAGER_EMAIL_AUTH_PASSWORD is not set. Email notifications will be disabled."

--- a/modules/deploy/Rakefile
+++ b/modules/deploy/Rakefile
@@ -42,27 +42,30 @@ end
 task :setup_secrets do
   saved_secrets_file_path = "secrets/#{ENV["TF_VAR_cluster_name"]}-secrets.yml"
   begin
-    secrets_wo_syms = YAML.load(File.read(saved_secrets_file_path))
-    @secrets = secrets_wo_syms.collect{|k,v| [k.to_s.to_sym, v]}.to_h
+    @secrets = YAML.load(File.read(saved_secrets_file_path))
   rescue Errno::ENOENT
     generate_file = true
     @secrets = Hash.new
   end
 
+  puts("\n#########################\n")
+  require 'pp'
+  pp @secrets
+  puts("\n#########################\n")
+
   ['couchdb_user','couchdb_password','erlang_cookie'].each do |secret|
     unless ENV[secret.upcase].to_s.empty?
-      @secrets[secret.to_sym] = ENV[secret.upcase]
+      @secrets[secret] = ENV[secret.upcase]
       # we don't want to store Environment variables
       generate_file = false
     end
-    @secrets[secret.to_sym] = SecureRandom.hex if @secrets[secret.to_sym].to_s.empty?
+    @secrets[secret] = SecureRandom.hex if @secrets[secret].to_s.empty?
   end
 
   if generate_file
     puts "Secret file #{saved_secrets_file_path} for this deployment not found. I will create one."
     File.open(saved_secrets_file_path, 'w+') do |file|
-      secrets_wo_syms = @secrets.collect{|k,v| [k.to_s, v]}.to_h
-      file.write(secrets_wo_syms.to_yaml)
+      file.write(@secrets.to_yaml)
     end
   end
 


### PR DESCRIPTION
This PR includes some refactoring of the code and also saves the variables in a yml file if they aren't found. In the case that the variables are set using environment variables (i.e. CI production or staging) the variables are not saved in a local file to improve the security.

More info: https://issues.gpii.net/browse/GPII-2833