### PR TITLE
Add :check_destroy_allowed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,8 +344,8 @@ gcp-prd:
     # Clean up even if something failed.
     - cd gcp/live/prd
     # Destroy Locust module (used for smoke tests)
-    - rake destroy_module[locust]
+    - export RAKE_REALLY_DESTROY_IN_PRD=true ; rake destroy_module[locust] ; unset RAKE_REALLY_DESTROY_IN_PRD
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
-    - rake destroy_sa_keys
+    - export RAKE_REALLY_DESTROY_IN_PRD=true ; rake destroy_sa_keys ; unset RAKE_REALLY_DESTROY_IN_PRD=true
   only:
     - master@gpii-ops/gpii-infra

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -338,8 +338,8 @@ gcp-prd:
     - rake clobber
     - rake configure_serviceaccount_ci_restore
     - rake
-    - rake test_preferences
-    - rake test_flowmanager
+    - export RAKE_REALLY_DESTROY_IN_PRD=true ; rake test_preferences ; unset RAKE_REALLY_DESTROY_IN_PRD
+    - export RAKE_REALLY_DESTROY_IN_PRD=true ; rake test_flowmanager ; unset RAKE_REALLY_DESTROY_IN_PRD
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/prd


### PR DESCRIPTION
Extra protection for prd. See https://github.com/gpii-ops/exekube/pull/16.

```
[tyler@toaster:~/rtf/gpii-infra/gcp/live/prd]$ rake destroy_module"[k8s/stackdriver/export]"
  ERROR: Tried to run in env 'prd' but RAKE_REALLY_RUN_IN_PRD is not set
rake aborted!

[tyler@toaster:~/rtf/gpii-infra/gcp/live/prd]$ RAKE_REALLY_RUN_IN_PRD=1 rake destroy_module"[k8s/stackdriver/export]"
  ERROR: Tried to destroy something in env 'prd' but RAKE_REALLY_DESTROY_IN_PRD is not set
rake aborted!
ArgumentError: Tried to destroy something in env 'prd' but RAKE_REALLY_DESTROY_IN_PRD is not set

[tyler@toaster:~/rtf/gpii-infra/gcp/live/prd]$ RAKE_REALLY_RUN_IN_PRD=1 RAKE_REALLY_DESTROY_IN_PRD=1 rake destroy_module"[k8s/stackdriver/export]"
docker-compose run --rm xk rake xk['down live/prd/k8s/stackdriver/export',skip_secret_mgmt]
Creating volume "gpii-gcp-prd-tyler-secrets" with default driver
Creating volume "gpii-gcp-prd-tyler-helm" with default driver
...
```