### PR TITLE
Fix the location of the charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ common/live/*/**/owner.json
 common/live/*/compose.env
 common/live/*/*values/** 
 common/live/*/*secrets/**
-common/charts/locust/tasks/*
+shared/charts/locust/tasks/*
 aws/modules/deploy/secrets/*-secrets.yml
 aws/prereqs/dev/terraform.tfstate*
 tags

--- a/aws/modules/deploy/charts/config.yml
+++ b/aws/modules/deploy/charts/config.yml
@@ -1,7 +1,7 @@
 # This is the config file for GPII Helm Charts.
 #
 # It contain a list of chart names with respect to install/uninstall order.
-# All charts are being installed from /common/charts directory, which
+# All charts are being installed from /shared/charts directory, which
 # is shared between AWS and GCP parts of the project.
 #
 # Child directory named "values" may contain ERB template with custom values

--- a/aws/rakefiles/vars.rb
+++ b/aws/rakefiles/vars.rb
@@ -65,5 +65,5 @@ def setup_vars(env_short)
   ENV["RAKE_TMPDIR_ALREADY_SET"] = "true"
 
   # Directory where Helm charts live
-  @chartdir = '../../common/charts'
+  @chartdir = '../../shared/charts'
 end


### PR DESCRIPTION
This fixes:
```
Error: could not find a ready tiller pod
helm install --name nginx-ingress --namespace gpii -f /tmp/rake-tmp/dev-gitlab-runner-modules/deploy/charts/values/nginx-ingress.yaml ../../common/charts/nginx-ingress
```