### PR TITLE
[GCP]: Bumping kubernetes version to 1.9.7-gke.5

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -12,7 +12,7 @@ module "gke_cluster" {
 
   initial_node_count = 2
   node_type          = "n1-standard-2"
-  kubernetes_version = "1.9.6-gke.1"
+  kubernetes_version = "1.9.7-gke.5"
 
   main_compute_zone = "us-central1-a"
   additional_zones  = []


### PR DESCRIPTION
Kubernetes `1.9.6-gke.1` is now unsupported:
```
Error: Error applying plan:

1 error(s) occurred:

* module.gke_cluster.google_container_cluster.cluster: 1 error(s) occurred:

* google_container_cluster.cluster: googleapi: Error 400: Master version "1.9.6-gke.1" is unsupported., badRequest
```
