### PR TITLE
GPII-3387 Upgrade CouchDB 2.2.0 due security vulnerabilities

### DIFF
--- a/aws/modules/deploy/53-couchdb-statefulset.erb
+++ b/aws/modules/deploy/53-couchdb-statefulset.erb
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: couchdb
-        image: gpii/couchdb:latest
+        image: gpii/couchdb:2.2.0
         env:
         - name: COUCHDB_USER
           valueFrom:

--- a/common/charts/couchdb/Chart.yaml
+++ b/common/charts/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: couchdb
-version: 0.1.8
-appVersion: 2.1.1
+version: 0.2.0
+appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/common/charts/couchdb/README.md
+++ b/common/charts/couchdb/README.md
@@ -75,7 +75,7 @@ CouchDB chart and their default values:
 |           Parameter             |             Description                               |                Default                 |
 |---------------------------------|-------------------------------------------------------|----------------------------------------|
 | `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
-| `couchdbConfig`                 | Map allowing override elements of server .ini config  | {}                                     |
+| `couchdbConfig`                 | Map allowing override elements of server .ini config  | chttpd.bind_address=any                |
 | `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
 | `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
 | `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
@@ -94,7 +94,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `helperImage.tag`               | 0.1.0                                  |
 | `helperImage.pullPolicy`        | IfNotPresent                           |
 | `image.repository`              | couchdb                                |
-| `image.tag`                     | 2.1.1                                  |
+| `image.tag`                     | 2.2.0                                  |
 | `image.pullPolicy`              | IfNotPresent                           |
 | `ingress.enabled`               | false                                  |
 | `ingress.hosts`                 | chart-example.local                    |

--- a/common/charts/couchdb/values.yaml
+++ b/common/charts/couchdb/values.yaml
@@ -40,7 +40,7 @@ persistentVolume:
 ## The CouchDB image
 image:
   repository: couchdb
-  tag: 2.1.1
+  tag: 2.2.0
   pullPolicy: IfNotPresent
 
 ## Sidecar that connects the individual Pods into a cluster
@@ -118,3 +118,5 @@ erlangFlags:
 couchdbConfig:
   # cluster:
   #   q: 8 # Create 8 shards for each database
+  chttpd:
+    bind_address: any


### PR DESCRIPTION
The https://github.com/gpii-ops/couchdb-docker/pull/2 is also needed. Although the CouchDB container is already built and tested.

I updated the chart from [the incubator](https://github.com/helm/charts/tree/master/incubator/couchdb) and added the code needed to provide the "affinity" feature from Sergey's PR: https://github.com/helm/charts/pull/7224

Since we don't have the commit history of upstream, I checked out the repository and see the differences with upstream, applying them in our branch.