### PR TITLE
GPII-2996: Re-order destroy_tfstate and destroy_secrets.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,8 +83,8 @@ gcp-dev:
     - rake destroy
     # Destroy secrets, so they can be repopulated on the next run to exercise
     # managing secrets from scratch.
-    - rake destroy_tfstate[k8s]
     - rake destroy_secrets[default]
+    - rake destroy_tfstate[k8s]
     - rake clobber
 
 aws-promote-to-stg:


### PR DESCRIPTION
The former deletes the terragrunt volume, which the latter re-creates. The new order avoids this double dribble.