### PR TITLE
GPII-3248: Add links from README.md to additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ This repository manages infrastructure for the [GPII](https://gpii.net/).
 * [Amazon Web Services (AWS)](aws/) *(stable but soon to be deprecated)*
 * [Google Cloud Platform (GCP)](gcp/) *(beta but soon to be stable)*
 * [Common plumbing](common/) *(mostly for admins)*
+
+Additional documents are available at the root of this repository:
+
+* [Continuous Integration/Delivery Process](./CI-CD.md)
+* [Testing the GPII frontend against the backend](./TESTING.md)
+* [User Training Notes](./USER-TRAINING.md)


### PR DESCRIPTION
Given the increasing number of markdown files, we should help to ensure that someone can navigate to them from the top level README.md file.

Note that this PR addresses a single comment from the previous PR for GPII-3248: https://github.com/gpii-ops/gpii-infra/pull/111#discussion_r216551489.