### PR TITLE
Obfuscate sensitive data in deploy task output

### DIFF
--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -1,6 +1,8 @@
 require "rake/clean"
 
-Dir[File.dirname(__FILE__) + '/*.rb'].each {|file| require file }
+require_relative "./vars.rb"
+require_relative "./secrets.rb"
+require_relative "./sh_filter.rb"
 
 if @env.nil?
   puts "  ERROR: @env must be set!"

--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -1,8 +1,6 @@
 require "rake/clean"
 
-require_relative "./vars.rb"
-require_relative "./secrets.rb"
-require_relative "./utils.rb"
+Dir[File.dirname(__FILE__) + '/*.rb'].each {|file| require file }
 
 if @env.nil?
   puts "  ERROR: @env must be set!"

--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -85,7 +85,7 @@ end
 
 desc "Create cluster and deploy GPII components to it"
 task :deploy => [:set_vars, @gcp_creds_file, @serviceaccount_key_file, @kubectl_creds_file, :apply_infra] do
-  sh "#{@exekube_cmd} up"
+  sh "#{@exekube_cmd} up | sed -f secrets/#{ENV["TF_VAR_project_id"]}-sed.cfg"
 end
 
 desc "Destroy cluster and low-level infrastructure"

--- a/gcp/rakefiles/secrets.rb
+++ b/gcp/rakefiles/secrets.rb
@@ -7,10 +7,10 @@ class Secrets
     saved_secrets_file_path = "../#{ENV['ENV']}/secrets/#{ENV["TF_VAR_project_id"]}-secrets.yml"
 
     begin
-      @secrets = YAML.load(File.read(saved_secrets_file_path))
+      secrets = YAML.load(File.read(saved_secrets_file_path))
     rescue Errno::ENOENT
       generate_file = true
-      @secrets = Hash.new
+      secrets = Hash.new
     end
 
     [ \
@@ -19,21 +19,21 @@ class Secrets
       'couchdb_secret', \
     ].each do |secret|
       unless ENV[secret.upcase].to_s.empty?
-        @secrets[secret] = ENV[secret.upcase]
+        secrets[secret] = ENV[secret.upcase]
         # we don't want to store Environment variables
         generate_file = false
       end
-      @secrets[secret] = SecureRandom.hex if @secrets[secret].to_s.empty?
-      ENV["TF_VAR_#{secret}"] = @secrets[secret]
+      secrets[secret] = SecureRandom.hex if secrets[secret].to_s.empty?
+      ENV["TF_VAR_#{secret}"] = secrets[secret]
     end
 
     if generate_file
       puts "Secret file #{saved_secrets_file_path} for this deployment not found. I will create one."
       File.open(saved_secrets_file_path, 'w+') do |file|
-        file.write(@secrets.to_yaml)
+        file.write(secrets.to_yaml)
       end
     end
 
-    return @secrets
+    return secrets
   end
 end

--- a/gcp/rakefiles/secrets.rb
+++ b/gcp/rakefiles/secrets.rb
@@ -1,0 +1,39 @@
+require "securerandom"
+require "yaml"
+
+class Secrets
+
+  def self.set_secrets()
+    saved_secrets_file_path = "../#{ENV['ENV']}/secrets/#{ENV["TF_VAR_project_id"]}-secrets.yml"
+
+    begin
+      @secrets = YAML.load(File.read(saved_secrets_file_path))
+    rescue Errno::ENOENT
+      generate_file = true
+      @secrets = Hash.new
+    end
+
+    [ \
+      'couchdb_admin_username', \
+      'couchdb_admin_password', \
+      'couchdb_secret', \
+    ].each do |secret|
+      unless ENV[secret.upcase].to_s.empty?
+        @secrets[secret] = ENV[secret.upcase]
+        # we don't want to store Environment variables
+        generate_file = false
+      end
+      @secrets[secret] = SecureRandom.hex if @secrets[secret].to_s.empty?
+      ENV["TF_VAR_#{secret}"] = @secrets[secret]
+    end
+
+    if generate_file
+      puts "Secret file #{saved_secrets_file_path} for this deployment not found. I will create one."
+      File.open(saved_secrets_file_path, 'w+') do |file|
+        file.write(@secrets.to_yaml)
+      end
+    end
+
+    return @secrets
+  end
+end

--- a/gcp/rakefiles/sh_filter.rb
+++ b/gcp/rakefiles/sh_filter.rb
@@ -3,7 +3,7 @@ def sh_filter(*cmd)
   if @secrets
     IO.popen(*cmd).each do |out|
       @secrets.each do |key, val|
-        out = out.gsub("#{val}", "<SENSITIVE>")
+        out.gsub!("#{Regexp.escape(val)}", "<SENSITIVE>")
       end
       puts out
     end

