### PR TITLE
GPII-3215: Don't use --recreate-pods

### DIFF
--- a/aws/modules/deploy/charts/values/gpii-flowmanager.erb
+++ b/aws/modules/deploy/charts/values/gpii-flowmanager.erb
@@ -1,8 +1,12 @@
-replicaCount: <%= ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? '6' : '2' %>
+replicaCount: <%= replicaCount = ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? '6' : '2' %>
 
 image:
   repository: <%= @versions["preferences"].split('@')[0] %>
   checksum: <%= @versions["preferences"].split('@')[1] %>
+
+rollingUpdate:
+  maxSurge: <%= replicaCount.to_i < 4 ? 1 : "25%" %>
+  maxUnavailable: 0
 
 issuerRef:
   <% if ENV["TF_VAR_cluster_name"].start_with?("prd.", "stg.") %>

--- a/aws/modules/deploy/charts/values/gpii-preferences.erb
+++ b/aws/modules/deploy/charts/values/gpii-preferences.erb
@@ -1,9 +1,13 @@
-replicaCount: <%= ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? '6' : '2' %>
+replicaCount: <%= replicaCount = ENV["TF_VAR_cluster_name"].start_with?("stg.","prd.") ? '6' : '2' %>
 
 image:
   repository: <%= @versions["preferences"].split('@')[0] %>
   checksum: <%= @versions["preferences"].split('@')[1] %>
 
+rollingUpdate:
+  maxSurge: <%= replicaCount.to_i < 4 ? 1 : "25%" %>
+  maxUnavailable: 0
+    
 issuerRef:
   <% if ENV["TF_VAR_cluster_name"].start_with?("prd.", "stg.") %>
   name: letsencrypt-production

--- a/aws/rakefiles/deploy.rake
+++ b/aws/rakefiles/deploy.rake
@@ -170,7 +170,7 @@ task :install_charts => [:configure_kubectl, :generate_modules, :setup_system_co
       if allow_upgrade
         begin
           wait_for(
-            "helm upgrade --namespace #{chart_namespace} --recreate-pods -f #{@tmpdir}-modules/deploy/charts/values/#{chart}.yaml #{chart_name} #{@chartdir}/#{chart}",
+            "helm upgrade --namespace #{chart_namespace} -f #{@tmpdir}-modules/deploy/charts/values/#{chart}.yaml #{chart_name} #{@chartdir}/#{chart}",
             sleep_secs: 5,
             max_wait_secs: 60,
           )

--- a/common/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/common/charts/gpii-flowmanager/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ template "flowmanager.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.maxUnavailable }}
   template:
     metadata:
       labels:

--- a/common/charts/gpii-flowmanager/values.yaml
+++ b/common/charts/gpii-flowmanager/values.yaml
@@ -18,6 +18,10 @@ image:
   checksum: sha256:8547f22ae8e86d7b4b09e10d9ec87b1605b47dc37904171c84555a55462f161e
   pullPolicy: IfNotPresent
 
+rollingUpdate:
+  maxSurge: 25%
+  maxUnavailable: 0
+
 issuerRef:
   name: letsencrypt-production
   kind: Issuer

--- a/common/charts/gpii-preferences/templates/deployment.yaml
+++ b/common/charts/gpii-preferences/templates/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ template "preferences.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/common/charts/gpii-preferences/values.yaml
+++ b/common/charts/gpii-preferences/values.yaml
@@ -16,6 +16,10 @@ image:
   checksum: sha256:8547f22ae8e86d7b4b09e10d9ec87b1605b47dc37904171c84555a55462f161e
   pullPolicy: IfNotPresent
 
+rollingUpdate:
+  maxSurge: 25%
+  maxUnavailable: 0
+
 issuerRef:
   name: letsencrypt-production
   kind: Issuer


### PR DESCRIPTION
--recreate-pods on a helm upgrade restarts all services and prevents us from keeping the services available during upgrades. This PR removes this particular flag as well as promotes a expand-then-contract model for the rolling updates during deployments.