### PR TITLE
[GPII-3456] Add encryption keys config to keep the order

### DIFF
--- a/gcp/modules/gcp-secret-mgmt/config.yaml
+++ b/gcp/modules/gcp-secret-mgmt/config.yaml
@@ -1,3 +1,5 @@
+# This config file is required to keep the order of encryption keys.
+# More info: https://issues.gpii.net/browse/GPII-3456
 encryption_keys:
   - default
   - gcp-stackdriver-export

--- a/gcp/modules/gcp-secret-mgmt/config.yaml
+++ b/gcp/modules/gcp-secret-mgmt/config.yaml
@@ -1,0 +1,3 @@
+encryption_keys:
+  - default
+  - gcp-stackdriver-export

--- a/shared/rakefiles/secrets.rb
+++ b/shared/rakefiles/secrets.rb
@@ -75,13 +75,13 @@ class Secrets
       encryption_keys[encryption_key] = %Q|"#{encryption_key}"|
     end
 
-    unless collected_secrets.keys == encryption_keys.keys
+    unless (collected_secrets.keys - encryption_keys.keys).empty?
       puts "ERROR: Secret keys: #{(collected_secrets.keys - encryption_keys.keys).join(", ")} not present in"
       puts "ERROR: /modules/gcp-secret-mgmt/config.yaml"
       raise
     end
 
-    ENV["TF_VAR_encryption_keys"] = %Q|[ #{encryption_keys.keys.join(", ")} ]|
+    ENV["TF_VAR_encryption_keys"] = %Q|[ #{encryption_keys.values.join(", ")} ]|
 
     return collected_secrets
   end

--- a/shared/rakefiles/secrets.rb
+++ b/shared/rakefiles/secrets.rb
@@ -23,9 +23,10 @@ class Secrets
   #  - secret_module_and_one_more_secret
   # encryption_key: default
   #
-  # Config file /modules/gcp-secret-mgmt/config.yaml
+  # Config file gcp/modules/gcp-secret-mgmt/config.yaml
   # is needed to preserve the order of encryption keys.
   # All used encryption keys must be present in that config, otherwise exception is raised
+  # More info: https://issues.gpii.net/browse/GPII-3456
   #
   # Attribute "encryption_key" is optional – if not present, module name will be used as Key name
   # After collecting, method returns the Hash with collected secrets, where the keys are KMS Encryption Keys and the values are
@@ -75,9 +76,10 @@ class Secrets
       encryption_keys[encryption_key] = %Q|"#{encryption_key}"|
     end
 
-    unless (collected_secrets.keys - encryption_keys.keys).empty?
-      puts "ERROR: Secret keys: #{(collected_secrets.keys - encryption_keys.keys).join(", ")} not present in"
-      puts "ERROR: /modules/gcp-secret-mgmt/config.yaml"
+    leftover_keys = collected_secrets.keys - encryption_keys.keys
+    unless leftover_keys.empty?
+      puts "ERROR: Secret keys: \"#{leftover_keys.join(", ")}\" not present in"
+      puts "ERROR: gcp/modules/gcp-secret-mgmt/config.yaml"
       raise
     end
 


### PR DESCRIPTION
As discovered by Alfredo, Terraform freaks out in case order of the encryption keys changes.