### PR TITLE
GPII-2827: spike: CIS Kubernetes hardening standard

### DIFF
--- a/dev/Rakefile
+++ b/dev/Rakefile
@@ -18,6 +18,7 @@ task :apply => [@tmpdir, :generate_modules] do
   sleep 60
   Rake::Task["wait_for_api_dns_local"].invoke
   Rake::Task["test_master"].invoke
+  Rake::Task["kops_rolling_update"].invoke
 end
 CLEAN << "#{ENV['HOME']}/.terragrunt"
 

--- a/dev/Rakefile
+++ b/dev/Rakefile
@@ -23,7 +23,10 @@ end
 CLEAN << "#{ENV['HOME']}/.terragrunt"
 
 task :test_master do
-  sh "ssh -i #{ENV["HOME"]}/.ssh/id_rsa.gpii-ci -o StrictHostKeyChecking=no admin@api.#{ENV["TF_VAR_cluster_name"]} -- ping -c 1 8.8.8.8"
+  wait_for(
+    "ssh -i #{ENV["HOME"]}/.ssh/id_rsa.gpii-ci -o StrictHostKeyChecking=no admin@api.#{ENV["TF_VAR_cluster_name"]} -- ping -c 1 8.8.8.8",
+    max_wait_secs: 60,
+  )
 end
 
 desc "Destroy cluster"

--- a/modules/k8s-cluster-dns/provider.tf
+++ b/modules/k8s-cluster-dns/provider.tf
@@ -5,6 +5,6 @@
 # it's empty when I try to call it. Maybe because I need a provider to run the
 # data stanza that would fill in these values?
 provider "aws" {
-  version = "~> 1.7"
+  version = "~> 1.8"
   region = "us-east-2"
 }

--- a/modules/k8s/Rakefile
+++ b/modules/k8s/Rakefile
@@ -16,8 +16,9 @@ directory KOPS_OUT_DIR
 CLOBBER << KOPS_OUT_DIR
 
 desc "Generate config for cluster, including terraform files and kops cluster definition in S3"
-task :generate => [@tmpdir, :configure_kops, "Rakefile", "#{KOPS_OUT_DIR}/kubernetes.tf"]
+task :generate => [@tmpdir, :configure_kops, "Rakefile", KOPS_OUT_DIR, "#{KOPS_OUT_DIR}/kubernetes.tf"]
 rule "#{KOPS_OUT_DIR}/kubernetes.tf" do
+  # Create cluster iff it doesn't already exist.
   sh "kops get cluster #{ENV["TF_VAR_cluster_name"]}" do |ok, res|
     unless ok
       sh "kops create cluster \
@@ -35,47 +36,31 @@ rule "#{KOPS_OUT_DIR}/kubernetes.tf" do
         --out=#{KOPS_OUT_DIR} \
         --ssh-public-key=~/.ssh/id_rsa.gpii-ci.pub \
       "
-
-      # Export the configuration to a yaml file
-      sh "kops get \
-        --name #{ENV["TF_VAR_cluster_name"]} \
-        -o yaml > #{KOPS_OUT_DIR}/cluster-orig.yml \
-       "
- 
-      # Merge yaml file with custom config
-      current_settings = File.read("#{KOPS_OUT_DIR}/cluster-orig.yml")
-      custom_settings = ERB.new(File.read("cluster-custom-settings.yml.erb")).result(binding)
-      settings = MergeYaml.merge_yaml(current_settings, custom_settings)
-      File.open("#{KOPS_OUT_DIR}/cluster.yml", "w") do |file|
-        file.write(settings)
-      end
-
-      # Update the definition
-      sh "kops replace -f #{KOPS_OUT_DIR}/cluster.yml"
-      sh "kops update cluster \
-        --name=#{ENV["TF_VAR_cluster_name"]} \
-        --target=terraform \
-        --out=#{KOPS_OUT_DIR} \
-      "
-
-    else
-      puts "Cluster #{ENV["TF_VAR_cluster_name"]} already exists."
-      puts "If you want to change its configuration, you'll need to:"
-      puts "* rake destroy"
-      puts "* rake clobber"
-      puts "(Note that this DESTROYS THE CLUSTER.)"
-      puts "--OR--"
-      puts "* Upgrade manually. See https://github.com/kubernetes/kops/blob/master/docs/upgrade.md."
-      puts "(This is not recommended except for testing.)"
-      puts
-      puts "Updating an existing cluster is a planned feature."
-      sh "kops update cluster \
-        --name=#{ENV["TF_VAR_cluster_name"]} \
-        --target=terraform \
-        --out=#{KOPS_OUT_DIR} \
-      "
     end
   end
+
+  # Export cluster configuration to a file.
+  sh "kops get \
+    --name #{ENV["TF_VAR_cluster_name"]} \
+    -o yaml > #{KOPS_OUT_DIR}/cluster-orig.yml \
+  "
+
+  # Merge file with custom config.
+  current_settings = File.read("#{KOPS_OUT_DIR}/cluster-orig.yml")
+  custom_settings = ERB.new(File.read("cluster-custom-settings.yml.erb")).result(binding)
+  settings = MergeYaml.merge_yaml(current_settings, custom_settings)
+  File.open("#{KOPS_OUT_DIR}/cluster.yml", "w") do |file|
+    file.write(settings)
+  end
+
+  # Update the definition
+  sh "kops replace -f #{KOPS_OUT_DIR}/cluster.yml"
+  sh "kops update cluster \
+    --name=#{ENV["TF_VAR_cluster_name"]} \
+    --target=terraform \
+    --out=#{KOPS_OUT_DIR} \
+  "
+
   cp FileList.new("./*.tf"), "#{KOPS_OUT_DIR}/"
 end
 CLEAN << KOPS_OUT_DIR