--- a/gcp/rakefiles/utils.rb
+++ b/gcp/rakefiles/utils.rb
@@ -1,0 +1,15 @@
+require "yaml"
+
+# Obfuscate sensitive data in the output of a command, relying on @secrets
+def sh_filter(*cmd)
+  if @secrets
+    IO.popen(*cmd).each do |out|
+      @secrets.each do |key, val|
+        out = out.gsub("#{val}", "<SENSITIVE>")
+      end
+      puts out
+    end
+  else
+    sh *cmd
+  end
+end

--- a/gcp/rakefiles/utils.rb
+++ b/gcp/rakefiles/utils.rb
@@ -1,5 +1,3 @@
-require "yaml"
-
 # Obfuscate sensitive data in the output of a command, relying on @secrets
 def sh_filter(*cmd)
   if @secrets

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,9 +1,9 @@
-require "securerandom"
 require "yaml"
 
 class Vars
 
-  SENSITIVE = "<sensitive>"
+  # Hack to avoid changes in gpii-version-updater
+  VERSION_FILE = '../../../aws/modules/deploy/version.yml'
 
   def self.set_vars(env, project_type)
     if ["dev"].include?(env)
@@ -53,8 +53,7 @@ class Vars
     end
 
     # Hack to avoid changes in gpii-version-updater
-    version_file = '../../../aws/modules/deploy/version.yml'
-    versions = YAML.load(File.read(version_file))
+    versions = YAML.load(File.read(Vars::VERSION_FILE))
     if versions['flowmanager']
       ENV['TF_VAR_flowmanager_repository'] = versions['flowmanager'].split('@')[0]
       ENV['TF_VAR_flowmanager_checksum'] = versions['flowmanager'].split('@')[1]
@@ -66,44 +65,6 @@ class Vars
     if versions['gpii-dataloader']
       ENV['TF_VAR_dataloader_repository'] = versions['gpii-dataloader'].split('@')[0]
       ENV['TF_VAR_dataloader_checksum'] = versions['gpii-dataloader'].split('@')[1]
-    end
-  end
-
-  def self.set_secrets()
-    saved_secrets_file_path = "../#{ENV['ENV']}/secrets/#{ENV["TF_VAR_project_id"]}-secrets.yml"
-    sed_cfg_file_path = "../#{ENV['ENV']}/secrets/#{ENV["TF_VAR_project_id"]}-sed.cfg"
-    sed_cfg = ""
-
-    begin
-      @secrets = YAML.load(File.read(saved_secrets_file_path))
-    rescue Errno::ENOENT
-      generate_file = true
-      @secrets = Hash.new
-    end
-
-    [ \
-      'couchdb_admin_username', \
-      'couchdb_admin_password', \
-      'couchdb_secret', \
-    ].each do |secret|
-      unless ENV[secret.upcase].to_s.empty?
-        @secrets[secret] = ENV[secret.upcase]
-        # we don't want to store Environment variables
-        generate_file = false
-      end
-      @secrets[secret] = SecureRandom.hex if @secrets[secret].to_s.empty?
-      ENV["TF_VAR_#{secret}"] = @secrets[secret]
-      sed_cfg << "s/#{@secrets[secret]}/#{Vars::SENSITIVE}/g\n"
-    end
-
-    if generate_file
-      puts "Secret file #{saved_secrets_file_path} for this deployment not found. I will create one."
-      File.open(saved_secrets_file_path, 'w+') do |file|
-        file.write(@secrets.to_yaml)
-      end
-      File.open(sed_cfg_file_path, 'w+') do |file|
-        file.write(sed_cfg)
-      end
     end
   end
 end


### PR DESCRIPTION
This is more like a proof-of-concept, but it does the job even in its current state:
```module.gpii-flowmanager.null_resource.helm_template: Creating...
  triggers.%:      "" => "2"
  triggers.chart:  "" => ""
  triggers.values: "" => "replicaCount: 2\n\nimage:\n  repository: gpii/universal\n  checksum: sha256:d0b69df1e900912eab6db7185c5d998c25729f0bffeec0996ec433a750b52b64\n\nissuerRef:\n  name: letsencrypt-staging\n  kind: ClusterIssuer\n\ndnsNames:\n- flowmanager.natarajaya.dev.gcp.gpii.net\n\ningress:\n  disable_ssl_redirect: true\n\nmatchmaker_url: \"http://flowmanager.natarajaya.dev.gcp.gpii.net\"\n\ndatasource_hostname: \"http://<sensitive>:<sensitive>@couchdb-svc-couchdb.gpii.svc.cluster.local\"\n"```