### PR TITLE
Add Sergio and Stepan dev clusters

### DIFF
--- a/common/live/prd/infra/dev/sergio/terraform.tfvars
+++ b/common/live/prd/infra/dev/sergio/terraform.tfvars
@@ -1,0 +1,19 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-project"
+  }
+  dependencies {
+    paths = ["../zone"]
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+
+project_name    = "dev-seg10"
+project_owner   = "sergio@raisingthefloor.org"
+

--- a/common/live/prd/infra/dev/stepan/terraform.tfvars
+++ b/common/live/prd/infra/dev/stepan/terraform.tfvars
@@ -1,0 +1,19 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-project"
+  }
+  dependencies {
+    paths = ["../zone"]
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+
+project_name    = "dev-stepan"
+project_owner   = "stepan@raisingthefloor.org"
+


### PR DESCRIPTION
Before merge this PR. As @seg10 has an already created project, the existing resources must be imported first, in order to avoid conflicts at the project creation.

```
cd common/live/prd
RAKE_REALLY_RUN_IN_PRD=yes rake plain_shell
cd live/prd/infra/dev/sergio/
terragrunt import google_project.project gpii-gcp-dev-seg10
terragrunt import google_project_services.project gpii-gcp-dev-seg10
terragrunt import google_storage_bucket.project-tfstate gpii-gcp-dev-seg10-tfstate
terragrunt import google_service_account.project projects/gpii-gcp-dev-seg10/serviceAccounts/projectowner@gpii-gcp-dev-seg10.iam.gserviceaccount.com
```
As the importing of a DNS don't work, the delete of the zone and the NS registry in the dev.gcp.gpii.net are also needed.
```
#The following didn't work in other cases
terragrunt import google_dns_managed_zone.project seg10-dev-gcp-gpii-net
```