### PR TITLE
Introducing TF_VAR_nonce, applying CouchDB PVs patch on every run

### DIFF
--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -46,6 +46,10 @@ services:
       # We also need to have ENV as Terraform var
       TF_VAR_env: ${ENV:?err}
 
+      # This will be set to a random value every run,
+      # so we can force Terraform to reapply some resources
+      TF_VAR_nonce:
+
       # We need to pass module variables for templater
       TF_VAR_couchdb_admin_username:
       TF_VAR_couchdb_admin_password:

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -5,6 +5,7 @@ terraform {
 variable "env" {}
 variable "secrets_dir" {}
 variable "values_dir" {}
+variable "nonce" {}
 
 # Terragrunt variables
 variable "couchdb_replicas" {}
@@ -73,8 +74,7 @@ resource "null_resource" "couchdb_enable_pv_backups" {
   depends_on = ["module.couchdb"]
 
   triggers = {
-    couchdb_replicas = "${var.couchdb_replicas}"
-    backup_deltas    = "${var.backup_deltas}"
+    nonce = "${var.nonce}"
   }
 
   provisioner "local-exec" {
@@ -99,6 +99,7 @@ resource "null_resource" "couchdb_destroy_pvcs" {
 
   provisioner "local-exec" {
     when = "destroy"
+
     command = <<EOF
       for PVC in $(kubectl get pvc --namespace ${var.release_namespace} -o json | jq --raw-output '.items[] | select(.metadata.name | startswith("database-storage-couchdb")) | .metadata.name'); do
         kubectl --namespace ${var.release_namespace} delete --ignore-not-found pvc $PVC

--- a/gcp/rakefiles/tests/spec/vars_spec.rb
+++ b/gcp/rakefiles/tests/spec/vars_spec.rb
@@ -103,6 +103,16 @@ describe Vars do
     expect(ENV).not_to have_received(:[]=).with("ORGANIZATION_ID", any_args)
     expect(ENV).not_to have_received(:[]=).with("BILLING_ID", any_args)
   end
+
+  it "set_vars sets TF_VAR_nonce" do
+    allow(ENV).to receive(:[]=)
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    env = "fake-env"
+    project_type = "fake-project-type"
+    Vars.set_vars(env, project_type)
+    expect(ENV).to have_received(:[]=).with("TF_VAR_nonce", a_value)
+  end
 end
 
 

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "securerandom"
 
 class Vars
 
@@ -67,6 +68,9 @@ class Vars
       ENV['TF_VAR_dataloader_checksum'] = versions['gpii-dataloader'].split('@')[1]
     end
   end
+
+  # Hack to force Terraform to reapply some resources on every run
+  ENV["TF_VAR_nonce"] = SecureRandom.hex
 end
 
 

--- a/gcp/rakefiles/vars.rb
+++ b/gcp/rakefiles/vars.rb
@@ -1,5 +1,5 @@
-require "yaml"
 require "securerandom"
+require "yaml"
 
 class Vars
 
@@ -67,11 +67,10 @@ class Vars
       ENV['TF_VAR_dataloader_repository'] = versions['gpii-dataloader'].split('@')[0]
       ENV['TF_VAR_dataloader_checksum'] = versions['gpii-dataloader'].split('@')[1]
     end
+
+    # Hack to force Terraform to reapply some resources on every run
+    ENV["TF_VAR_nonce"] = SecureRandom.hex
   end
-
-  # Hack to force Terraform to reapply some resources on every run
-  ENV["TF_VAR_nonce"] = SecureRandom.hex
 end
-
 
 # vim: et ts=2 sw=2:


### PR DESCRIPTION
This is the only way to force Terraform to apply resource on every run that I am aware of. It will give us the ability to workaround probable narrow points, similar to the situation, where we need to patch CouchDB PVs manually, described in the comments to #58.