### PR TITLE
Apply null_resource resources on every run

### DIFF
--- a/gcp/modules/cert-manager/main.tf
+++ b/gcp/modules/cert-manager/main.tf
@@ -2,6 +2,7 @@ terraform {
   backend "gcs" {}
 }
 
+variable "nonce" {}
 variable "secrets_dir" {}
 variable "charts_dir" {}
 
@@ -18,6 +19,10 @@ module "cert-manager" {
 
 resource "null_resource" "cert_manager_resources" {
   depends_on = ["module.cert-manager"]
+
+  triggers = {
+    nonce = "${var.nonce}"
+  }
 
   provisioner "local-exec" {
     command = "kubectl apply -f ${path.module}/resources/"

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -51,6 +51,10 @@ module "couchdb" {
 resource "null_resource" "couchdb_finish_cluster" {
   depends_on = ["module.couchdb"]
 
+  triggers = {
+    nonce = "${var.nonce}"
+  }
+
   provisioner "local-exec" {
     command = <<EOF
       RETRIES=10


### PR DESCRIPTION
I tried to run `rake` locally to recover `prd` from cluster destruction, and the only thing which prevented everything from getting back to its original state was null_resource resources of cert-manager and couchdb.

I see no harm in adding a little bit of execution time to improve idempotency of apply operation.