### PR TITLE
GPII-3196 Improve certificates check

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -42,6 +42,10 @@ I generally download and install these tools by hand (verifying checksums when a
 1. Install [Bundler](http://bundler.io/) **==1.16.2**, probably via `gem install bundler -v 1.16.2`.
 1. Install [rake](https://github.com/ruby/rake) **==12.3.0**, probably via `gem install rake -v 12.3.0`.
 1. Install [jq](https://stedolan.github.io/jq/) **==1.5**.
+1. If on macOS version prior to High Sierra (10.13), install curl with openssl
+   (`brew install curl --with-openssl` and add to your path by adding following line
+   to your shell rc `export PATH="/usr/local/opt/curl/bin:$PATH" >> ~/zshrc`).
+   *This is required due to native macOS curl not supporting TLS SNI in insecure mode.*
 
 ### Configure cloud provider credentials
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -44,7 +44,7 @@ I generally download and install these tools by hand (verifying checksums when a
 1. Install [jq](https://stedolan.github.io/jq/) **==1.5**.
 1. If on macOS version prior to High Sierra (10.13), install curl with openssl
    (`brew install curl --with-openssl` and add to your path by adding following line
-   to your shell rc `export PATH="/usr/local/opt/curl/bin:$PATH" >> ~/zshrc`).
+   to your shell rc `export PATH="/usr/local/opt/curl/bin:$PATH" >> ~/.bashrc`).
    *This is required due to native macOS curl not supporting TLS SNI in insecure mode.*
 
 ### Configure cloud provider credentials


### PR DESCRIPTION
This solves [GPII-3196](https://issues.gpii.net/browse/GPII-3196).

- Add check for certificate K8s resource being created
- Add a note to README about curl dependency on older macOS to resolve the SNI issue mentioned in the ticket. This is not required on High Sierra and newer, since macOS switched its native curl version to one based on LibreSSL (as opposed to one based on Secure Transport previously)

Tested cluster creation & destroy.

(this could also be solved by containerising everything, but this was discussed in https://github.com/gpii-ops/gpii-infra/pull/82)