### PR TITLE
Sort helm charts to ensure correct ordering.

### DIFF
--- a/aws/modules/deploy/Rakefile
+++ b/aws/modules/deploy/Rakefile
@@ -105,7 +105,7 @@ task :setup_secrets_from_files => :setup_secrets do
 end
 
 Dir.chdir('helms') do
-  HELMCHARTS_DIRS = Dir.glob('*').select {|d| File.directory? d}
+  HELMCHARTS_DIRS = Dir.glob('*').select {|d| File.directory? d}.sort
 end
 SOURCE_FILES = FileList.new("*.erb")
 DEST_FILES = SOURCE_FILES.ext(".yml")

--- a/aws/rakefiles/deploy.rake
+++ b/aws/rakefiles/deploy.rake
@@ -143,7 +143,7 @@ end
 desc "Install Helm charts in the cluster #{ENV["TF_VAR_cluster_name"]}"
 task :install_charts => [:configure_kubectl, :generate_modules, :setup_system_components, :init_helm] do
   Dir.chdir("#{@tmpdir}-modules/deploy/helms/") do
-    @gpii_helmcharts = Dir.glob("*").select {|d| File.directory? d }
+    @gpii_helmcharts = Dir.glob("*").select {|d| File.directory? d }.sort
   end
 
   installed_charts = `helm list -q -a`
@@ -233,7 +233,7 @@ task :undeploy => [:configure_kubectl, :find_gpii_components] do
   end
 
   Dir.chdir("#{@tmpdir}-modules/deploy/helms/") do
-    @gpii_helmcharts = Dir.glob("*").select {|d| File.directory? d }
+    @gpii_helmcharts = Dir.glob("*").select {|d| File.directory? d }.sort
   end
   @gpii_helmcharts.reverse.each do |chart|
     chart_config = YAML.load_file("#{@tmpdir}-modules/deploy/helms/#{chart}/custom-values.yaml")


### PR DESCRIPTION
This manifested as a bug where cert-manager isn't deployed before flowmanager/preferences try to use the Certificate TPR, leading to this confusing error:

```
Error: apiVersion "certmanager.k8s.io/v1alpha1" in gpii-flowmanager/templates/certificate.yaml is not available
```