### PR TITLE
wait_for kops rolling-update

### DIFF
--- a/aws/rakefiles/kops.rake
+++ b/aws/rakefiles/kops.rake
@@ -97,5 +97,8 @@ task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
 end
 
 task :kops_rolling_update => [@tmpdir, :configure_kops] do
-  sh "KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes"
+  wait_for("\
+    KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' \
+    kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes
+  ")
 end

--- a/aws/rakefiles/kops.rake
+++ b/aws/rakefiles/kops.rake
@@ -97,8 +97,9 @@ task :display_rolling_update_cmd => [@tmpdir, :configure_kops] do
 end
 
 task :kops_rolling_update => [@tmpdir, :configure_kops] do
-  wait_for("\
-    KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' \
-    kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes
-  ")
+  wait_for(
+    "KOPS_FEATURE_FLAGS='+DrainAndValidateRollingUpdate' \
+      kops rolling-update cluster #{ENV["TF_VAR_cluster_name"]} --yes",
+    max_wait_secs: 60,
+  )
 end


### PR DESCRIPTION
This is in response to an intermittent failure in `:kops_rolling_update`, "Unable to reach the kubernetes API." E.g. in https://gitlab.com/gpii-ops/gpii-infra/-/jobs/84470317.

I didn't test this very much, but I think it's safe. `kops rolling-update` seems to be reasonably idempotent even in the face of several failure modes.