### PR TITLE
Gpii 3200 bumps

### DIFF
--- a/USER-TRAINING.md
+++ b/USER-TRAINING.md
@@ -7,6 +7,8 @@ This document is for Ops team members setting up new developers to work in the G
 * You are about to be granted administrative (aka "root") access to a number of resources on the public internet, including our staging and production environments. This is a serious responsiblity! You will be able to do harm to the system!
 * Measure twice, cut once.
 * If you're ever in doubt about what a command will do, STOP! Then ask for help.
+   * Ask other developers who have experience using gpii-infra
+   * Ask #ops in Slack
 * Be ethical. Don't steal data. Don't run your startup on RtF's billing account.
 * RtF pays for these resources so please destroy your cluster when you're done using it, or won't use it for a while (e.g. before the weekend).
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -348,6 +348,15 @@ Examples of when you might want to do this:
    * Or, to add an additional dev cluster: `USER=mrtyler-experiment1 TF_VAR_environment=dev-mrtyler-experiment1`
    * `TF_VAR_environment` must contain `USER` as above. Otherwise, behavior is undefined.
 
+### I want to change Kubernetes versions, Instance types of Nodes, or similar [experimental]
+
+* For new clusters: edit the `kops` command in [modules/k8s/Rakefile](modules/k8s/Rakefile).
+* For existing clusters:
+   * `rake kops_edit_cluster`
+   * This will drop you into an editor several times to modify several different configs.
+   * Make needed changes in each relevant file.
+   * Follow the instructions to apply the changes to the pre-existing cluster.
+
 ### I want to change Grafana dashboards or Alertmanager alerts [experimental]
 
 The manifests that control Grafana dashboards and Alertmanager alerts are copied from [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/contrib/kube-prometheus) and then modified locally (e.g. a few more things in the `monitoring` namespace, different Service types).

--- a/aws/README.md
+++ b/aws/README.md
@@ -356,6 +356,30 @@ Examples of when you might want to do this:
    * This will drop you into an editor several times to modify several different configs.
    * Make needed changes in each relevant file.
    * Follow the instructions to apply the changes to the pre-existing cluster.
+   * Manually verify that Prometheus, Alertmanager, and Grafana came back and are continuing to collect data
+      * Prometheus sometimes requires some special handling on restart. See the next section.
+
+### Prometheus lost all of its alerts
+
+Due to a [suspected bug](https://issues.gpii.net/browse/GPII-3103?focusedCommentId=33300&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-33300) in our version of Prometheus/prometheus-operator, Prometheus sometimes loses its Alerts when it restarts.
+
+You can check for this failure mode like this:
+
+```
+kubectl --namespace monitoring exec -it prometheus-k8s-0 find /etc/prometheus/rules/
+kubectl --namespace monitoring exec -it prometheus-k8s-1 find /etc/prometheus/rules/
+kubectl --namespace monitoring exec -it prometheus-k8s-[NUMBER] find /etc/prometheus/rules/
+```
+
+The command should list some rules files. If it shows nothing (i.e. an empty directory), then the target Prometheus Pod needs to be restarted so that it will detect the rules:
+
+```
+kubectl --namespace monitoring delete pod/prometheus-k8s-0
+kubectl --namespace monitoring delete pod/prometheus-k8s-1
+kubectl --namespace monitoring delete pod/prometheus-k8s-[NUMBER]
+```
+
+When the Pod restarts, run the `find` command again to make sure the rules files have appeared.
 
 ### I want to change Grafana dashboards or Alertmanager alerts [experimental]
 

--- a/aws/modules/k8s/Rakefile
+++ b/aws/modules/k8s/Rakefile
@@ -21,13 +21,14 @@ rule "#{KOPS_OUT_DIR}/kubernetes.tf" do
   # Create cluster iff it doesn't already exist.
   sh "kops get cluster #{ENV["TF_VAR_cluster_name"]}" do |ok, res|
     unless ok
+      node_size = ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? "c4.xlarge" : "t2.medium"
       sh "kops create cluster \
         --name=#{ENV["TF_VAR_cluster_name"]} \
         --channel=alpha \
         --cloud-labels='Env=#{ENV["TF_VAR_environment"]}' \
-        --kubernetes-version=1.8.7 \
+        --kubernetes-version=1.8.15 \
         --node-count=3 \
-        --node-size=t2.medium \
+        --node-size=#{node_size} \
         --master-size=t2.small \
         --zones=us-east-2a,us-east-2b,us-east-2c \
         --master-zones=us-east-2a,us-east-2b,us-east-2c \

--- a/aws/modules/k8s/Rakefile
+++ b/aws/modules/k8s/Rakefile
@@ -21,7 +21,7 @@ rule "#{KOPS_OUT_DIR}/kubernetes.tf" do
   # Create cluster iff it doesn't already exist.
   sh "kops get cluster #{ENV["TF_VAR_cluster_name"]}" do |ok, res|
     unless ok
-      node_size = ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? "c4.xlarge" : "t2.medium"
+      node_size = ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? "c5.xlarge" : "t2.medium"
       sh "kops create cluster \
         --name=#{ENV["TF_VAR_cluster_name"]} \
         --channel=alpha \

--- a/aws/rakefiles/deploy.rake
+++ b/aws/rakefiles/deploy.rake
@@ -50,7 +50,7 @@ task :wait_for_gpii_ready => :configure_kubectl do
         end
         # We also need to make sure that certificate is issued by Letsencrypt
         wait_for(
-          "curl -k -vI 'https://#{test[:url]}' 2>&1 | grep 'CN=Fake LE Intermediate X1'",
+          "curl -k -vI 'https://#{test[:url]}' 2>&1 | grep -C5 'CN=Fake LE Intermediate X1'",
           sleep_secs: 5,
           max_wait_secs: 20,
         )


### PR DESCRIPTION
Scenarios I tested:
* Create dev cluster from scratch with k8s 1.8.15
* Create dev cluster from scratch with k8s 1.8.7, upgrade to 1.8.15
* Create dev cluster from scratch with t2.medium Nodes, upgrade to c4.xlarge Nodes

Everything went smoothly (except for that thing Prometheus started doing where it comes up with an empty /rules mount :/).

Note that upgrading existing clusters like stg and prd will require some manual steps. I added documentation about how this works after I tried to do it and discovered that I had forgotten how it works :).

Once we merge this, push the upgrade through prd, and prove that it all works, I might bump us back down to t2.medium until we're ready for traffic -- just so we're not paying for quite so many c4.xlarge hours. Anyone think this is not worth the trouble/risk?