### PR TITLE
GPII-3428 Remove terragrunt volume

### DIFF
--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -45,7 +45,6 @@ services:
       - ../shared/rakefiles:/rakefiles
       - secrets:/project/live/${ENV}/secrets
       - helm:/root/.helm
-      - terragrunt:/root/.terragrunt
       - gcloud:/root/.config/gcloud
       - kube:/root/.kube
 
@@ -63,8 +62,6 @@ volumes:
     name: ${TF_VAR_project_id}-${USER}-secrets
   helm:
     name: ${TF_VAR_project_id}-${USER}-helm
-  terragrunt:
-    name: ${TF_VAR_project_id}-${USER}-terragrunt
   gcloud:
     name: ${TF_VAR_project_id}-${USER}-gcloud
   kube:

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -22,7 +22,7 @@ end
 @serviceaccount_key_file = "secrets/kube-system/owner.json"
 
 task :clean_volumes => :set_vars do
-  ["helm", "terragrunt", "kube"].each do |app|
+  ["helm", "kube"].each do |app|
     sh "docker volume rm -f -- #{ENV["TF_VAR_project_id"]}-#{ENV["USER"]}-#{app}"
   end
 end
@@ -174,7 +174,6 @@ task :destroy_tfstate, [:prefix] => [:set_vars, :check_destroy_allowed] do |task
     prefix = args[:prefix]
   end
   sh "#{@exekube_cmd} sh -c 'gsutil rm -r gs://#{ENV["TF_VAR_project_id"]}-tfstate/#{@env}/#{prefix}'"
-  sh "docker volume rm -f -- #{ENV["TF_VAR_project_id"]}-#{ENV["USER"]}-terragrunt"
 end
 
 desc "[ADVANCED] Destroy provided module in the cluster, and then deploy it -- rake redeploy_module['k8s/kube-system/cert-manager']"


### PR DESCRIPTION
This PR fixes issues described in [GPII-3428](https://issues.gpii.net/browse/GPII-3428). There's a couple of different cases I was able to reproduce, all related to Terragrunt's caching of modules and providers.

The behavior without the volume is more consistent with what happens on CI, where we delete the volumes between runs.

The particular issue described can be reproduced by:
- Run `rake` in `gcp/dev/`
- Change version of one of the TF providers (I've changed `helm` to 0.5 for testing) and build `gpii/exekube:0.4.0-google` image
- Run `rake` again and you should get the error.

There seems to be slight performance hit on average by not using the volume, as `init` has to be run every time:

| # | with volume | without volume |
| --- | --- | --- |
| 1st | 2:08s | 1:57s |
| 2nd | 1:53s | 2:05s |
| 3rd | 1:47s | 2:03s |

However as this a) fixes the issues and b) makes local dev run more consistent with CI run, I'm in favor of going forward.