### PR TITLE
Disable versions check if DISABLE_VERSIONS_CHECK env var is set

### DIFF
--- a/aws/rakefiles/vars.rb
+++ b/aws/rakefiles/vars.rb
@@ -2,6 +2,7 @@ require "tmpdir"
 
 
 def check_versions()
+  return if ENV["DISABLE_VERSIONS_CHECK"]
   required_versions = {
     "terraform version": "v0.11.7",
     "terragrunt --version": "v0.14.0",


### PR DESCRIPTION
This is useful, when you really want to interact with a cluster (and you need `rake configure_kubectl`) on a machine, but some component version is different (for example, earliest `terragrunt` version available in Homebrew is `0.14.7`: `pushd "$(brew --repo homebrew/core)" && git log Formula/terragrunt.rb | tail -c 500 && popd`).