### PR TITLE
Remove storage class variable in gcp-secret-mgmt

### DIFF
--- a/gcp/modules/gcp-secret-mgmt/main.tf
+++ b/gcp/modules/gcp-secret-mgmt/main.tf
@@ -14,10 +14,6 @@ variable "storage_location" {
   default = "us-central1"
 }
 
-variable "storage_class" {
-  default = "REGIONAL"
-}
-
 module "gcp-secret-mgmt" {
   source = "/exekube-modules/gcp-secret-mgmt"
 
@@ -25,6 +21,5 @@ module "gcp-secret-mgmt" {
   serviceaccount_key = "${var.serviceaccount_key}"
   encryption_keys    = "${var.encryption_keys}"
   storage_location   = "${var.storage_location}"
-  storage_class      = "${var.storage_class}"
   keyring_name       = "${var.keyring_name}"
 }


### PR DESCRIPTION
Accidentally left this behind after couple experiments with `gcp-secret-mgmt` exekube's module.