### PR TITLE
GPII-2886 Add secrets[:alertmanager_email_auth_username].

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,8 @@ See https://github.com/ussjoin/gpii-backup-scripts#ec2-ebs-snapshot-replication.
 
 We use [Prometheus Alertmanager](https://github.com/prometheus/alertmanager), managed by [Prometheus Operator](https://github.com/coreos/prometheus-operator/) and some pieces from [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus), to handle alerts and notifications.
 
-1. Create a dedicated Gmail account (ours is `alertmanager@RtF`) for sending alerts.
-   * Log in to the account.
-   * Create a filter that sends all incoming mail (`to: alertmanager`) to the Trash.
-   * Create an [App Password](https://support.google.com/accounts/answer/185833?hl=en). Note that you'll need to temporarily enable 2-Step Verification (and successfully authenticate using that second factor) before you can create an App Password. Once the password is created, you can disable 2-Step Verification again.
-   * Add the App Password to [Gitlab](CI-CD.md#configure-gitlab-secret-variables).
+1. Create [Amazon SES credentials](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html).
+   * Add the usernamd and password to [Gitlab](CI-CD.md#configure-gitlab-secret-variables).
 1. Create a dedicate Google Group (ours is `alerts@RtF`) to receive alerts and re-distribute them to Operations staff.
    * Remove public access.
    * Allow posts from the address you created above.

--- a/modules/deploy/Rakefile
+++ b/modules/deploy/Rakefile
@@ -73,6 +73,13 @@ task :setup_secrets do
     end
   end
 
+  if ENV["ALERTMANAGER_EMAIL_AUTH_USERNAME"].nil?
+    puts "WARNING: ALERTMANAGER_EMAIL_AUTH_USERNAME is not set. Email notifications will be disabled."
+    puts "For details on enabling these notifications, see:"
+    puts "  https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-gitlab-secret-variables"
+  else
+    @secrets[:alertmanager_email_auth_username] = ENV["ALERTMANAGER_EMAIL_AUTH_USERNAME"]
+  end
   if ENV["ALERTMANAGER_EMAIL_AUTH_PASSWORD"].nil?
     puts "WARNING: ALERTMANAGER_EMAIL_AUTH_PASSWORD is not set. Email notifications will be disabled."
     puts "For details on enabling these notifications, see:"

--- a/modules/deploy/secrets/alertmanager.yaml.erb
+++ b/modules/deploy/secrets/alertmanager.yaml.erb
@@ -26,10 +26,10 @@ receivers:
 - name: email-alerts
   email_configs:
   - to: alerts+<%= ENV["TF_VAR_environment"] %>@raisingthefloor.org
-    from: alertmanager@raisingthefloor.org
-    smarthost: smtp.gmail.com:587
-    auth_username: "alertmanager@raisingthefloor.org"
-    auth_identity: "alertmanager@raisingthefloor.org"
+    from: alertmanager@automation.raisingthefloor.org
+    smarthost: email-smtp.us-east-1.amazonaws.com:587
+    auth_username: "<%= @secrets[:alertmanager_email_auth_username] %>"
+    auth_identity: "<%= @secrets[:alertmanager_email_auth_username] %>"
     auth_password: "<%= @secrets[:alertmanager_email_auth_password] %>"
 <% end %>
 


### PR DESCRIPTION
Alertmanager email is now Amazon SES.