### PR TITLE
Bump kubernetes_version to 1.10.7-gke.6.

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -15,7 +15,7 @@ module "gke_cluster" {
 
   initial_node_count = 1
   node_type          = "${var.node_type}"
-  kubernetes_version = "1.10.7-gke.2"
+  kubernetes_version = "1.10.7-gke.6"
 
   main_compute_zone = "us-central1-a"
   additional_zones  = ["us-central1-b", "us-central1-c", "us-central1-f"]


### PR DESCRIPTION
`* google_container_cluster.cluster: googleapi: Error 400: Master version "1.10.7-gke.2" is unsupported., badRequest`

I haven't tested upgrading an existing cluster; I think that was a pain last time? Anyway I hit the above error so I thought I'd start the ball rolling on the (mandatory) upgrade.