### PR TITLE
[GPII-3418]: Tune resource requests one more time

### DIFF
--- a/gcp/live/dev/k8s/cluster/terraform.tfvars
+++ b/gcp/live/dev/k8s/cluster/terraform.tfvars
@@ -17,3 +17,5 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
+
+node_type = "n1-standard-2"

--- a/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
@@ -18,6 +18,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-couchdb_replicas = 2
-backup_deltas = "PT5M PT15M PT45M"
+backup_deltas     = "PT5M PT15M PT45M"
 release_namespace = "gpii"
+
+replica_count     = 2
+requests_cpu      = "500m"
+requests_memory   = "512Mi"
+limits_cpu        = "1000m"
+limits_memory     = "512Mi"

--- a/gcp/live/dev/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/flowmanager/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-staging"
+disable_ssl_redirect = "true"
+
+replica_count     = 2
+requests_cpu      = "250m"
+requests_memory   = "256Mi"
+limits_cpu        = "500m"
+limits_memory     = "256Mi"

--- a/gcp/live/dev/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/preferences/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-staging"
+disable_ssl_redirect = "true"
+
+replica_count     = 2
+requests_cpu      = "500m"
+requests_memory   = "256Mi"
+limits_cpu        = "1000m"
+limits_memory     = "256Mi"

--- a/gcp/live/prd/k8s/cluster/terraform.tfvars
+++ b/gcp/live/prd/k8s/cluster/terraform.tfvars
@@ -17,3 +17,5 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
+
+node_type = "n1-highcpu-4"

--- a/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
@@ -18,6 +18,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-couchdb_replicas = 3
-backup_deltas = "PT5M PT60M PT24H P7D P52W"
+backup_deltas     = "PT5M PT60M PT24H P7D P52W"
 release_namespace = "gpii"
+
+replica_count     = 3
+requests_cpu      = "1000m"
+requests_memory   = "512Mi"
+limits_cpu        = "1000m"
+limits_memory     = "512Mi"

--- a/gcp/live/prd/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/flowmanager/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-production"
+disable_ssl_redirect = "false"
+
+replica_count     = 4
+requests_cpu      = "500m"
+requests_memory   = "256Mi"
+limits_cpu        = "500m"
+limits_memory     = "256Mi"

--- a/gcp/live/prd/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/preferences/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-production"
+disable_ssl_redirect = "false"
+
+replica_count     = 4
+requests_cpu      = "1000m"
+requests_memory   = "256Mi"
+limits_cpu        = "1000m"
+limits_memory     = "256Mi"

--- a/gcp/live/stg/k8s/cluster/terraform.tfvars
+++ b/gcp/live/stg/k8s/cluster/terraform.tfvars
@@ -17,3 +17,5 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
+
+node_type = "n1-highcpu-4"

--- a/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
@@ -18,6 +18,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-couchdb_replicas = 3
-backup_deltas = "PT15M PT60M PT4H PT24H P7D"
+backup_deltas     = "PT15M PT60M PT4H PT24H P7D"
 release_namespace = "gpii"
+
+replica_count     = 3
+requests_cpu      = "1000m"
+requests_memory   = "512Mi"
+limits_cpu        = "1000m"
+limits_memory     = "512Mi"

--- a/gcp/live/stg/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/flowmanager/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-production"
+disable_ssl_redirect = "false"
+
+replica_count     = 4
+requests_cpu      = "500m"
+requests_memory   = "256Mi"
+limits_cpu        = "500m"
+limits_memory     = "256Mi"

--- a/gcp/live/stg/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/preferences/terraform.tfvars
@@ -19,3 +19,11 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+cert_issuer_name     = "letsencrypt-production"
+disable_ssl_redirect = "false"
+
+replica_count     = 4
+requests_cpu      = "1000m"
+requests_memory   = "256Mi"
+limits_cpu        = "1000m"
+limits_memory     = "256Mi"

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -2,16 +2,18 @@ terraform {
   backend "gcs" {}
 }
 
-variable "env" {}
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "nonce" {}
 
 # Terragrunt variables
-variable "couchdb_replicas" {}
-
+variable "replica_count" {}
 variable "backup_deltas" {}
 variable "release_namespace" {}
+variable "requests_cpu" {}
+variable "requests_memory" {}
+variable "limits_cpu" {}
+variable "limits_memory" {}
 
 # Secret variables
 variable "secret_couchdb_admin_username" {}
@@ -22,10 +24,14 @@ data "template_file" "couchdb_values" {
   template = "${file("values.yaml")}"
 
   vars {
-    env                    = "${var.env}"
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
     couchdb_auth_cookie    = "${var.secret_couchdb_auth_cookie}"
+    replica_count          = "${var.replica_count}"
+    requests_cpu           = "${var.requests_cpu}"
+    requests_memory        = "${var.requests_memory}"
+    limits_cpu             = "${var.limits_cpu}"
+    limits_memory          = "${var.limits_memory}"
   }
 }
 

