### PR TITLE
GCP: Various fixes

### DIFF
--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -31,7 +31,10 @@ services:
       TF_VAR_secrets_dir: /project/live/${ENV}/secrets
 
        # TF_VAR_values_dir is used by templater to put rendered files into
-      TF_VAR_values_dir: /project/live/${ENV}/values
+      TF_VAR_values_dir: /tmp/${ENV}/values
+
+      # TF_VAR_charts_dir is the place where common charts live, relative to modules
+      TF_VAR_charts_dir: ../../../../../charts
 
     # File with other environment variables will be populated by rake
     env_file:

--- a/gcp/modules/cert-manager/main.tf
+++ b/gcp/modules/cert-manager/main.tf
@@ -3,6 +3,7 @@ terraform {
 }
 
 variable "secrets_dir" {}
+variable "charts_dir" {}
 
 module "cert-manager" {
   source           = "/exekube-modules/helm-release"
@@ -12,7 +13,7 @@ module "cert-manager" {
   release_name      = "cert-manager"
   release_namespace = "kube-system"
 
-  chart_name = "../../../../../charts/cert-manager"
+  chart_name = "${var.charts_dir}/cert-manager"
 }
 
 resource "null_resource" "cert_manager_resources" {

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -5,6 +5,7 @@ terraform {
 variable "env" {}
 variable "secrets_dir" {}
 variable "values_dir" {}
+variable "charts_dir" {}
 variable "nonce" {}
 
 # Terragrunt variables
@@ -25,7 +26,7 @@ module "couchdb" {
   release_namespace = "${var.release_namespace}"
   release_values    = "${var.values_dir}/couchdb.yaml"
 
-  chart_name = "../../../../../charts/couchdb"
+  chart_name = "${var.charts_dir}/couchdb"
 }
 
 resource "null_resource" "couchdb_finish_cluster" {

--- a/gcp/modules/gpii-dataloader/main.tf
+++ b/gcp/modules/gpii-dataloader/main.tf
@@ -3,13 +3,17 @@ terraform {
 }
 
 variable "values_dir" {}
+variable "secrets_dir" {}
+variable "charts_dir" {}
 
 module "gpii-dataloader" {
-  source = "/exekube-modules/helm-template-release"
+  source = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
   release_name      = "dataloader"
   release_namespace = "gpii"
   release_values    = "${var.values_dir}/gpii-dataloader.yaml"
 
-  chart_name = "../../../../../charts/gpii-dataloader"
+  chart_name = "${var.charts_dir}/gpii-dataloader"
 }

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -3,13 +3,17 @@ terraform {
 }
 
 variable "values_dir" {}
+variable "secrets_dir" {}
+variable "charts_dir" {}
 
 module "gpii-flowmanager" {
-  source = "/exekube-modules/helm-template-release"
+  source = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
   release_name      = "flowmanager"
   release_namespace = "gpii"
   release_values    = "${var.values_dir}/gpii-flowmanager.yaml"
 
-  chart_name = "../../../../../charts/gpii-flowmanager"
+  chart_name = "${var.charts_dir}/gpii-flowmanager"
 }

--- a/gcp/modules/gpii-preferences/main.tf
+++ b/gcp/modules/gpii-preferences/main.tf
@@ -3,13 +3,17 @@ terraform {
 }
 
 variable "values_dir" {}
+variable "secrets_dir" {}
+variable "charts_dir" {}
 
 module "gpii-preferences" {
-  source = "/exekube-modules/helm-template-release"
+  source = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
   release_name      = "preferences"
   release_namespace = "gpii"
   release_values    = "${var.values_dir}/gpii-preferences.yaml"
 
-  chart_name = "../../../../../charts/gpii-preferences"
+  chart_name = "${var.charts_dir}/gpii-preferences"
 }

--- a/gcp/modules/k8s-snapshots/main.tf
+++ b/gcp/modules/k8s-snapshots/main.tf
@@ -3,6 +3,7 @@ terraform {
 }
 
 variable "secrets_dir" {}
+variable "charts_dir" {}
 
 module "k8s-snapshots" {
   source           = "/exekube-modules/helm-release"
@@ -12,5 +13,5 @@ module "k8s-snapshots" {
   release_name      = "k8s-snapshots"
   release_namespace = "kube-system"
 
-  chart_name = "../../../../../charts/k8s-snapshots"
+  chart_name = "${var.charts_dir}/k8s-snapshots"
 }

--- a/gcp/modules/nginx-ingress/main.tf
+++ b/gcp/modules/nginx-ingress/main.tf
@@ -6,6 +6,7 @@ variable "env" {}
 variable "serviceaccount_key" {}
 variable "project_id" {}
 variable "secrets_dir" {}
+variable "charts_dir" {}
 
 data "terraform_remote_state" "network" {
   backend = "gcs"
@@ -25,7 +26,7 @@ module "nginx-ingress" {
   release_name      = "nginx-ingress"
   release_namespace = "gpii"
 
-  chart_name = "../../../../../charts/nginx-ingress"
+  chart_name = "${var.charts_dir}/nginx-ingress"
 
   load_balancer_ip = "${data.terraform_remote_state.network.static_ip_address}"
 }

--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -121,8 +121,7 @@ end
 desc "Undeploy GPII compoments and destroy cluster"
 task :destroy => [:set_vars, @gcp_creds_file, @serviceaccount_key_file, @kubectl_creds_file, :set_secrets] do
   # Terraform will fail if template files are missing
-  Rake::Task[:deploy_module].invoke('k8s/templater')
-  sh "#{@exekube_cmd} down"
+  sh "#{@exekube_cmd} sh -c 'xk up live/#{@env}/k8s/templater && xk down'"
 end
 
 desc "[ADVANCED] Remove stale Terraform locks from GS -- for non-dev environments coordinate with the team first"

--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -120,7 +120,9 @@ end
 
 desc "Undeploy GPII compoments and destroy cluster"
 task :destroy => [:set_vars, @gcp_creds_file, @serviceaccount_key_file, @kubectl_creds_file, :set_secrets] do
-  # Terraform will fail if template files are missing
+  # Terraform will fail if template files are missing, and since values_dir is not mounted
+  # from host machine anymore, all templates vanish after docker-compose container is terminated.
+  # So we have to invoke templater with the main exekube command
   sh "#{@exekube_cmd} sh -c 'xk up live/#{@env}/k8s/templater && xk down'"
 end
 

--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -172,7 +172,7 @@ task :deploy_module, [:module] => [:set_vars, @gcp_creds_file, :set_secrets] do 
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise IOError, "args[:module] must point to existing Terragrunt directory"
   end
-  sh_filter "#{@exekube_cmd} up live/#{@env}/#{args[:module]}"
+  sh_filter "#{@exekube_cmd} sh -c 'xk up live/#{@env}/k8s/templater && xk up live/#{@env}/#{args[:module]}'"
 end
 
 desc '[ADVANCED] Destroy provided module in the cluster -- rake destroy_module"[k8s/kube-system/cert-manager]"'
@@ -184,7 +184,7 @@ task :destroy_module, [:module] => [:set_vars, @gcp_creds_file, :set_secrets] do
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise IOError, "args[:module] must point to existing Terragrunt directory"
   end
-  sh "#{@exekube_cmd} down live/#{@env}/#{args[:module]}"
+  sh_filter "#{@exekube_cmd} sh -c 'xk up live/#{@env}/k8s/templater && xk down live/#{@env}/#{args[:module]}'"
 end
 
 # vim: et ts=2 sw=2:

--- a/gcp/rakefiles/secrets.rb
+++ b/gcp/rakefiles/secrets.rb
@@ -6,7 +6,6 @@ class Secrets
   KMS_KEYRING = "keyring"
 
   SECRETS_DIR = "secrets"
-  VALUES_DIR = "values"
 
   SECRETS_FILE = "secrets.yaml"
 
@@ -79,7 +78,6 @@ class Secrets
     return if collected_secrets.empty?
 
     FileUtils.mkdir_p Secrets::SECRETS_DIR
-    FileUtils.mkdir_p Secrets::VALUES_DIR
 
     collected_secrets.each do |encryption_key, secrets|
       sh_filter "#{exekube_cmd} secrets-fetch #{encryption_key}"


### PR DESCRIPTION
* Fixed gpii modules to use `helm-release` instead of `helm-template-release` for consistency
* Moved `charts_dir` to docker-compose config
* We don't need `values_dir` to be mounted from host machine, use temp dir instead and render templates on every run