### PR TITLE
GPII-3248: Draft up initial ideas on testing security of GCP-based clusters

### DIFF
--- a/gcp/live/dev/Gemfile
+++ b/gcp/live/dev/Gemfile
@@ -1,0 +1,4 @@
+source :rubygems
+
+gem 'rake'
+gem 'rspec'

--- a/gcp/live/dev/Gemfile.lock
+++ b/gcp/live/dev/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rake (12.3.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rspec
+
+BUNDLED WITH
+   1.16.2

--- a/gcp/live/dev/Rakefile
+++ b/gcp/live/dev/Rakefile
@@ -3,5 +3,12 @@ import "../../rakefiles/entrypoint.rake"
 @env = File.basename(File.dirname(__FILE__))
 @project_type = File.basename(File.expand_path("../../../", __FILE__))
 
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:securityTest) do |t|
+    t.rspec_opts = '--format documentation'
+  end
+rescue LoadError
+end
 
 # vim: et ts=2 sw=2:

--- a/gcp/live/dev/Rakefile
+++ b/gcp/live/dev/Rakefile
@@ -5,7 +5,7 @@ import "../../rakefiles/entrypoint.rake"
 
 begin
   require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:securityTest) do |t|
+  RSpec::Core::RakeTask.new(:test_security) do |t|
     t.rspec_opts = '--format documentation'
   end
 rescue LoadError

--- a/gcp/live/dev/spec/network_spec.rb
+++ b/gcp/live/dev/spec/network_spec.rb
@@ -73,6 +73,30 @@ describe "Security:" do
       end
     end
   end
+
+  context "FlowManager Pod" do
+    context "Container Port 8081" do
+      it "listens on port 8081" do
+        @preferences_pods.each do |pod|
+          kubectl("exec -n gpii -it #{pod.name} -- nc -z #{pod.ip} 8081")
+  
+          expect($?.exitstatus).to eq(0)
+        end
+      end
+  
+      it "is not accessible directly by any other pod on port 8081" do
+        pending "implementation of network security policies"
+  
+        @preferences_pods.each do |target|
+          (@all_pods-[target]).each do |source|
+            kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 8081")
+  
+             expect($?.exitstatus).to_not eq(0)
+          end
+        end
+      end
+    end 
+  end
   
   context "Couchdb" do
     context "Application" do
@@ -86,8 +110,7 @@ describe "Security:" do
         end
   
         it "is not accessible directly by any other pod on port 5984" do
-          pending "implementation of network security policies"
-  
+          pending "implementation of network security policies" 
           @couchdb_pods.each do |target|
             (@all_pods-@couchdb_pods).each do |source|
               kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 5984")

