### PR TITLE
[GCP]: Corresponding changes after migration to exekube 0.4

### DIFF
--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   xk:
-    image: gpii/exekube:0.3.1-google
+    image: gpii/exekube:0.4.0-google
     working_dir: /project
     environment:
       USER: root

--- a/gcp/live/dev/infra/api-mgmt/terraform.tfvars
+++ b/gcp/live/dev/infra/api-mgmt/terraform.tfvars
@@ -1,0 +1,15 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-api-mgmt"
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+
+waiting_period = 60

--- a/gcp/live/dev/infra/network/terraform.tfvars
+++ b/gcp/live/dev/infra/network/terraform.tfvars
@@ -5,6 +5,12 @@ terragrunt = {
     source = "/project/modules//gke-network"
   }
 
+  dependencies {
+    paths = [
+      "../api-mgmt",
+    ]
+  }
+
   include = {
     path = "${find_in_parent_folders()}"
   }

--- a/gcp/modules/gcp-api-mgmt/main.tf
+++ b/gcp/modules/gcp-api-mgmt/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "project_id" {}
+variable "serviceaccount_key" {}
+
+variable "waiting_period" {
+	default = 60
+}
+
+module "gcp-api-mgmt" {
+  source = "/exekube-modules/gcp-api-mgmt"
+
+  project_id         = "${var.project_id}"
+  serviceaccount_key = "${var.serviceaccount_key}"
+  waiting_period     = "${var.waiting_period}"
+}

--- a/gcp/modules/helm-initializer/main.tf
+++ b/gcp/modules/helm-initializer/main.tf
@@ -15,13 +15,3 @@ module "system_tiller" {
   secrets_dir      = "${var.secrets_dir}"
   tiller_namespace = "${var.tiller_namespace}"
 }
-
-# We need to give Tiller a little time to spin up
-# to prevent any "could not find a ready tiller pod" errors
-resource "null_resource" "wait_for_tiller" {
-  depends_on = ["module.system_tiller"]
-
-  provisioner "local-exec" {
-    command = "sleep 30"
-  }
-}


### PR DESCRIPTION
Merge this after https://github.com/gpii-ops/exekube/pull/7 is merged and new image built by CI.

After moving API management into separate module I discovered couple of issues and opened tickets for them:
* Running `:destroy` after another successful destroy always fails with Tiller certs error (GPII-3251)
* Running `:destroy_infra` after successful `:destroy` always fails due to dependency on `:destroy` and same issue described in previous point
* Running `:destroy_infra` after removing dependency on `:destroy` also fails due to issues disabling different APIs / removing network resources (GPII-3241)