### PR TITLE
GPII-3248: Add testing notes for manually testing the front-end app with the backend apps on the cloud

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,8 @@ common-setup:
     - ruby --version
     - bundle version
     - rake --version
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-setup:
   stage: setup
@@ -42,6 +44,8 @@ aws-setup:
     - ruby --version
     - bundle version
     - rake --version
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-setup:
   stage: setup
@@ -55,6 +59,8 @@ gcp-setup:
     - ruby --version
     - bundle version
     - rake --version
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-unit-tests:
   stage: unit-tests
@@ -63,6 +69,8 @@ aws-unit-tests:
   script:
     - cd aws/rakefiles/tests
     - rake
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-unit-tests:
   stage: unit-tests
@@ -72,6 +80,8 @@ gcp-unit-tests:
     - cd shared/rakefiles/tests
     - bundle install --path "vendor/bundle"
     - rake
+  only:
+    - master@gpii-ops/gpii-infra
 
 common-stg:
   stage: common-stg
@@ -85,6 +95,8 @@ common-stg:
     - rake apply_infra
   environment:
     name: stg
+  only:
+    - master@gpii-ops/gpii-infra
 
 common-stg-test-gcp-dev:
   stage: common-stg-test
@@ -117,6 +129,8 @@ common-stg-test-gcp-dev:
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys
     - rake clobber
+  only:
+    - master@gpii-ops/gpii-infra
 
 common-promote-common-to-prd:
   stage: promote-common-to-prd
@@ -132,6 +146,8 @@ common-promote-common-to-prd:
     - git push --tags origin-rw
   when: manual
   allow_failure: false
+  only:
+    - master@gpii-ops/gpii-infra
 
 common-prd:
   stage: common-prd
@@ -147,6 +163,8 @@ common-prd:
     - rake apply_infra
   environment:
     name: prd
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-dev:
   stage: dev
@@ -162,6 +180,8 @@ aws-dev:
     - cd aws/dev
     - rake destroy
     - rake clobber
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-dev:
   stage: dev
@@ -187,6 +207,8 @@ gcp-dev:
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys
     - rake clobber
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-promote-to-stg:
   stage: promote-to-stg
@@ -200,6 +222,8 @@ aws-promote-to-stg:
     # if we add a remote that already exists.
     - git remote | grep -q "^origin-rw" || git remote add origin-rw git@github.com:gpii-ops/gpii-infra
     - git push --tags origin-rw
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-promote-to-stg:
   stage: promote-to-stg
@@ -213,6 +237,8 @@ gcp-promote-to-stg:
     # if we add a remote that already exists.
     - git remote | grep -q "^origin-rw" || git remote add origin-rw git@github.com:gpii-ops/gpii-infra
     - git push --tags origin-rw
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-stg:
   stage: stg
@@ -224,6 +250,8 @@ aws-stg:
     - cd aws/stg
     - rake clobber
     - rake
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-stg:
   stage: stg
@@ -245,6 +273,8 @@ gcp-stg:
     - rake destroy_module[locust]
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-promote-to-prd:
   stage: promote-to-prd
@@ -260,6 +290,8 @@ aws-promote-to-prd:
     - git push --tags origin-rw
   when: manual
   allow_failure: false
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-promote-to-prd:
   stage: promote-to-prd
@@ -275,6 +307,8 @@ gcp-promote-to-prd:
     - git push --tags origin-rw
   when: manual
   allow_failure: false
+  only:
+    - master@gpii-ops/gpii-infra
 
 aws-prd:
   stage: prd
@@ -288,6 +322,8 @@ aws-prd:
     - cd aws/prd
     - rake clobber
     - rake
+  only:
+    - master@gpii-ops/gpii-infra
 
 gcp-prd:
   stage: prd
