### PR TITLE
[GPII-3329]: Various fixes

### DIFF
--- a/gcp/rakefiles/entrypoint.rake
+++ b/gcp/rakefiles/entrypoint.rake
@@ -52,7 +52,7 @@ CLEAN << @compose_env_file
 task :set_compose_env do
   tf_vars = []
   ENV.each do |key, val|
-   tf_vars << key if key.start_with?("TF_VAR_")
+    tf_vars << key if key.start_with?("TF_VAR_")
   end
   File.open(@compose_env_file, 'w') do |file|
     file.write(tf_vars.sort.join("\n"))
@@ -127,7 +127,7 @@ task :sh, [:cmd] => [:set_vars] do |taskname, args|
     puts "Argument :cmd -- the command to run inside the exekube container -- not present, defaulting to bash"
     cmd = "bash"
   end
-  sh "#{@exekube_cmd} rake xk['#{cmd}',skip_infra,skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['#{cmd}',skip_secret_mgmt]"
 end
 
 desc '[ADVANCED] Destroy all SA keys except current one'
@@ -182,7 +182,7 @@ task :deploy_module, [:module] => [:set_vars] do |taskname, args|
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise
   end
-  sh "#{@exekube_cmd} rake xk['up live/#{@env}/#{args[:module]}',skip_infra,skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['up live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
 desc '[ADVANCED] Destroy provided module in the cluster -- rake destroy_module"[k8s/kube-system/cert-manager]"'
@@ -194,7 +194,7 @@ task :destroy_module, [:module] => [:set_vars] do |taskname, args|
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise
   end
-  sh "#{@exekube_cmd} rake xk['down live/#{@env}/#{args[:module]}',skip_infra,skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['down live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
 # vim: et ts=2 sw=2:

--- a/gcp/rakefiles/xk.rake
+++ b/gcp/rakefiles/xk.rake
@@ -52,12 +52,11 @@ rule @kubectl_creds_file => [@gcp_creds_file] do
 end
 
 # This task is being called from entrypoint.rake and runs inside exekube container.
-# It applies infra, secret-mgmt, sets secrets, and then executes arbitrary command from args[:cmd].
+# It applies secret-mgmt, sets secrets, and then executes arbitrary command from args[:cmd].
 # You should not invoke this task directly!
-task :xk, [:cmd, :skip_infra, :skip_secret_mgmt] => [@serviceaccount_key_file, @kubectl_creds_file] do |taskname, args|
+task :xk, [:cmd, :skip_secret_mgmt] => [@serviceaccount_key_file, @kubectl_creds_file] do |taskname, args|
   @secrets = Secrets.collect_secrets()
 
-  sh "#{@exekube_cmd} up live/#{@env}/infra" unless args[:skip_infra]
   sh "#{@exekube_cmd} up live/#{@env}/secret-mgmt" unless args[:skip_secret_mgmt]
 
   Secrets.set_secrets(@secrets)


### PR DESCRIPTION
This contains a fix for illegal base64 data in `tfstate_encryption_key` issue.
While working on that I had to fix the way we set secrets from ENV vars: since secrets are being handled inside of the exekube container, and only `TF_VAR_` vars are being passed, it is impossible to set secrets using `ENV[secret_name.upcase]` anymore.
I also found that infra is being applied twice, because of prerequisite of `:deploy` task and direct invocation from `:xk` task, fixed as well.