### PR TITLE
Adding missing dependency on helm-initializer to k8s-snapshots Terragrunt module

### DIFF
--- a/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -4,6 +4,12 @@ terragrunt = {
     source = "/project/modules//k8s-snapshots"
   }
 
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
   include = {
     path = "${find_in_parent_folders()}"
   }


### PR DESCRIPTION
GCP master is failing because of this.