### PR TITLE
GPII-3216: Rake :undeploy should not delete system components by default

### DIFF
--- a/aws/dev/Rakefile
+++ b/aws/dev/Rakefile
@@ -31,7 +31,8 @@ task :test_master do
 end
 
 desc "Destroy cluster"
-task :destroy => [@tmpdir, :generate_modules, :undeploy] do
+task :destroy => [@tmpdir, :generate_modules] do
+  Rake::Task["undeploy"].invoke(true)
   Rake::Task["_destroy"].invoke
 end
 

--- a/aws/prd/Rakefile
+++ b/aws/prd/Rakefile
@@ -23,7 +23,8 @@ end
 CLEAN << "#{ENV['HOME']}/.terragrunt"
 
 desc "Destroy cluster"
-task :destroy => [@tmpdir, :generate_modules, :undeploy] do
+task :destroy => [@tmpdir, :generate_modules] do
+  Rake::Task["undeploy"].invoke(true)
   Rake::Task["_destroy"].invoke
 end
 

--- a/aws/rakefiles/deploy.rake
+++ b/aws/rakefiles/deploy.rake
@@ -264,7 +264,7 @@ task :undeploy, [:delete_system_components] => [:configure_kubectl, :find_gpii_c
         max_wait_secs: 20,
       )
     rescue
-      puts "WARNING: Failed to configure system components."
+      puts "WARNING: Failed to delete system components."
     end
   end
 

--- a/aws/stg/Rakefile
+++ b/aws/stg/Rakefile
@@ -23,7 +23,8 @@ end
 CLEAN << "#{ENV['HOME']}/.terragrunt"
 
 desc "Destroy cluster"
-task :destroy => [@tmpdir, :generate_modules, :undeploy] do
+task :destroy => [@tmpdir, :generate_modules] do
+  Rake::Task["undeploy"].invoke(true)
   Rake::Task["_destroy"].invoke
 end
 


### PR DESCRIPTION
@mrtyler The reason behind that `Unauthorized` error is that `:undeploy` deletes Tiller's SA and CRB, while keeping deployment intact. On the next `rake` run, it recreates missing system resources, but it does not help.

I can think of couple solutions:
1. Delete Tiller deployment at the end of `:undeploy`, let `helm init --upgrade` recreate it on next `rake` run.
2. Do not delete system components during `:undeploy`.

Considering typical dev workflow, **2** makes more sense to me, so I implemented it here. There is probably no need to undeploy stuff that we have in `modules/deploy/system` (namespaces, SAs, CRBs, etc.) at all, since it is currently safe to leave all of that in the cluster. However, I decided to not change how `:destroy` task currently works, which should give us more flexibility in future.