--- a/gcp/live/dev/spec/network_spec.rb
+++ b/gcp/live/dev/spec/network_spec.rb
@@ -1,0 +1,168 @@
+require 'json'
+require 'rspec/expectations'
+
+class Pod
+  def self.from_hash(hash)
+    Pod.new(hash)
+  end
+
+  def initialize(hash)
+    @data = hash
+  end
+
+  def ip
+    @data['status']['podIP']
+  end
+
+  def name
+    @data['metadata']['name']
+  end
+
+  def has_label(key, value)
+    @data['metadata']['labels'].keys.include?(key) &&
+    @data['metadata']['labels'][key] == value
+  end
+end
+
+def get_gpii_pods
+  JSON.parse(`kubectl get pods -n gpii -o json`)['items']
+    .collect{ |item| Pod.from_hash(item) }
+end
+
+def get_gpii_pods_labeled(key, value)
+  get_gpii_pods
+    .select{ |item| item.has_label(key, value) }
+end
+
+def kubectl(cmd)
+  `kubectl #{cmd} 2>/dev/null`
+end
+
+describe "Security:" do
+  before :all do
+    @couchdb_pods = get_gpii_pods_labeled("app", "couchdb")
+    @preferences_pods = get_gpii_pods_labeled("app", "preferences")
+    @flowmanager_pods = get_gpii_pods_labeled("app", "flowmanager")
+    @all_pods = @couchdb_pods | @preferences_pods | @flowmanager_pods
+
+    @couchdb_pods.each do |pod|
+      kubectl("exec -n gpii -it #{pod.name} -- sh -c \"[ ! -f /bin/nc ] && apt-get update -y && apt-get install netcat -y\"")
+    end
+  end
+
+  context "Preferences Pod" do
+    context "Container Port 8081" do
+      it "listens on port 8081" do
+        @preferences_pods.each do |pod|
+          kubectl("exec -n gpii -it #{pod.name} -c preferences -- nc -z #{pod.ip} 8081")
+  
+          expect($?.exitstatus).to eq(0)
+        end
+      end
+  
+      it "is not accessible directly by any other pod on port 8081" do
+        pending "implementation of network security policies"
+  
+        @preferences_pods.each do |target|
+          (@all_pods-[target]).each do |source|
+            kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 8081")
+  
+             expect($?.exitstatus).to_not eq(0)
+          end
+        end
+      end
+    end
+  end
+  
+  context "Couchdb" do
+    context "Application" do
+      context "Container Port 5984" do
+        it "should have couchdb listening on port 5984" do
+          @couchdb_pods.each do |pod|
+            kubectl("exec -n gpii -it #{pod.name} -- nc -z #{pod.ip} 5984")
+    
+            expect($?.exitstatus).to eq(0)
+          end
+        end
+  
+        it "is not accessible directly by any other pod on port 5984" do
+          pending "implementation of network security policies"
+  
+          @couchdb_pods.each do |target|
+            (@all_pods-@couchdb_pods).each do |source|
+              kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 5984")
+  
+              expect($?.exitstatus).to_not eq(0)
+            end
+          end
+        end
+      end
+    end
+
+    context "Erlang Clustering" do
+      context "Container Port 4368 (EPMD)" do
+        it "should have couchdb listening on port 4369 for erlang clustering" do
+          @couchdb_pods.each do |pod|
+            kubectl("exec -n gpii -it #{pod.name} -- nc -z #{pod.ip} 4369")
+    
+            expect($?.exitstatus).to eq(0)
+          end
+        end
+
+        it "should be able to reach out to other couchdb pods on port 4369 for erlang clustering" do
+          @couchdb_pods.each do |source|
+            (@couchdb_pods-[source]).each do |target|
+              kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 4369")
+    
+              expect($?.exitstatus).to eq(0)
+            end
+          end
+        end
+  
+        it "should not allow non-couchdb pods to reach port 4369" do
+          pending "implementation of network security policies"
+  
+          @couchdb_pods.each do |target|
+            (@all_pods-@couchdb_pods).each do |source|
+              kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 4369")
+  
+              expect($?.exitstatus).to_not eq(0)
+            end
+          end
+        end
+      end
+
+      context "Container Port 9100" do
+        it "should have couchdb listening on port 9100 for erlang clustering" do
+          @couchdb_pods.each do |pod|
+            kubectl("exec -n gpii -it #{pod.name} -- nc -z #{pod.ip} 9100")
+    
+            expect($?.exitstatus).to eq(0)
+          end
+        end
+
+        it "should be able to reach out to other couchdb pods on port 9100 for erlang clustering" do
+          @couchdb_pods.each do |source|
+            (@couchdb_pods-[source]).each do |target|
+              kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 9100")
+  
+              expect($?.exitstatus).to eq(0)
+            end
+          end
+        end
+  
+        it "should not allow non-couchdb pods to reach port 9100" do
+          pending "implementation of network security policies"
+    
+          @couchdb_pods.each do |target|
+            (@all_pods-@couchdb_pods).each do |source|
+              kubectl("exec -n gpii -it #{source.name} -- nc -z #{target.ip} 9100")
+    
+              expect($?.exitstatus).to_not eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains an early draft of code that allows us to test-drive development of network security policies on GCP. There are a large number of improvements that can/will be made. Notably:
1. Potential inclusion of a more domain-specific frameworks like `serverspec`, `inspec`, `goss`, or `gauntlt`
1. Execution of code within a standard container (perhaps the same container as the exekube container)
1. Documentation
1. Improved rspec matchers to improve readability (may be obviated by (1)) 
1. Move of securityTest related task definitions to its own Rake file