@@ -311,3 +347,5 @@ gcp-prd:
     - rake destroy_module[locust]
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys
+  only:
+    - master@gpii-ops/gpii-infra

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,156 @@
+# Testing 
+
+This document describes pointers and notes for testing the GPII infrastructure in different contexts.
+
+# End-to-End Manual Testing Tutorial
+
+This section contains a tutorial to test the frontend GPII application against the backend. Relevant calls against the backend are noted after each action.
+
+## Testing key-in/key-out and basic settings
+
+1. Obtain a copy of the gpii/windows repository:
+
+```bash
+$ git clone git@github.com:GPII/windows.git
+```
+
+2. Use vagrant to spin up the instance.
+
+```bash
+$ cd windows
+
+$ vagrant up
+```
+
+3. Once the windows image is spun up, open a command prompt within the virtual machine and spin up the components locally.
+
+```shell
+$ cd C:\Vagrant
+
+$ SET GPII_CLOUD_URL=http://flowmanager.<CLUSTER_NAME>
+
+$ SET NODE_ENV=gpii.config.untrusted.development
+
+$ node gpii
+
+```
+
+The above will bring up a local flowmanager and point it to the specified cloud based flowmanager.
+
+4. Once the node process is started, create a new command prompt and login:
+
+```shell
+$ curl http://localhost:8081/users/carla/login
+```
+
+On the backend, two calls should be registered against the cloud based flow manager. Use kubectl to view the logs on either the ingress controller or the flowmanager pods:
+
+```
+$ kubectl logs -n gpii -l app=flowmanager
+...
+10.16.0.3 - [10.16.0.3] - - [10/Sep/2018:13:04:07 +0000] "POST /access_token HTTP/1.1" 200 90 "-" "-" 308 0.168 [gpii-flowmanager-80] 10.17.1.10:8081 90 0.136 200 7fc8385cfb9bc2cd6bb6ebfc2b5a7ee5
+...
+```
+
+The above is a call to obtain an oauth bearer token to be used in subsequent calls.
+
+
+```
+$ kubectl logs -n gpii -l app=flowmanager
+...
+10.16.0.3 - [10.16.0.3] - - [10/Sep/2018:13:05:43 +0000] "GET /carla/settings/%7B%22solutions%22%3A%5B%7B%22id%22%3A%22net.gpii.test.speechControl%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.interface%22%7D%2C%7B%22id%22%3A%22fakemag2%22%7D%2C%7B%22id%22%3A%22fakescreenreader1%22%7D%2C%7B%22id%22%3A%22org.gnome.nautilus%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.keyboard%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.applications.onscreen-keyboard%22%7D%2C%7B%22id%22%3A%22org.gnome.orca%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.magnifier%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.magnifier%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.onscreenKeyboard%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.narrator%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.highContrast%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.highContrastTheme%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.stickyKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.filterKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseTrailing%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenDPI%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.cursors%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenResolution%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.nightScreen%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.typingEnhancement%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.language%22%7D%2C%7B%22id%22%3A%22com.android.activitymanager%22%7D%2C%7B%22id%22%3A%22com.android.talkback%22%7D%2C%7B%22id%22%3A%22com.android.freespeech%22%7D%2C%7B%22id%22%3A%22com.android.settings.secure%22%7D%2C%7B%22id%22%3A%22com.android.audioManager%22%7D%2C%7B%22id%22%3A%22com.android.persistentConfiguration%22%7D%2C%7B%22id%22%3A%22org.alsa-project%22%7D%2C%7B%22id%22%3A%22org.freedesktop.xrandr%22%7D%2C%7B%22id%22%3A%22com.android.settings.system%22%7D%2C%7B%22id%22%3A%22net.gpii.uioPlus%22%7D%2C%7B%22id%22%3A%22net.gpii.explode%22%7D%5D%2C%22OS%22%3A%7B%22id%22%3A%22win32%22%2C%22version%22%3A%2210.0.16299%22%7D%7D HTTP/1.1" 200 38362 "-" "-" 2145 0.280 [gpii-flowmanager-80] 10.17.1.10:8081 38362 0.250 200 0e1061c44f8963b44399eb245e613d30
+...
+```
+
+The second call here was made to obtain the settings for the device.
+
+## Production Config Tests
+
+Another way to exercise the frontend nodejs code against a cloud based backend is to run the productionConfigTests. As of September 10, 2018, these productionConfigTests only exercise login and logout. To execute them, run the following test script from the universal container. Make sure to use an appropriate version.
+
+```
+$ docker run --rm --name productionConfigTests -e GPII_CLOUD_URL=https://flowmanager.<CLUSTER_NAME> gpii/universal@sha256:bc92279591c0ab60d11ecf55e43f783cd7cb92a0bc2fea6661054a065bbb2e49 node tests/ProductionConfigTests.js
+
+...
+14:18:42.191:  Creating GPII settings directory in /tmp/gpii
+14:18:42.196:  jq: Test concluded - Module "gpii.config.untrusted.development tests" Test name "Flow Manager development tests": 2/2 passed - PASS
+14:18:42.198:  jq: ***************
+14:18:42.198:  jq: All tests concluded: 2/2 total passed in 1542ms - PASS
+14:18:42.198:  jq: ***************
+
+```
+
+On the backend, we should expect the following log entres to be made for the ingress:
+
+```
+10.16.0.2 - [10.16.0.2] - - [10/Sep/2018:14:19:51 +0000] "POST /access_token HTTP/1.1" 200 90 "-" "-" 312 0.146 [gpii-flowmanager-80] 10.17.1.10:8081 90 0.113 200 7c63c0b04856e04bad6872e8f28884f1
+10.16.0.3 - [10.16.0.3] - - [10/Sep/2018:14:24:00 +0000] "GET /testUser1/settings/%7B%22solutions%22%3A%5B%7B%22id%22%3A%22net.gpii.test.speechControl%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.interface%22%7D%2C%7B%22id%22%3A%22fakemag2%22%7D%2C%7B%22id%22%3A%22fakescreenreader1%22%7D%2C%7B%22id%22%3A%22org.gnome.nautilus%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.keyboard%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.applications.onscreen-keyboard%22%7D%2C%7B%22id%22%3A%22org.gnome.orca%22%7D%2C%7B%22id%22%3A%22org.gnome.desktop.a11y.magnifier%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.magnifier%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.onscreenKeyboard%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.narrator%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.highContrast%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.highContrastTheme%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.stickyKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.filterKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseTrailing%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenDPI%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.cursors%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenResolution%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.nightScreen%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.typingEnhancement%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.language%22%7D%2C%7B%22id%22%3A%22com.android.activitymanager%22%7D%2C%7B%22id%22%3A%22com.android.talkback%22%7D%2C%7B%22id%22%3A%22com.android.freespeech%22%7D%2C%7B%22id%22%3A%22com.android.settings.secure%22%7D%2C%7B%22id%22%3A%22com.android.audioManager%22%7D%2C%7B%22id%22%3A%22com.android.persistentConfiguration%22%7D%2C%7B%22id%22%3A%22org.alsa-project%22%7D%2C%7B%22id%22%3A%22org.freedesktop.xrandr%22%7D%2C%7B%22id%22%3A%22com.android.settings.system%22%7D%2C%7B%22id%22%3A%22net.gpii.uioPlus%22%7D%2C%7B%22id%22%3A%22net.gpii.explode%22%7D%5D%2C%22OS%22%3A%7B%22id%22%3A%22linux%22%2C%22version%22%3A%223.10.0-862.el7.x86-64%22%7D%7D HTTP/1.1" 200 18570 "-" "-" 2160 0.237 [gpii-flowmanager-80] 10.17.1.10:8081 18570 0.237 200 39a38afe8ca911e5f15c3cd2906af73b
+```
+
+In addition, the flowmanager calls the preferences server and similar logs entries should be found in the preferences pod:
+
+```
+14:24:00.021:  Invoking handler gpii.preferencesServer.get.handler for route /preferences/:gpiiKey with expectedGrade kettle.request.http
+14:24:00.025:  Kettle server allocated request object with type gpii.preferencesServer.get.handler
+14:24:00.025:  gpii.preferencesServer.getPreferences called - fetching preferences for the GPII key testUser1
+14:24:00.025:  DataSource Issuing HTTP request with options {
+    "port": "5984",
+    "method": "GET",
+    "headers": {
+
+    },
+    "protocol": "http:",
+    "auth": "9af19d4cc412590b61e2440ce29eff2c:72e93ea87d01b2685950c01354e9ec70",
+    "host": "couchdb-svc-couchdb.gpii.svc.cluster.local:5984",
+    "hostname": "couchdb-svc-couchdb.gpii.svc.cluster.local",
+    "path": "/gpii/_design/views/_view/findPrefsSafeByGpiiKey?key=%22testUser1%22&include_docs=true",
+    "termMap": {
+        "gpiiKey": "%gpiiKey",
+        "baseUrl": "noencode:%baseUrl",
+        "port": "%port",
+        "dbName": "%dbName"
+    },
+    "url": "%baseUrl:%port/%dbName/_design/views/_view/findPrefsSafeByGpiiKey?key=%22%gpiiKey%22&include_docs=true",
+    "directModel": {
+        "baseUrl": "http://9af19d4cc412590b61e2440ce29eff2c:72e93ea87d01b2685950c01354e9ec70@couchdb-svc-couchdb.gpii.svc.cluster.local",
+        "port": "5984",
+        "dbName": "gpii",
+        "gpiiKey": "testUser1"
+    },
+    "operation": "get",
+    "reverse": false,
+    "writeMethod": "PUT",
+    "notFoundIsEmpty": true
+}
+14:24:00.097:  Preferences Server, getPreferences(), returning preferences: {
+    "contexts": {
+        "gpii-default": {
+            "name": "Default preferences",
+            "preferences": {
+                "http://registry.gpii.net/common/setting1": 12,
+                "http://registry.gpii.net/common/setting2": "white",
+                "http://registry.gpii.net/common/setting3": "black",
+                "http://registry.gpii.net/common/setting4": [
+                    "Comic Sans"
+                ],
+                "http://registry.gpii.net/common/setting5": "sans serif",
+                "http://registry.gpii.net/common/setting6": false
+            }
+        }
+    },
+    "name": undefined
+}
+```
+
+The above functionality is a limited test suite that needs to be expanded to be more complete. Work is being tracked in (GPII-3333)[https://issues.gpii.net/browse/GPII-3333] for that.
+
+## Testing login/logout and basic settings
+
+1. Obtain a copy of the gpii/windows repository:
+
+```bash
+
+
+# Security Testing
+
+_TODO_

--- a/TESTING.md
+++ b/TESTING.md
@@ -174,7 +174,7 @@ $ npm start
 
 ```
 
-4. You can open morphic now on the taskbar. The icon will of a gear. Update of the preferences should now register against the specified cluster.
+4. You can open morphic now on the taskbar. Find the icon in your taskbar that looks like a gear. Update of the preferences should now register against the specified cluster.
 
 
 ## Security Testing

--- a/TESTING.md
+++ b/TESTING.md
@@ -66,7 +66,7 @@ The second call here was made to obtain the settings for the device.
 
 ## Production Config Tests
 
-Another way to exercise the frontend nodejs code against a cloud based backend is to run the productionConfigTests. As of September 10, 2018, these productionConfigTests only exercise login and logout. To execute them, run the following test script from the universal container. Make sure to use an appropriate version.
+Another way to exercise the frontend nodejs code against a cloud based backend is to run the productionConfigTests. As of September 10, 2018, these productionConfigTests only exercise login and logout. To execute them, run the following test script from the universal container. Make sure to use an appropriate version. Generally, the latest version can be found in `common/versions.yml`, which is automatically kept up to date.
 
 ```
 $ docker run --rm --name productionConfigTests -e GPII_CLOUD_URL=https://flowmanager.<CLUSTER_NAME> gpii/universal@sha256:bc92279591c0ab60d11ecf55e43f783cd7cb92a0bc2fea6661054a065bbb2e49 node tests/ProductionConfigTests.js

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,7 +27,7 @@ $ vagrant up
 ```shell
 $ cd C:\Vagrant
 
-$ SET GPII_CLOUD_URL=http://flowmanager.<CLUSTER_NAME>
+$ SET GPII_CLOUD_URL=http://flowmanager.<CLUSTER_DNS>
 
 $ SET NODE_ENV=gpii.config.untrusted.development
 
@@ -69,7 +69,7 @@ The second call here was made to obtain the settings for the device.
 Another way to exercise the frontend nodejs code against a cloud based backend is to run the productionConfigTests. As of September 10, 2018, these productionConfigTests only exercise login and logout. To execute them, run the following test script from the universal container. Make sure to use an appropriate version. Generally, the latest version can be found in `common/versions.yml`, which is automatically kept up to date.
 
 ```
-$ docker run --rm --name productionConfigTests -e GPII_CLOUD_URL=https://flowmanager.<CLUSTER_NAME> gpii/universal@sha256:bc92279591c0ab60d11ecf55e43f783cd7cb92a0bc2fea6661054a065bbb2e49 node tests/ProductionConfigTests.js
+$ docker run --rm --name productionConfigTests -e GPII_CLOUD_URL=https://flowmanager.<CLUSTER_DNS> gpii/universal@sha256:bc92279591c0ab60d11ecf55e43f783cd7cb92a0bc2fea6661054a065bbb2e49 node tests/ProductionConfigTests.js
 
 ...
 14:18:42.191:  Creating GPII settings directory in /tmp/gpii
@@ -166,7 +166,7 @@ $ vagrant up
 ```
 $ cd c:\vagrant
 
-$ set GPII_CLOUD_URL=http://flowmanager.<CLUSTER_NAME>
+$ set GPII_CLOUD_URL=http://flowmanager.<CLUSTER_DNS>
 
 $ npm start
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,11 +2,11 @@
 
 This document describes pointers and notes for testing the GPII infrastructure in different contexts.
 
-# End-to-End Manual Testing Tutorial
+## End-to-End Manual Testing Tutorial
 
 This section contains a tutorial to test the frontend GPII application against the backend. Relevant calls against the backend are noted after each action.
 
-## Testing key-in/key-out and basic settings
+### Testing key-in/key-out and basic settings
 
 1. Obtain a copy of the gpii/windows repository:
 
@@ -64,7 +64,7 @@ $ kubectl logs -n gpii -l app=flowmanager
 
 The second call here was made to obtain the settings for the device.
 
-## Production Config Tests
+### Production Config Tests
 
 Another way to exercise the frontend nodejs code against a cloud based backend is to run the productionConfigTests. As of September 10, 2018, these productionConfigTests only exercise login and logout. To execute them, run the following test script from the universal container. Make sure to use an appropriate version. Generally, the latest version can be found in `common/versions.yml`, which is automatically kept up to date.
 
@@ -144,7 +144,7 @@ In addition, the flowmanager calls the preferences server and similar logs entri
 
 The above functionality is a limited test suite that needs to be expanded to be more complete. Work is being tracked in [GPII-3333](https://issues.gpii.net/browse/GPII-3333) for that.
 
-## Testing login/logout and basic settings
+### Testing login/logout and basic settings
 
 1. Obtain a copy of the gpii/gpii-app repository:
 
@@ -177,6 +177,6 @@ $ npm start
 4. You can open morphic now on the taskbar. The icon will of a gear. Update of the preferences should now register against the specified cluster.
 
 
-# Security Testing
+## Security Testing
 
 _TODO_

--- a/TESTING.md
+++ b/TESTING.md
@@ -142,13 +142,39 @@ In addition, the flowmanager calls the preferences server and similar logs entri
 }
 ```
 
-The above functionality is a limited test suite that needs to be expanded to be more complete. Work is being tracked in (GPII-3333)[https://issues.gpii.net/browse/GPII-3333] for that.
+The above functionality is a limited test suite that needs to be expanded to be more complete. Work is being tracked in [GPII-3333](https://issues.gpii.net/browse/GPII-3333) for that.
 
 ## Testing login/logout and basic settings
 
-1. Obtain a copy of the gpii/windows repository:
+1. Obtain a copy of the gpii/gpii-app repository:
 
 ```bash
+$ git clone https://github.com/GPII/gpii-app.git
+
+```
+
+2. Spin up the vagrant box:
+
+```bash
+$ cd gpii-app
+
+$ vagrant up
+```
+
+3. When the machine is up and running, open a command prompt and run the application:
+
+```
+$ cd c:\vagrant
+
+$ set GPII_CLOUD_URL=http://flowmanager.<CLUSTER_NAME>
+
+$ npm start
+
+...
+
+```
+
+4. You can open morphic now on the taskbar. The icon will of a gear. Update of the preferences should now register against the specified cluster.
 
 
 # Security Testing


### PR DESCRIPTION
This PR details out the path forward on how to bring up the frontend app locally and how to tie it into a custom cluster.