### PR TITLE
GPII-3324: Add gcp-stackdriver-export

### DIFF
--- a/gcp/live/dev/k8s/cluster/terraform.tfvars
+++ b/gcp/live/dev/k8s/cluster/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../stackdriver/exclusion",
+      "../stackdriver/export",
     ]
   }
 

--- a/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
@@ -1,0 +1,26 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-stackdriver-export"
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+exports = {
+  # Captures interactions with many Google products, including GCE, GS, IAM,
+  # and more.
+  #
+  # TODO: This is a lot less noisy if we add "AND NOT operation.producer=k8s.io".
+  "cloudaudit-activity" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Factivity"
+
+  # Captures Google Storage and KMS events
+  "cloudaudit-data-access" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Fdata_access"
+
+  # Captures events for products within GCE, such as Snapshots, Instance
+  # Groups, Firewalls, etc.
+  "compute-activity" = "logName=projects/__var.project_id__/logs/compute.googleapis.com%2Factivity_log"
+}

--- a/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
@@ -10,17 +10,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-exports = {
-  # Captures interactions with many Google products, including GCE, GS, IAM,
-  # and more.
-  #
-  # TODO: This is a lot less noisy if we add "AND NOT operation.producer=k8s.io".
-  "cloudaudit-activity" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Factivity"
-
-  # Captures Google Storage and KMS events
-  "cloudaudit-data-access" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Fdata_access"
-
-  # Captures events for products within GCE, such as Snapshots, Instance
-  # Groups, Firewalls, etc.
-  "compute-activity" = "logName=projects/__var.project_id__/logs/compute.googleapis.com%2Factivity_log"
-}

--- a/gcp/live/prd/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/prd/k8s/stackdriver/export/terraform.tfvars
@@ -1,0 +1,12 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-stackdriver-export"
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/stg/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/stg/k8s/stackdriver/export/terraform.tfvars
@@ -1,0 +1,12 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-stackdriver-export"
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/modules/gcp-stackdriver-export/main.tf
+++ b/gcp/modules/gcp-stackdriver-export/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "project_id" {}
+variable "serviceaccount_key" {}
+variable "exports" {
+  default = {}
+}
+
+module "gcp_stackdriver_export" {
+  source             = "/exekube-modules/gcp-stackdriver-export"
+  project_id         = "${var.project_id}"
+  serviceaccount_key = "${var.serviceaccount_key}"
+  exports            = "${var.exports}"
+}

--- a/gcp/modules/gcp-stackdriver-export/main.tf
+++ b/gcp/modules/gcp-stackdriver-export/main.tf
@@ -12,12 +12,15 @@ variable "exports" {
     # TODO: This is a lot less noisy if we add "AND NOT operation.producer=k8s.io".
     "cloudaudit-activity" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Factivity"
 
-    # Captures Google Storage and KMS events
+    # Captures Google Storage and KMS events.
     "cloudaudit-data-access" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Fdata_access"
 
     # Captures events for products within GCE, such as Snapshots, Instance
     # Groups, Firewalls, etc.
     "compute-activity" = "logName=projects/__var.project_id__/logs/compute.googleapis.com%2Factivity_log"
+
+    # Events from GPII containers.
+    "gpii-containers" = "resource.type=container AND resource.labels.namespace_id=gpii"
   }
 }
 

--- a/gcp/modules/gcp-stackdriver-export/main.tf
+++ b/gcp/modules/gcp-stackdriver-export/main.tf
@@ -5,7 +5,20 @@ terraform {
 variable "project_id" {}
 variable "serviceaccount_key" {}
 variable "exports" {
-  default = {}
+  default = {
+    # Captures interactions with many Google products, including GCE, GS, IAM,
+    # and more.
+    #
+    # TODO: This is a lot less noisy if we add "AND NOT operation.producer=k8s.io".
+    "cloudaudit-activity" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Factivity"
+
+    # Captures Google Storage and KMS events
+    "cloudaudit-data-access" = "logName=projects/__var.project_id__/logs/cloudaudit.googleapis.com%2Fdata_access"
+
+    # Captures events for products within GCE, such as Snapshots, Instance
+    # Groups, Firewalls, etc.
+    "compute-activity" = "logName=projects/__var.project_id__/logs/compute.googleapis.com%2Factivity_log"
+  }
 }
 
 module "gcp_stackdriver_export" {


### PR DESCRIPTION
This PR is on top of my branch for #114.

Requires https://github.com/gpii-ops/exekube/pull/16.

Next steps:
* Retain some container logs. Only the gpii namespace? Some other set?