### PR TITLE
Destroy TF state for locust in stg and prd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -282,8 +282,9 @@ gcp-stg:
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/stg
-    # Destroy Locust module (used for smoke tests)
+    # Destroy Locust module (used for smoke tests) and its TF state
     - rake destroy_module[locust] || true
+    - rake destroy_tfstate[locust] || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
   only:
@@ -359,8 +360,9 @@ gcp-prd:
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/prd
-    # Destroy Locust module (used for smoke tests)
+    # Destroy Locust module (used for smoke tests) and its TF state
     - rake destroy_module[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
+    - rake destroy_tfstate[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys RAKE_REALLY_DESTROY_IN_PRD=true || true
   only:


### PR DESCRIPTION
We are rotating tfstate key for prefix `k8s`, but leaving `locust` behind.