--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -1,4 +1,4 @@
-clusterSize: ${env == "dev" ? 2 : 3}
+clusterSize: ${replica_count}
 
 adminUsername: ${couchdb_admin_username}
 adminPassword: ${couchdb_admin_password}
@@ -24,8 +24,8 @@ affinity:
 
 resources:
   requests:
-    cpu: ${env == "dev" ? 500 : 1000}m
-    memory: 512Mi
+    cpu: ${requests_cpu}
+    memory: ${requests_memory}
   limits:
-    cpu: 1000m
-    memory: 512Mi
+    cpu: ${limits_cpu}
+    memory: ${limits_memory}

--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -24,8 +24,8 @@ affinity:
 
 resources:
   requests:
-    cpu: 500m
+    cpu: ${env == "dev" ? 500 : 1000}m
     memory: 512Mi
   limits:
-    cpu: 1500m
+    cpu: 1000m
     memory: 512Mi

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -2,9 +2,11 @@ terraform {
   backend "gcs" {}
 }
 
-variable "env" {}
 variable "project_id" {}
 variable "serviceaccount_key" {}
+
+# Terragrunt variables
+variable "node_type" {}
 
 module "gke_cluster" {
   source             = "/exekube-modules/gke-cluster"
@@ -12,7 +14,7 @@ module "gke_cluster" {
   serviceaccount_key = "${var.serviceaccount_key}"
 
   initial_node_count = 1
-  node_type          = "${var.env == "dev" ? "n1-standard-2" : "n1-highcpu-4"}"
+  node_type          = "${var.node_type}"
   kubernetes_version = "1.10.7-gke.2"
 
   main_compute_zone  = "us-central1-a"

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -2,6 +2,7 @@ terraform {
   backend "gcs" {}
 }
 
+variable "env" {}
 variable "project_id" {}
 variable "serviceaccount_key" {}
 
@@ -11,7 +12,7 @@ module "gke_cluster" {
   serviceaccount_key = "${var.serviceaccount_key}"
 
   initial_node_count = 1
-  node_type          = "n1-standard-2"
+  node_type          = "${var.env == "dev" ? "n1-standard-2" : "n1-highcpu-4"}"
   kubernetes_version = "1.10.7-gke.2"
 
   main_compute_zone  = "us-central1-a"

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -2,27 +2,42 @@ terraform {
   backend "gcs" {}
 }
 
-variable "env" {}
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "domain_name" {}
 
-variable "secret_couchdb_admin_username" {}
-variable "secret_couchdb_admin_password" {}
-
 variable "flowmanager_repository" {}
 variable "flowmanager_checksum" {}
+
+# Terragrunt variables
+variable "cert_issuer_name" {}
+variable "disable_ssl_redirect" {}
+variable "replica_count" {}
+variable "requests_cpu" {}
+variable "requests_memory" {}
+variable "limits_cpu" {}
+variable "limits_memory" {}
+
+# Secret variables
+variable "secret_couchdb_admin_username" {}
+variable "secret_couchdb_admin_password" {}
 
 data "template_file" "flowmanager_values" {
   template = "${file("values.yaml")}"
 
   vars {
-    env                    = "${var.env}"
     domain_name            = "${var.domain_name}"
     flowmanager_repository = "${var.flowmanager_repository}"
     flowmanager_checksum   = "${var.flowmanager_checksum}"
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
+    cert_issuer_name       = "${var.cert_issuer_name}"
+    disable_ssl_redirect   = "${var.disable_ssl_redirect}"
+    replica_count          = "${var.replica_count}"
+    requests_cpu           = "${var.requests_cpu}"
+    requests_memory        = "${var.requests_memory}"
+    limits_cpu             = "${var.limits_cpu}"
+    limits_memory          = "${var.limits_memory}"
   }
 }
 

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -1,25 +1,25 @@
-replicaCount: ${env == "dev" ? 2 : 4}
+replicaCount: ${replica_count}
 
 image:
   repository: ${flowmanager_repository}
   checksum: ${flowmanager_checksum}
 
 issuerRef:
-  name: ${env == "dev" ? "letsencrypt-staging" : "letsencrypt-production"}
+  name: ${cert_issuer_name}
   kind: ClusterIssuer
 
 dnsNames:
 - flowmanager.${domain_name}
 
 ingress:
-  disable_ssl_redirect: ${env == "dev" ? "true" : "false"}
+  disable_ssl_redirect: ${disable_ssl_redirect}
 
 datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 resources:
   requests:
-    cpu: ${env == "dev" ? 250 : 500}m
-    memory: 256Mi
+    cpu: ${requests_cpu}
+    memory: ${requests_memory}
   limits:
-    cpu: 500m
-    memory: 256Mi
+    cpu: ${limits_cpu}
+    memory: ${limits_memory}

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: ${env == "dev" ? 2 : 6}
+replicaCount: ${env == "dev" ? 2 : 4}
 
 image:
   repository: ${flowmanager_repository}
@@ -18,8 +18,8 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 
 resources:
   requests:
-    cpu: 500m
+    cpu: ${env == "dev" ? 250 : 500}m
     memory: 256Mi
   limits:
-    cpu: 1000m
+    cpu: 500m
     memory: 256Mi

--- a/gcp/modules/gpii-preferences/main.tf
+++ b/gcp/modules/gpii-preferences/main.tf
@@ -2,27 +2,42 @@ terraform {
   backend "gcs" {}
 }
 
-variable "env" {}
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "domain_name" {}
 
-variable "secret_couchdb_admin_username" {}
-variable "secret_couchdb_admin_password" {}
-
 variable "preferences_repository" {}
 variable "preferences_checksum" {}
+
+# Terragrunt variables
+variable "cert_issuer_name" {}
+variable "disable_ssl_redirect" {}
+variable "replica_count" {}
+variable "requests_cpu" {}
+variable "requests_memory" {}
+variable "limits_cpu" {}
+variable "limits_memory" {}
+
+# Secret variables
+variable "secret_couchdb_admin_username" {}
+variable "secret_couchdb_admin_password" {}
 
 data "template_file" "preferences_values" {
   template = "${file("values.yaml")}"
 
   vars {
-    env                    = "${var.env}"
     domain_name            = "${var.domain_name}"
     preferences_repository = "${var.preferences_repository}"
     preferences_checksum   = "${var.preferences_checksum}"
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
+    cert_issuer_name       = "${var.cert_issuer_name}"
+    disable_ssl_redirect   = "${var.disable_ssl_redirect}"
+    replica_count          = "${var.replica_count}"
+    requests_cpu           = "${var.requests_cpu}"
+    requests_memory        = "${var.requests_memory}"
+    limits_cpu             = "${var.limits_cpu}"
+    limits_memory          = "${var.limits_memory}"
   }
 }
 

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -1,25 +1,25 @@
-replicaCount: ${env == "dev" ? 2 : 4}
+replicaCount: ${replica_count}
 
 image:
   repository: ${preferences_repository}
   checksum: ${preferences_checksum}
 
 issuerRef:
-  name: ${env == "dev" ? "letsencrypt-staging" : "letsencrypt-production"}
+  name: ${cert_issuer_name}
   kind: ClusterIssuer
 
 dnsNames:
 - preferences.${domain_name}
 
 ingress:
-  disable_ssl_redirect: ${env == "dev" ? "true" : "false"}
+  disable_ssl_redirect: ${disable_ssl_redirect}
 
 datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 resources:
   requests:
-    cpu: ${env == "dev" ? 500 : 1000}m
-    memory: 256Mi
+    cpu: ${requests_cpu}
+    memory: ${requests_memory}
   limits:
-    cpu: 1000m
-    memory: 256Mi
+    cpu: ${limits_cpu}
+    memory: ${limits_memory}

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: ${env == "dev" ? 2 : 6}
+replicaCount: ${env == "dev" ? 2 : 4}
 
 image:
   repository: ${preferences_repository}
@@ -18,7 +18,7 @@ datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}
 
 resources:
   requests:
-    cpu: 500m
+    cpu: ${env == "dev" ? 500 : 1000}m
     memory: 256Mi
   limits:
     cpu: 1000m

--- a/gcp/modules/nginx-ingress/values.yaml
+++ b/gcp/modules/nginx-ingress/values.yaml
@@ -11,21 +11,21 @@ controller:
     targetMemoryUtilizationPercentage: 50
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 200m
+      memory: 256Mi
     limits:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 200m
+      memory: 256Mi
 
 defaultBackend:
   replicaCount: 2
   resources:
     requests:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 100m
+      memory: 128Mi
     limits:
-      cpu: 10m
-      memory: 32Mi
+      cpu: 100m
+      memory: 128Mi
 
 rbac:
   create: true


### PR DESCRIPTION
This is the long-term solution I promised.

For dev clusters I had to keep requests lowered in order to stay on cheaper `n1-standard-2` nodes.

For staging / prod clusters:
* To have "more predictable" scheduling with requests = limits
* To also have more replicas of preferences, flowmanager and couchdb (similarly to AWS setup)
* And finally, to have enough room for rolling updates with `maxUnavailable: 0`

I suggest to use `n1-highcpu-4` instances. They are a bit cheaper than `n1-standard-4` and have significantly less RAM (4GB vs 15GB), but since we are very far away from hitting RAM limit, it seems like the most optimal choice in our situation.

Changing node type will most likely cause Terraform to attempt to recreate the cluster. I am not sure if there is a way around this issue for staging and prod, I am open to suggestions!

Using container_node_pool should improve this situation:
https://issues.gpii.net/browse/GPII-3419