### PR TITLE
Hack to stop dataloader related errors

### DIFF
--- a/gcp/modules/gpii-dataloader/main.tf
+++ b/gcp/modules/gpii-dataloader/main.tf
@@ -15,8 +15,13 @@ data "template_file" "dataloader_values" {
   template = "${file("values.yaml")}"
 
   vars {
-    dataloader_repository  = "${var.dataloader_repository}"
-    dataloader_checksum    = "${var.dataloader_checksum}"
+    dataloader_repository = "${var.dataloader_repository}"
+
+    # This is an ugly hack to stop TF/Helm dataloader errors and should be removed
+    # in scope of https://github.com/gpii-ops/gpii-infra/pull/163
+    # dataloader_checksum    = "${var.dataloader_checksum}"
+    dataloader_checksum = "sha256:3876e3526b8b59f94aa25c8b6d1a3166df115d402b51176ef8bd91c899430369"
+
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
   }


### PR DESCRIPTION
This is an ugly hack to stop TF/Helm data loader errors that freezes data loader version.

It should be removed in scope of https://github.com/gpii-ops/gpii-infra/pull/163, once the "new" dataloader is ready to be used.

After potentially failing once (if the dataloader is at older version), no more errors should appear, as TF will not try to update it even if `versions.yaml` change.