### PR TITLE
GPII-3421 - Allow couchdb updates

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -47,7 +47,8 @@ module "couchdb" {
   release_values          = ""
   release_values_rendered = "${data.template_file.couchdb_values.rendered}"
 
-  chart_name = "${var.charts_dir}/couchdb"
+  chart_name   = "${var.charts_dir}/couchdb"
+  force_update = true
 }
 
 resource "null_resource" "couchdb_finish_cluster" {

--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "couchdb.fullname" . }}
   labels:
     app: {{ template "couchdb.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:


### PR DESCRIPTION
This fixes CouchDB updates by removing `Version` part from StatefulSet label, as Kubernetes don't allow updates to any other fields but 'replicas', 'template', and 'updateStrategy' (https://issues.gpii.net/browse/GPII-3421).

Also adds `force_update` to the CouchDB and this will cause StatefulSet recreation, but without it we wouldn't be able to update, as the chart is already deployed with the `Version` in the label.

While this causes CouchDB downtime, the underlying volumes and therefore data are preserved. In future we should be carefull about updates that modify anything but the fields mentioned above.

From the tests on my cluster:
PVC and associated PVs before the update:
```
$ kubectl get pvc -n gpii
NAME                                 STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
database-storage-couchdb-couchdb-0   Bound     pvc-a65ac690-c6f0-11e8-ae25-42010a800276   10Gi       RWO            standard       9d
database-storage-couchdb-couchdb-1   Bound     pvc-a65fa6d6-c6f0-11e8-ae25-42010a800276   10Gi       RWO            standard       9d`
```

after the update:
```
$ kubectl get statefulset -n gpii
NAME              DESIRED   CURRENT   AGE
couchdb-couchdb   2         2         4m

$ kubectl get pvc -n gpii
NAME                                 STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
database-storage-couchdb-couchdb-0   Bound     pvc-a65ac690-c6f0-11e8-ae25-42010a800276   10Gi       RWO            standard       9d
database-storage-couchdb-couchdb-1   Bound     pvc-a65fa6d6-c6f0-11e8-ae25-42010a800276   10Gi       RWO            standard       9d
```
-> the volumes were not affected by re-creating the StatefulSet (this is how it should work :)).