### PR TITLE
GPII-3214 - Remove unused GPII_FLOWMANAGER_MATCHMAKER_URL variable

### DIFF
--- a/aws/modules/deploy/charts/values/gpii-flowmanager.erb
+++ b/aws/modules/deploy/charts/values/gpii-flowmanager.erb
@@ -24,11 +24,4 @@ ingress:
   disable_ssl_redirect: true
 <% end %>
 
-
-<% if ENV["TF_VAR_cluster_name"].start_with?("stg.", "prd.") %>
-matchmaker_url: "https://flowmanager.<%= ENV["TF_VAR_cluster_name"] %>"
-<% else %>
-matchmaker_url: "http://flowmanager.<%= ENV["TF_VAR_cluster_name"] %>"
-<% end %>
-
 datasource_hostname: "http://<%= @secrets["couchdb_user"] %>:<%= @secrets["couchdb_password"] %>@couchdb-lb.gpii.svc.cluster.local"

--- a/common/charts/gpii-flowmanager/README.md
+++ b/common/charts/gpii-flowmanager/README.md
@@ -53,7 +53,6 @@ Parameter | Description | Default
 `datasource_hostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
 `node_env` | flowmanager node env | `gpii.config.cloudBased.flowManager.production`
 `preferences_url` | preferences service url | `http://preferences.gpii.svc.cluster.local/preferences/%gpiiKey?merge=%merge`
-`matchmaker_url` | matchmaker url | `https://flowmanager.test.local`
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
 `dnsNames` | list of host names for nginx-ingress controller | `flowmanager.test.local`

--- a/common/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/common/charts/gpii-flowmanager/templates/deployment.yaml
@@ -31,5 +31,3 @@ spec:
           value: '{{ .Values.datasource_listen_port }}'
         - name: GPII_FLOWMANAGER_TO_PREFERENCESSERVER_URL
           value: {{ .Values.preferences_url }}
-        - name: GPII_FLOWMANAGER_MATCHMAKER_URL
-          value: {{ .Values.matchmaker_url }}

--- a/common/charts/gpii-flowmanager/values.yaml
+++ b/common/charts/gpii-flowmanager/values.yaml
@@ -11,7 +11,6 @@ datasource_hostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster
 
 node_env: gpii.config.cloudBased.flowManager.production
 preferences_url: http://preferences.gpii.svc.cluster.local/preferences/%gpiiKey?merge=%merge
-matchmaker_url: https://flowmanager.test.local
 
 image:
   repository: gpii/universal

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -14,6 +14,4 @@ dnsNames:
 ingress:
   disable_ssl_redirect: ${env == "dev" ? "true" : "false"}
 
-matchmaker_url: "${env == "dev" ? "http" : "https"}://flowmanager.${domain_name}"
-
 datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"


### PR DESCRIPTION
Removes unused GPII_FLOWMANAGER_MATCHMAKER_URL env variable from Flowmanager chart and corresponding bits