### PR TITLE
GPII-3361 - Remove DNS description and leave default as it is in exekube

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -93,7 +93,6 @@ resource "google_dns_managed_zone" "project" {
   project     = "${google_project.project.project_id}"
   name        = "${replace(local.dnsname, ".", "-")}"
   dns_name    = "${local.dnsname}."
-  description = "${google_project.project.project_id} DNS zone"
   depends_on  = ["google_project_services.project",
                  "google_project_iam_binding.project"]
 }


### PR DESCRIPTION
This change avoid the "fighting" between exekube and the common gcp-project Terraform module where each one sets a different description of the DNS zone.