### PR TITLE
GPII-3103: Make check_versions work during/after 'rake clobber'.

### DIFF
--- a/aws/rakefiles/vars.rb
+++ b/aws/rakefiles/vars.rb
@@ -1,4 +1,22 @@
+def check_versions()
+  required_versions = {
+    "terraform version": "v0.11.7",
+    "terragrunt --version": "v0.14.0",
+    "kubectl version --client": "v1.9.8",
+    "kops version": "Version 1.8.1",
+    "helm version --client": "v2.8.2",
+  }
+  required_versions.each do |command, version|
+    command_output = `#{command}`
+    unless command_output.include? version
+      raise "ERROR: Command #{command} must be #{version}. Version output was:\n#{command_output}"
+    end
+  end
+end
+
 def setup_vars(env_short)
+  check_versions
+
   shared_envs = ["stg", "prd"]
   if ENV["TF_VAR_environment"].nil?
     if shared_envs.include?(env_short)


### PR DESCRIPTION
This is a follow up to #49. In fact, the first commit is exactly the change from #49 (though it's probably easier to read both diffs together).

I'm going to merge this so I can verify in CI, but please comment if you see a better solution.