### PR TITLE
[GPII-3329]: Workaround for Terraform GCS backend encryption issue

### DIFF
--- a/gcp/live/terraform.tfvars
+++ b/gcp/live/terraform.tfvars
@@ -7,7 +7,9 @@ terragrunt = {
       credentials    = "${get_env("TF_VAR_serviceaccount_key", "")}"
       bucket         = "${get_env("TF_VAR_project_id", "")}-tfstate"
       prefix         = "${path_relative_to_include()}"
-      encryption_key = "${get_env("TF_VAR_key_tfstate_encryption_key", "")}"
+      # TODO: Next line needs to be uncommented back once Terraform issue with GCS backend encryption is fixed
+      # https://issues.gpii.net/browse/GPII-3329
+      # encryption_key = "${get_env("TF_VAR_key_tfstate_encryption_key", "")}"
     }
   }
 

--- a/gcp/modules/nginx-ingress/main.tf
+++ b/gcp/modules/nginx-ingress/main.tf
@@ -15,6 +15,10 @@ data "terraform_remote_state" "network" {
     credentials = "${var.serviceaccount_key}"
     bucket      = "${var.project_id}-tfstate"
     prefix      = "${var.env}/infra/network"
+
+    # TODO: Next line should be removed once Terraform issue with GCS backend encryption is fixed
+    # https://issues.gpii.net/browse/GPII-3329
+    encryption_key = "/dev/null"
   }
 }
 

--- a/shared/rakefiles/secrets.rb
+++ b/shared/rakefiles/secrets.rb
@@ -109,6 +109,10 @@ class Secrets
         push_secrets(populated_secrets, encryption_key)
       end
     end
+
+    # TODO: Next line should be removed once Terraform issue with GCS backend encryption is fixed
+    # https://issues.gpii.net/browse/GPII-3329
+    ENV['GOOGLE_ENCRYPTION_KEY'] = ENV['TF_VAR_key_tfstate_encryption_key']
   end
 
   def self.push_secrets(secrets, encryption_key)

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -65,10 +65,6 @@ task :xk, [:cmd, :skip_secret_mgmt] => [:configure_serviceaccount, @kubectl_cred
 
   Secrets.set_secrets(@secrets)
 
-  # TODO: Next line should be removed once Terraform issue with GCS backend encryption is fixed
-  # https://issues.gpii.net/browse/GPII-3329
-  ENV['GOOGLE_ENCRYPTION_KEY'] = ENV['TF_VAR_key_tfstate_encryption_key']
-
   sh_filter "#{@exekube_cmd} #{args[:cmd]}" if args[:cmd]
 end
 

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -65,6 +65,10 @@ task :xk, [:cmd, :skip_secret_mgmt] => [:configure_serviceaccount, @kubectl_cred
 
   Secrets.set_secrets(@secrets)
 
+  # TODO: Next line should be removed once Terraform issue with GCS backend encryption is fixed
+  # https://issues.gpii.net/browse/GPII-3329
+  ENV['GOOGLE_ENCRYPTION_KEY'] = ENV['TF_VAR_key_tfstate_encryption_key']
+
   sh_filter "#{@exekube_cmd} #{args[:cmd]}" if args[:cmd]
 end
 


### PR DESCRIPTION
Small update on how we got here:
* CI [sometimes fail](https://gitlab.com/gpii-ops/gpii-infra/-/jobs/98913039) with `Error configuring the backend "gcs": Error decoding encryption key: illegal base64 data at input byte 0`.
* Recovered TF state encryption keys looked valid.
* We tried to change base64 encoding standard  that is used from RFC 2045 to RFC 4648, the failure rate decreased (may be coincidence), but issue was still there.
* Pulled up Terraform GCS backend code and tried to decrypt keys under question using [exact Go code](https://github.com/hashicorp/terraform/blob/master/backend/remote-state/gcs/backend.go#L184-L188) from GCS backend – all keys appeared to be valid during tests.
* Discovered that GCS backend also provides a way to set encryption key [using `GOOGLE_ENCRYPTION_KEY` env var](https://github.com/hashicorp/terraform/blob/master/backend/remote-state/gcs/backend.go#L167-L170).
* All questionable encryption key work just fine when being set via `GOOGLE_ENCRYPTION_KEY` env var.
* Conclusion – we are facing Terraform GCS backend bug, I'll submit new issue, link to this PR and update GPII ticket as well.