### PR TITLE
GPII-2990: rake glue for exekube-based project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ setup:
     - terragrunt -version
     - kubectl version --client
     - kops version
+    - helm version
     - aws --version
     - jq --version
     - ruby --version

--- a/aws/README.md
+++ b/aws/README.md
@@ -207,7 +207,7 @@ See [CI-CD.md#running-in-non-dev-environments](CI-CD.md#running-manually-in-non-
    * E.g., `gpii/universal -> mrtyler/universal`
 1. Run `update-version`. It will generate a `version.yml` in the current directory.
 1. `cp version.yml ../gpii-infra/modules/deploy`
-1. `cd ../gpii-infra/dev && rake deploy`
+1. `cd ../gpii-infra/aws/dev && rake deploy`
 
 #### Can't I just edit `version.yml` by hand?
 
@@ -217,7 +217,7 @@ If you don't want to deal with gpii-version-updater, you can instead:
 1. Edit `modules/deploy/version.yml`. Find your component and replace the entire image value (path and SHA) with your Docker Hub user account.
    * E.g., `flowmanager: "gpii/universal@sha256:4b3...64f" -> flowmanager: "mrtyler/universal"`
 1. Manually delete the component via Kubernetes Dashboard or `kubectl delete`.
-1. `cd dev && rake deploy`
+1. `cd aws/dev && rake deploy`
 
 #### A note about local changes and gpii-dataloader
 
@@ -226,7 +226,7 @@ If you don't want to deal with gpii-version-updater, you can instead:
 1. Because of how Kubernetes Jobs work, the dataloader will not re-run when a new Docker image becomes available (this is different from Deployments like `flowmanager`, which are updated when the Docker image changes).
 1. Thus, to make changes to the dataloader:
    * Delete the Job: `kubectl -n gpii delete job gpii-dataloader`
-   * Re-deploy the Job: `cd dev && rake deploy`
+   * Re-deploy the Job: `cd aws/dev && rake deploy`
 
 ### Restoring a volume from a backup/snapshot
 
@@ -265,7 +265,7 @@ If you don't want to deal with gpii-version-updater, you can instead:
 
 This is what I used to create a fake preference while verifying that volumes are restored correctly.
 
-1. Run a container inside the cluster: `cd dev && rake run_interactive`
+1. Run a container inside the cluster: `cd aws/dev && rake run_interactive`
 1. From inside the container, install some tools: `apk update && apk add curl`
 1. Define a record:
 ```

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -4,7 +4,7 @@ This directory manages GPII infrastructure in [Google Cloud Project (GCP)](https
 
 Initial instructions based on [exekube's Getting Started](https://exekube.github.io/exekube/in-practice/getting-started/) (version 0.3.0).
 
-## Setup
+## Creating an environment
 
 1. Clone this repo.
 1. (Optional) Clone [the gpii-ops fork of exekube](https://github.com/gpii-ops/exekube).
@@ -13,14 +13,14 @@ Initial instructions based on [exekube's Getting Started](https://exekube.github
    * You can use a different Organization or Billing Account, e.g. from a GCP Free Trial Account, with `export ORGANIZATION_ID=111111111111` and/or `export BILLING_ID=222222-222222-222222`.
 1. `export TF_VAR_project_id=xk-mrtyler`
    * The project ID must be unique across all of Google Cloud Platform, like an AWS S3 Bucket.
-   * When changing to a new project\_id, I had to `rm .config/terragrunt`. This is something that `rake clean` should handle.
+   * When changing to a new project\_id, I had to `rm .config/terragrunt`. This is something that `rake clean` will handle.
 1. `cd gpii-infra/gcp`
 1. `rake dev:project_init`
    * Follow the instructions to authenticate.
    * This step is not idempotent. It will fail if you've already initialized the project named in `$TF_VAR_project_id`.
 1. `rake dev`
 
-## Teardown
+## Tearing down an environment
 
 1. `rake dev:destroy_cluster`
    * This is the important one since it shuts down the expensive bits (VMs in the Kubernetes cluster, mostly)

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -9,28 +9,22 @@ Initial instructions based on [exekube's Getting Started](https://exekube.github
 1. Clone this repo.
 1. (Optional) Clone [the gpii-ops fork of exekube](https://github.com/gpii-ops/exekube).
    * The `gpii-infra` clone and the `exekube` clone should be siblings in the same directory (there are some references to `../exekube`).
-1. `cd gpii-infra/gcp`
-1. `alias xk='docker-compose run --rm --service-ports xk'`
-1. `export ENV=dev`
-1. `export ORGANIZATION_ID=247149361674`
-   * *OR* Create a GCP Free Trial account. Use the Organization ID from there.
-1. `export BILLING_ID=01A0E1-B0B31F-349F4F`
-   * *OR* Create a GCP Free Trial account. Use the Billing ID from there.
+1. By default you'll use the RtF Organization and Billing Account.
+   * You can use a different Organization or Billing Account, e.g. from a GCP Free Trial Account, with `export ORGANIZATION_ID=111111111111` and/or `export BILLING_ID=222222-222222-222222`.
 1. `export TF_VAR_project_id=xk-mrtyler`
    * The project ID must be unique across all of Google Cloud Platform, like an AWS S3 Bucket.
    * When changing to a new project\_id, I had to `rm .config/terragrunt`. This is something that `rake clean` should handle.
-1. `xk gcloud auth login`
+1. `cd gpii-infra/gcp`
+1. `rake dev:project_init`
    * Follow the instructions to authenticate.
-1. `xk gcp-project-init`
    * This step is not idempotent. It will fail if you've already initialized the project named in `$TF_VAR_project_id`.
-1. `xk up live/dev/infra`
-1. `xk up`
+1. `rake dev`
 
 ## Teardown
 
-1. `xk down`
+1. `rake dev:destroy_cluster`
    * This is the important one since it shuts down the expensive bits (VMs in the Kubernetes cluster, mostly)
-1. `xk down live/dev/infra`
+1. `rake dev:destroy`
    * Exekube recommends leaving these resources up since they are cheap
 1. There's no automation for destroying the Project and starting over. I usually use the GCP Dashboard.
    * Note that "deleting" a Project really marks it for deletion in 30 days. You can't create a new Project with the same name until the old one is culled.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -41,8 +41,7 @@ Initial instructions based on [exekube's Getting Started](https://exekube.github
       * @mrtyler believes he did this when he created his Free Trial account using his RtF email address.
    * "If you're the Super Admin of your G Suite domain account, you can add yourself and others as the Organization Admin of the corresponding Organization. For instructions on adding Organization Admins, see Adding an organization admin."
 * https://cloud.google.com/resource-manager/docs/creating-managing-organization#adding_an_organization_admin
-   * Manually create IAMs for Ops Team. Assign role "Organization Policy Administrator" and "Billing Account User".
-      * Actually this isn't working either -- even with admin privileges, Alfredo can't attach his Project to the Official Billing Account. Alfredo is investigating.
+   * Manually create IAMs for Ops Team. Assign role "Project -> Owner" and "Billing Account User".
 * https://cloud.google.com/resource-manager/docs/quickstart-organizations#create_a_billing_account
    * Manually create IAM for Eugene. Assign role "Billing Account Administrator".
    * Eugene creates Billing Account, "Official". Fills in contact info, payment info.
@@ -51,3 +50,6 @@ Initial instructions based on [exekube's Getting Started](https://exekube.github
       * In spite of all those privileges, I can't Manage Payment Users for any Billing Accounts other than the one from my Free Trial Account.
    * Send billing emails to accounts-payable@rtf-us.org -- https://cloud.google.com/billing/docs/how-to/modify-contacts
       * Billing -> Official -> Payment Settings -> Payments Users -> Manage Payments Users -> Add a New User. Leave all Permissions unchecked. Leave Primary Contact unchecked (there can be only one, and it's Eugene). Confirm invitation email.
+* https://support.google.com/code/contact/billing_quota_increase
+   * @mrtyler requested a quota bump to 100 Projects.
+      * He only authorized his own email for now, to see what it did. But it's possible other Ops team members will need to go through this step.

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -28,6 +28,7 @@ namespace :dev do |namespace|
   task :project_init => [:set_vars, @gcp_creds_file] do
     sh "#{@exekube_cmd} gcp-project-init"
     # TODO: Move this to exekube gcp-project-init instead?
+    # https://github.com/exekube/exekube/issues/90
     sh "#{@exekube_cmd} gcloud services enable serviceusage.googleapis.com"
   end
 

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -38,6 +38,16 @@ namespace :dev do |namespace|
     sh "#{@exekube_cmd} up"
   end
 
+  desc "Destroy cluster and low-level infrastructure"
+  task :destroy => [:set_vars, @gcp_creds_file, :destroy_cluster] do
+    sh "#{@exekube_cmd} down live/#{@env}/infra"
+  end
+
+  desc "Destroy cluster"
+  task :destroy_cluster => [:set_vars, @gcp_creds_file] do
+    sh "#{@exekube_cmd} down"
+  end
+
   desc "[ADVANCED] Interactive exekube shell"
   task :xk_sh => :set_vars do
     sh "#{@exekube_cmd} sh"

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -2,6 +2,7 @@ require "rake/clean"
 require_relative "rakefiles/vars.rb"
 
 @exekube_cmd = "docker-compose run --rm --service-ports xk"
+
 desc "Create dev cluster and deploy GPII components to it"
 task :dev => "dev:default"
 

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -2,6 +2,8 @@ require "rake/clean"
 require_relative "rakefiles/vars.rb"
 
 @exekube_cmd = "docker-compose run --rm --service-ports xk"
+desc "Create dev cluster and deploy GPII components to it"
+task :dev => "dev:default"
 
 namespace :dev do |namespace|
   task :default => :deploy
@@ -21,9 +23,24 @@ namespace :dev do |namespace|
   end
   CLOBBER << @gcp_creds_path
 
-  desc "Deploy GPII components to cluster"
-  task :deploy => :set_vars do
-    puts "_ID #{ENV["BILLING_ID"]} #{ENV["ORGANIZATION_ID"]}"
+  desc "[NOT IDEMPOTENT] Initialize GCP Project where this environment's resources will live"
+  task :project_init => [:set_vars, @gcp_creds_file] do
+    sh "#{@exekube_cmd} gcp-project-init"
+  end
+
+  desc "[ADVANCED] Create or update low-level infrastructure"
+  task :apply_infra => [:set_vars, @gcp_creds_file] do
+    sh "#{@exekube_cmd} up live/#{@env}/infra"
+  end
+
+  desc "Create cluster and deploy GPII components to it"
+  task :deploy => [:set_vars, @gcp_creds_file, :apply_infra] do
+    sh "#{@exekube_cmd} up"
+  end
+
+  desc "[ADVANCED] Interactive exekube shell"
+  task :xk_sh => :set_vars do
+    sh "#{@exekube_cmd} sh"
   end
 end
 

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -6,9 +6,9 @@ desc "Create dev cluster and deploy GPII components to it"
 task :dev => "dev:default"
 
 namespace :dev do |namespace|
-  task :default => :deploy
-
   @env = namespace.scope.path
+
+  task :default => :deploy
 
   task :set_vars do
     Vars.set_vars(@env)
@@ -23,9 +23,16 @@ namespace :dev do |namespace|
   end
   CLOBBER << @gcp_creds_path
 
-  desc "[NOT IDEMPOTENT] Initialize GCP Project where this environment's resources will live"
+  desc "[NOT IDEMPOTENT, RUN ONCE] Initialize GCP Project where this environment's resources will live"
   task :project_init => [:set_vars, @gcp_creds_file] do
     sh "#{@exekube_cmd} gcp-project-init"
+    # TODO: Move this to exekube gcp-project-init instead?
+    sh "#{@exekube_cmd} gcloud services enable serviceusage.googleapis.com"
+  end
+
+  desc "[ADVANCED] Tell gcloud to use TF_VAR_project_id as the default Project; can be useful after 'rake clobber'"
+  task :set_current_project => [:set_vars, @gcp_creds_file] do
+    sh "#{@exekube_cmd} gcloud config set project #{ENV["TF_VAR_project_id"]}"
   end
 
   desc "[ADVANCED] Create or update low-level infrastructure"

--- a/gcp/Rakefile
+++ b/gcp/Rakefile
@@ -1,0 +1,31 @@
+require "rake/clean"
+require_relative "rakefiles/vars.rb"
+
+@exekube_cmd = "docker-compose run --rm --service-ports xk"
+
+namespace :dev do |namespace|
+  task :default => :deploy
+
+  @env = namespace.scope.path
+
+  task :set_vars do
+    Vars.set_vars(@env)
+  end
+
+  @gcp_creds_path = ".config/#{@env}/gcloud"
+  @gcp_creds_file = "#{@gcp_creds_path}/credentials.db"
+  desc "Authenticate and generate GCP credentials (gcloud auth login)"
+  task :auth => [:set_vars, @gcp_creds_file]
+  rule @gcp_creds_file do
+    sh "#{@exekube_cmd} gcloud auth login"
+  end
+  CLOBBER << @gcp_creds_path
+
+  desc "Deploy GPII components to cluster"
+  task :deploy => :set_vars do
+    puts "_ID #{ENV["BILLING_ID"]} #{ENV["ORGANIZATION_ID"]}"
+  end
+end
+
+
+# vim: et ts=2 sw=2:

--- a/gcp/rakefiles/tests/Gemfile
+++ b/gcp/rakefiles/tests/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem "rspec"

--- a/gcp/rakefiles/tests/Gemfile.lock
+++ b/gcp/rakefiles/tests/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec
+
+BUNDLED WITH
+   1.16.1

--- a/gcp/rakefiles/tests/Rakefile
+++ b/gcp/rakefiles/tests/Rakefile
@@ -1,0 +1,6 @@
+desc "Run tests"
+task :default do
+  sh "bundle exec rspec"
+end
+
+# vim: set et ts=2 sw=2:

--- a/gcp/rakefiles/tests/spec/vars_spec.rb
+++ b/gcp/rakefiles/tests/spec/vars_spec.rb
@@ -19,11 +19,12 @@ describe Vars do
 
   it "set_vars doesn't clobber vars that are already set" do
     allow(ENV).to receive(:[]=)
-    allow(ENV).to receive(:[])
-    allow(ENV).to receive(:[]).with("ENV").and_return("fake-env")
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    allow(ENV).to receive(:[]).with("ENV").and_return("fake-env")
+    allow(ENV).to receive(:[]).with("ORGANIZATION_ID").and_return("fake-organization-id")
+    allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     Vars.set_vars()
-    expect(ENV).not_to have_received(:[]=).with("ENV", "dev")
+    expect(ENV).not_to have_received(:[]=)
   end
 end
 

--- a/gcp/rakefiles/tests/spec/vars_spec.rb
+++ b/gcp/rakefiles/tests/spec/vars_spec.rb
@@ -4,14 +4,16 @@ describe Vars do
   it "set_vars requires ENV['TF_VAR_project_id']" do
     allow(ENV).to receive(:[]=)
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return(nil)
-    expect { Vars.set_vars() }.to raise_error(ArgumentError, "TF_VAR_project_id must be set")
+    env = "fake-env"
+    expect { Vars.set_vars(env) }.to raise_error(ArgumentError, "TF_VAR_project_id must be set")
   end
 
   it "set_vars sets default vars" do
     allow(ENV).to receive(:[]=)
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
-    Vars.set_vars()
+    env = "fake-env"
+    Vars.set_vars(env)
     expect(ENV).to have_received(:[]=).with("ENV", "dev")
     expect(ENV).to have_received(:[]=).with("ORGANIZATION_ID", "247149361674")
     expect(ENV).to have_received(:[]=).with("BILLING_ID", "01A0E1-B0B31F-349F4F")
@@ -23,7 +25,8 @@ describe Vars do
     allow(ENV).to receive(:[]).with("ENV").and_return("fake-env")
     allow(ENV).to receive(:[]).with("ORGANIZATION_ID").and_return("fake-organization-id")
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
-    Vars.set_vars()
+    env = "fake-env"
+    Vars.set_vars(env)
     expect(ENV).not_to have_received(:[]=)
   end
 end

--- a/gcp/rakefiles/tests/spec/vars_spec.rb
+++ b/gcp/rakefiles/tests/spec/vars_spec.rb
@@ -14,7 +14,7 @@ describe Vars do
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
     env = "fake-env"
     Vars.set_vars(env)
-    expect(ENV).to have_received(:[]=).with("ENV", "dev")
+    expect(ENV).to have_received(:[]=).with("ENV", env)
     expect(ENV).to have_received(:[]=).with("ORGANIZATION_ID", "247149361674")
     expect(ENV).to have_received(:[]=).with("BILLING_ID", "01A0E1-B0B31F-349F4F")
   end
@@ -22,12 +22,12 @@ describe Vars do
   it "set_vars doesn't clobber vars that are already set" do
     allow(ENV).to receive(:[]=)
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
-    allow(ENV).to receive(:[]).with("ENV").and_return("fake-env")
     allow(ENV).to receive(:[]).with("ORGANIZATION_ID").and_return("fake-organization-id")
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     env = "fake-env"
     Vars.set_vars(env)
-    expect(ENV).not_to have_received(:[]=)
+    expect(ENV).not_to have_received(:[]=).with("ORGANIZATION_ID")
+    expect(ENV).not_to have_received(:[]=).with("BILLING_ID")
   end
 end
 

--- a/gcp/rakefiles/tests/spec/vars_spec.rb
+++ b/gcp/rakefiles/tests/spec/vars_spec.rb
@@ -1,0 +1,30 @@
+require "../vars.rb"
+
+describe Vars do
+  it "set_vars requires ENV['TF_VAR_project_id']" do
+    allow(ENV).to receive(:[]=)
+    allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return(nil)
+    expect { Vars.set_vars() }.to raise_error(ArgumentError, "TF_VAR_project_id must be set")
+  end
+
+  it "set_vars sets default vars" do
+    allow(ENV).to receive(:[]=)
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    Vars.set_vars()
+    expect(ENV).to have_received(:[]=).with("ENV", "dev")
+    expect(ENV).to have_received(:[]=).with("ORGANIZATION_ID", "247149361674")
+    expect(ENV).to have_received(:[]=).with("BILLING_ID", "01A0E1-B0B31F-349F4F")
+  end
+
+  it "set_vars doesn't clobber vars that are already set" do
+    allow(ENV).to receive(:[]=)
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("ENV").and_return("fake-env")
+    allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    Vars.set_vars()
+    expect(ENV).not_to have_received(:[]=).with("ENV", "dev")
+  end
+end
+
+# vim: set et ts=2 sw=2:

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,9 +1,9 @@
 class Vars
   def self.set_vars
     if ENV["TF_VAR_project_id"].nil?
-      puts "ERROR: TF_VAR_project_id must be set!"
-      puts "Do this: export TF_VAR_project_id=<your name>-<env>"
-      puts "and try again."
+      puts "  ERROR: TF_VAR_project_id must be set!"
+      puts "  Do this: export TF_VAR_project_id=<your name>-<env>"
+      puts "  and try again."
       raise ArgumentError, "TF_VAR_project_id must be set"
     end
     if ENV["ENV"].nil?

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,0 +1,17 @@
+class Vars
+  def self.set_vars
+    if ENV["TF_VAR_project_id"].nil?
+      puts "ERROR: TF_VAR_project_id must be set!"
+      puts "Do this: export TF_VAR_project_id=<your name>-<env>"
+      puts "and try again."
+      raise ArgumentError, "TF_VAR_project_id must be set"
+    end
+    if ENV["ENV"].nil?
+      ENV["ENV"] = "dev"
+    end
+    ENV["ORGANIZATION_ID"] = "247149361674"  # RtF Organization
+    ENV["BILLING_ID"] = "01A0E1-B0B31F-349F4F"  # RtF Billing Account
+  end
+end
+
+# vim: set et ts=2 sw=2:

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,5 +1,5 @@
 class Vars
-  def self.set_vars
+  def self.set_vars(env)
     if ENV["TF_VAR_project_id"].nil?
       puts "  ERROR: TF_VAR_project_id must be set!"
       puts "  Do this: export TF_VAR_project_id=<your name>-<env>"
@@ -18,4 +18,4 @@ class Vars
   end
 end
 
-# vim: set et ts=2 sw=2:
+# vim: et ts=2 sw=2:

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -6,9 +6,7 @@ class Vars
       puts "  and try again."
       raise ArgumentError, "TF_VAR_project_id must be set"
     end
-    if ENV["ENV"].nil?
-      ENV["ENV"] = "dev"
-    end
+    ENV["ENV"] = env
     if ENV["ORGANIZATION_ID"].nil?
       ENV["ORGANIZATION_ID"] = "247149361674"  # RtF Organization
     end

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -9,8 +9,12 @@ class Vars
     if ENV["ENV"].nil?
       ENV["ENV"] = "dev"
     end
-    ENV["ORGANIZATION_ID"] = "247149361674"  # RtF Organization
-    ENV["BILLING_ID"] = "01A0E1-B0B31F-349F4F"  # RtF Billing Account
+    if ENV["ORGANIZATION_ID"].nil?
+      ENV["ORGANIZATION_ID"] = "247149361674"  # RtF Organization
+    end
+    if ENV["BILLING_ID"].nil?
+      ENV["BILLING_ID"] = "01A0E1-B0B31F-349F4F"  # RtF Billing Account
+    end
   end
 end
 


### PR DESCRIPTION
This isn't quite done, but nothing uses this code yet so feel free to merge if it will help you start integrating.

I used TDD to write the new vars.rb. I looked at using minitest, which Alfredo introduced to test merge_yaml.rb, but I needed mocks to work with ENV. I decided to switch to rspec since AFAIK it is the most popular way to test in ruby and it gives us more options for testing later (there are rspec matchers for all kinds of things).

The next few problems on my todo list:

1. The system doesn't work when I `rake dev:deploy`, then `rake dev:destroy`, then `rake dev:deploy` again:

```
Error enabling service: Error enabling service ["containerregistry.googleapis.com"] for project "xk-tyler9": Error waiting for api to enable:
 googleapi: Error 403: The caller does not have permission, forbidden
```

I don't understand this since I (and the projectowner service account) have admin permissions in the Project. Also, I never saw this problem when running `xk` commands directly. This will require more debugging.

2. When a vars.rb unit test fails, it dumps the entire environment into the error message. This is bad since the environment may contain secrets. This will require more research -- maybe there is a way to limit the error message, or maybe we'll have to scrub the environment down to an allowed list of safe variables before running tests.

3. Somehow, the user must tell the system which environment to run in, e.g. "deploy new code to stg" or "destroy my dev cluster". A few "styles" I've considered:
   * a) `cd dev && rake deploy` - this is what we use today on the aws/ side. My main problems with this are:
      * It is "stateful" -- the behavior changes depending on what directory you're in when you run it. This can be dangerous, e.g. I want to delete my dev cluster, I cd to prd to look at something, I forget to switch back before running `rake destroy`.
      * It forces separate Rakefile in dev/ and stg/ and prd/.
   * b) `rake dev:deploy` - this is the first replacement I've tried:
      * I like how simple and explicit the resulting command is.
      * It would be difficult to type `rake prd:destroy` when you meant `rake dev:destroy`.
      * I want to avoid copy-paste duplication of whole `namespace` blocks, or the need to maintain a bunch of wrapper functions that only call wrapper functions with an argument to specify the cluster. My next experiment is to try manipulating the `namespace` object directly (Rubyists love this kind of thing :p).
   * c) `ENV=dev rake deploy` - this is an alternative I'm considering:
      * This makes the command explicit, at the cost of looking a little weird (especially if you're not overly familiar with Bourne shell) and requiring special handling to run the command (i.e. `sh -c 'ENV=dev rake deploy'` instead of `rake dev:deploy`)
      * It would be difficult to type `ENV=prd rake destroy` when you meant `ENV=dev rake destroy`. However, this style doesn't protect against a forgotten `export ENV=prd`.
      * The implementation is easy and reduces duplication without the need for wizardry