Currently, the way to execute this is to execute `rake securityTest` in `gcp/live/dev`. The output looks like the following:

```
$ rake securityTest
/usr/local/rvm/rubies/ruby-2.5.1/bin/ruby -I/usr/local/rvm/gems/ruby-2.5.1/gems/rspec-core-3.8.0/lib:/usr/local/rvm/gems/ruby-2.5.1/gems/rspec-support-3.8.0/lib /usr/local/rvm/gems/ruby-2.5.1/gems/rspec-core-3.8.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --format documentation
Security:
  Preferences Pod
    Container Port 8081
      listens on port 8081
      is not accessible directly by any other pod on port 8081 (PENDING: implementation of network security policies)
  Couchdb
    Application
      Container Port 5984
        should have couchdb listening on port 5984
        is not accessible directly by any other pod on port 5984 (PENDING: implementation of network security policies)
    Erlang Clustering
      Container Port 4368 (EPMD)
        should have couchdb listening on port 4369 for erlang clustering
        should be able to reach out to other couchdb pods on port 4369 for erlang clustering
        should not allow non-couchdb pods to reach port 4369 (PENDING: implementation of network security policies)
      Container Port 9100
        should have couchdb listening on port 9100 for erlang clustering
        should be able to reach out to other couchdb pods on port 9100 for erlang clustering
        should not allow non-couchdb pods to reach port 9100 (PENDING: implementation of network security policies)


Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Security: Preferences Pod Container Port 8081 is not accessible directly by any other pod on port 8081
     # implementation of network security policies
     Failure/Error: expect($?.exitstatus).to_not eq(0)

       expected: value != 0
            got: 0

       (compared using ==)
     # ./spec/network_spec.rb:70:in `block (6 levels) in <top (required)>'
     # ./spec/network_spec.rb:67:in `each'
     # ./spec/network_spec.rb:67:in `block (5 levels) in <top (required)>'
     # ./spec/network_spec.rb:66:in `each'
     # ./spec/network_spec.rb:66:in `block (4 levels) in <top (required)>'

  2) Security: Couchdb Application Container Port 5984 is not accessible directly by any other pod on port 5984
     # implementation of network security policies
     Failure/Error: expect($?.exitstatus).to_not eq(0)

       expected: value != 0
            got: 0

       (compared using ==)
     # ./spec/network_spec.rb:95:in `block (7 levels) in <top (required)>'
     # ./spec/network_spec.rb:92:in `each'
     # ./spec/network_spec.rb:92:in `block (6 levels) in <top (required)>'
     # ./spec/network_spec.rb:91:in `each'
     # ./spec/network_spec.rb:91:in `block (5 levels) in <top (required)>'

  3) Security: Couchdb Erlang Clustering Container Port 4368 (EPMD) should not allow non-couchdb pods to reach port 4369
     # implementation of network security policies
     Failure/Error: expect($?.exitstatus).to_not eq(0)

       expected: value != 0
            got: 0

       (compared using ==)
     # ./spec/network_spec.rb:129:in `block (7 levels) in <top (required)>'
     # ./spec/network_spec.rb:126:in `each'
     # ./spec/network_spec.rb:126:in `block (6 levels) in <top (required)>'
     # ./spec/network_spec.rb:125:in `each'
     # ./spec/network_spec.rb:125:in `block (5 levels) in <top (required)>'

  4) Security: Couchdb Erlang Clustering Container Port 9100 should not allow non-couchdb pods to reach port 9100
     # implementation of network security policies
     Failure/Error: expect($?.exitstatus).to_not eq(0)

       expected: value != 0
            got: 0

       (compared using ==)
     # ./spec/network_spec.rb:161:in `block (7 levels) in <top (required)>'
     # ./spec/network_spec.rb:158:in `each'
     # ./spec/network_spec.rb:158:in `block (6 levels) in <top (required)>'
     # ./spec/network_spec.rb:157:in `each'
     # ./spec/network_spec.rb:157:in `block (5 levels) in <top (required)>'

Finished in 13.55 seconds (files took 0.07256 seconds to load)
10 examples, 0 failures, 4 pending
```