--- a/modules/k8s/cluster-custom-settings.yml.erb
+++ b/modules/k8s/cluster-custom-settings.yml.erb
@@ -1,3 +1,5 @@
 spec:
   iam:
     legacy: true
+  kubelet:
+    anonymousAuth: false

--- a/modules/k8s/cluster-custom-settings.yml.erb
+++ b/modules/k8s/cluster-custom-settings.yml.erb
@@ -1,5 +1,7 @@
 spec:
   iam:
     legacy: true
+  kubeControllerManager:
+    terminatedPodGCThreshold: 100  # Wild, untested guess
   kubelet:
     anonymousAuth: false

--- a/modules/volume/provider.tf
+++ b/modules/volume/provider.tf
@@ -5,6 +5,6 @@
 # it's empty when I try to call it. Maybe because I need a provider to run the
 # data stanza that would fill in these values?
 provider "aws" {
-  version = "~> 1.7"
+  version = "~> 1.8"
   region = "us-east-2"
 }

--- a/rakefiles/kops.rake
+++ b/rakefiles/kops.rake
@@ -3,7 +3,7 @@ task :configure_kops do
   ENV["KOPS_STATE_STORE"] = "s3://#{ENV["S3_BUCKET"]}"
 end
 
-desc "Configure kubectl to know about cluster"
+desc "Configure kubectl to know about cluster #{ENV["TF_VAR_cluster_name"]}"
 task :configure_kubectl => [@tmpdir, :configure_kops] do
   sh "kops export kubecfg #{ENV["TF_VAR_cluster_name"]}"
 end
@@ -42,12 +42,8 @@ task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
   puts "  # Clears existing generated files. NOTE: will clean up other generated files for other modules."
   puts "  rake clean"
   puts
-  puts "  # Enact changes controlled by Terraform (e.g. instance types used by Masters and Nodes)"
+  puts "  # Enact changes."
   puts "  rake apply"
-  puts
-  puts "  # Enact changes controlled by kops (e.g. Kubernetes version) and changes that require instance restarts"
-  puts "  # (e.g. instance types used by Masters and Nodes)"
-  puts "  rake kops_rolling_update"
 end
 
 task :kops_rolling_update => [@tmpdir, :configure_kops] do

--- a/rakefiles/kops.rake
+++ b/rakefiles/kops.rake
@@ -28,6 +28,10 @@ task :kops_edit_cluster => [@tmpdir, :configure_kops] do
   puts
   puts "Running 'kops edit instancegroups master-us-east-2c'"
   sh "kops edit instancegroups master-us-east-2c --name #{ENV["TF_VAR_cluster_name"]}"
+  Rake::Task[:display_rolling_update_cmd].invoke
+end
+
+task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
   puts
   puts "Here's what 'kops update cluster' and 'kops rolling-update cluster' will do:"
   sh "kops update cluster #{ENV["TF_VAR_cluster_name"]} --target terraform"
@@ -37,12 +41,15 @@ task :kops_edit_cluster => [@tmpdir, :configure_kops] do
   puts
   puts "  # Clears existing generated files. NOTE: will clean up other generated files for other modules."
   puts "  rake clean"
-  Rake::Task[:display_rolling_update_cmd].invoke
-end
-
-task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
+  puts
+  puts "  # Enact changes controlled by Terraform (e.g. instance types used by Masters and Nodes)"
+  puts "  rake apply"
   puts
   puts "  # Enact changes controlled by kops (e.g. Kubernetes version) and changes that require instance restarts"
   puts "  # (e.g. instance types used by Masters and Nodes)"
-  puts "  KOPS_STATE_STORE=#{ENV["KOPS_STATE_STORE"]} KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes"
+  puts "  rake kops_rolling_update"
+end
+
+task :kops_rolling_update => [@tmpdir, :configure_kops] do
+  sh "KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes"
 end

--- a/rakefiles/kops.rake
+++ b/rakefiles/kops.rake
@@ -35,12 +35,12 @@ task :kops_edit_cluster => [@tmpdir, :configure_kops] do
   puts
   puts "If that looks right, run:"
   puts
-  ###puts "  KOPS_STATE_STORE=#{ENV["KOPS_STATE_STORE"]} kops update cluster #{ENV["TF_VAR_cluster_name"]} --yes"
   puts "  # Clears existing generated files. NOTE: will clean up other generated files for other modules."
   puts "  rake clean"
-  puts
-  puts "  # Enact changes controlled by Terraform (e.g. instance types used by Masters and Nodes)"
-  puts "  rake apply"
+  Rake::Task[:display_rolling_update_cmd].invoke
+end
+
+task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
   puts
   puts "  # Enact changes controlled by kops (e.g. Kubernetes version) and changes that require instance restarts"
   puts "  # (e.g. instance types used by Masters and Nodes)"


### PR DESCRIPTION
(This PR replaces https://github.com/gpii-ops/gpii-infra/pull/10.)

More details in ticket: https://issues.gpii.net/browse/GPII-2827

One thing that's neat is we now update the kops cluster configuration every time, even for existing clusters.

After discussing with Alfredo, I decided to run `kops rolling-update cluster` as part of `apply` so that configuration changes take effect immediately and automatically. Note that `rolling-update` is a no-op if there no configuration changes are needed.

Also note that `rake clean` is needed after cluster config changes so that `:generate_modules` runs to re-generate cluster config files. Dependency calculations in `modules/k8s` could use some clean-up to avoid the need for `rake clean`, but I'm punting it for now as this is a rare operation.