### PR TITLE
Tune CPU requests for GPII components

### DIFF
--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -25,7 +25,7 @@ affinity:
 resources:
   requests:
     cpu: 500m
-    memory: 512Mi
+    memory: 256Mi
   limits:
-    cpu: 500m
+    cpu: 1500m
     memory: 512Mi

--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -25,7 +25,7 @@ affinity:
 resources:
   requests:
     cpu: 500m
-    memory: 256Mi
+    memory: 512Mi
   limits:
     cpu: 1500m
     memory: 512Mi

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -19,7 +19,7 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 resources:
   requests:
     cpu: 500m
-    memory: 128Mi
+    memory: 256Mi
   limits:
-    cpu: "1"
+    cpu: 1000m
     memory: 256Mi

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -19,7 +19,7 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 resources:
   requests:
     cpu: 500m
-    memory: 256Mi
+    memory: 128Mi
   limits:
-    cpu: 500m
+    cpu: "1"
     memory: 256Mi

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -19,7 +19,7 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 resources:
   requests:
     cpu: 500m
-    memory: 128Mi
+    memory: 256Mi
   limits:
-    cpu: "1"
+    cpu: 1000m
     memory: 256Mi

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -19,7 +19,7 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 resources:
   requests:
     cpu: 500m
-    memory: 256Mi
+    memory: 128Mi
   limits:
-    cpu: 500m
+    cpu: "1"
     memory: 256Mi

--- a/gcp/modules/nginx-ingress/values.yaml
+++ b/gcp/modules/nginx-ingress/values.yaml
@@ -11,10 +11,10 @@ controller:
     targetMemoryUtilizationPercentage: 50
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 100m
+      memory: 64Mi
     limits:
-      cpu: 50m
+      cpu: 200m
       memory: 128Mi
 
 defaultBackend:
@@ -24,8 +24,8 @@ defaultBackend:
       cpu: 10m
       memory: 32Mi
     limits:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 20m
+      memory: 64Mi
 
 rbac:
   create: true

--- a/gcp/modules/nginx-ingress/values.yaml
+++ b/gcp/modules/nginx-ingress/values.yaml
@@ -12,9 +12,9 @@ controller:
   resources:
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 128Mi
 
 defaultBackend:
@@ -24,8 +24,8 @@ defaultBackend:
       cpu: 10m
       memory: 32Mi
     limits:
-      cpu: 20m
-      memory: 64Mi
+      cpu: 10m
+      memory: 32Mi
 
 rbac:
   create: true


### PR DESCRIPTION
@stepanstipl I had to return back to my original requests settings for CPU. Looks like the reason of recent build failures is too intense CPU throttling. And since we have only 6 CPUs in the cluster, out of which [almost 5 CPUs are already requested](https://www.dropbox.com/s/abderjo09nl61xc/Screenshot%202018-09-28%2021.46.56.png?dl=0), I was unable to divide remaining 1 CPU between all GPII components without causing issues with scheduling. However, when I set higher CPU limits, system performance significantly improves.

I suggest we keep this as it is for now and revisit in future (maybe when we introduce more powerful instances for stg/prd?)