### PR TITLE
[GPII-3395]: Increase update timeout for GCP cluster

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -25,4 +25,6 @@ module "gke_cluster" {
   ]
 
   dashboard_disabled = true
+
+  update_timeout = "30m"
 }


### PR DESCRIPTION
Merge after https://github.com/gpii-ops/exekube/pull/15