### PR TITLE
GPII-3351 - Change the way that the DNS zone is detected in GCP

### DIFF
--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -76,17 +76,10 @@ task :refresh_common_infra, [:project_type] => [@gcp_creds_file] do | taskname, 
   # conflicts at the creation resources we need to import the already created
   # DNS zone.
 
-  output = `#{@exekube_cmd} sh -c "\
-    terragrunt output -json dns_zones \
+  dns_zone_found = `#{@exekube_cmd} sh -c "\
+    terragrunt state show module.gke_network.google_dns_managed_zone.dns_zones \
     --terragrunt-working-dir /project/live/#{@env}/infra/network 2>/dev/null \
     "`
-  begin
-    # What does !! mean?
-    # https://stackoverflow.com/questions/524658/what-does-mean-in-ruby
-    dns_zone_found = !!JSON.parse(output)
-  rescue JSON::ParserError
-    dns_zone_found = false
-  end
 
   unless dns_zone_found
     # The DNS zone is not in the TF state file, we need to add it

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -76,12 +76,12 @@ task :refresh_common_infra, [:project_type] => [@gcp_creds_file] do | taskname, 
   # conflicts at the creation resources we need to import the already created
   # DNS zone.
 
-  dns_zone_found = `#{@exekube_cmd} sh -c "\
+  dns_zone_found = %x|#{@exekube_cmd} sh -c "\
     terragrunt state show module.gke_network.google_dns_managed_zone.dns_zones \
     --terragrunt-working-dir /project/live/#{@env}/infra/network 2>/dev/null \
-    "`
+    "|
 
-  unless dns_zone_found
+  if dns_zone_found.empty?
     # The DNS zone is not in the TF state file, we need to add it
     puts "DNS zone #{ENV["TF_VAR_domain_name"].tr('.','-')} not found in TF state, importing..."
     sh "#{@exekube_cmd} sh -c '\


### PR DESCRIPTION
https://issues.gpii.net/browse/GPII-3351

"The actual implementation of the detection if a DNS zone already exists relies on the fact that there is an output in the tf state. That could not be the case if the project is recently created. The output of this DNS resource is only saved once a new cluster is created inside the project."

This PR also solves this comment of the #60 : https://github.com/gpii-ops/gpii-infra/pull/60#pullrequestreview-154394605