### PR TITLE
Disable multi-threaded mode for gsutil in :destroy_tfstate

### DIFF
--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -147,7 +147,7 @@ task :destroy_tfstate, [:prefix] => [:set_vars] do |taskname, args|
   else
     prefix = args[:prefix]
   end
-  sh "#{@exekube_cmd} sh -c 'gsutil -m rm -r gs://#{ENV["TF_VAR_project_id"]}-tfstate/#{@env}/#{prefix}'"
+  sh "#{@exekube_cmd} sh -c 'gsutil rm -r gs://#{ENV["TF_VAR_project_id"]}-tfstate/#{@env}/#{prefix}'"
   sh "docker volume rm -f -- #{ENV["TF_VAR_project_id"]}-#{ENV["USER"]}-terragrunt"
 end
 


### PR DESCRIPTION
Due to unknown reasons `gsutil rm` hangs if multi-threaded mode enabled and there is nothing to remove:
```
bash-4.4# gsutil -m rm -r gs://gpii-gcp-dev-natarajaya-tfstate/dev/k8s
CommandException: 1 files/objects could not be removed.
^CCaught CTRL-C (signal 2) - exiting
```