### PR TITLE
GPII-3354 Restrict permissions to the common SA

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -23,6 +23,30 @@ variable "organization_id" {}
 
 variable "serviceaccount_key" {}
 
+variable "common_serviceaccount_roles" {
+  default = [
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/dns.admin",
+    "roles/storage.admin",
+  ]
+}
+
+variable "user_serviceaccount_roles" {
+  default = [
+    "roles/iam.serviceAccountUser",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/cloudkms.admin",
+    "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+    "roles/compute.admin",
+    "roles/container.clusterAdmin",
+    "roles/container.admin",
+    "roles/dns.admin",
+    "roles/logging.configWriter",
+    "roles/storage.admin",
+  ]
+}
+
 variable "project_id" {} # id of the project which owns the credentials used by the provider
 
 provider "google" {
@@ -90,8 +114,26 @@ resource "google_project_iam_binding" "project" {
 
   members = [
     "${var.project_owner}",
-    "serviceAccount:${google_service_account.project.email}",
+  ]
+}
+
+resource "google_project_iam_binding" "project_common_serviceaccount" {
+  count   = "${length(var.common_serviceaccount_roles)}"
+  project = "${google_project.project.project_id}"
+  role    = "${element(var.common_serviceaccount_roles, count.index)}"
+
+  members = [
     "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
+  ]
+}
+
+resource "google_project_iam_binding" "project_user_serviceaccount" {
+  count   = "${length(var.user_serviceaccount_roles)}"
+  project = "${google_project.project.project_id}"
+  role    = "${element(var.user_serviceaccount_roles, count.index)}"
+
+  members = [
+    "serviceAccount:${google_service_account.project.email}",
   ]
 }
 

--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -4,8 +4,15 @@ task :apply_common_infra => [:set_vars, :configure_aws_restore] do
   # create the rest of the infrastructure.
   # These steps are the same found in this tutorial:
   # https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform
-  #
-  # Due to the needed permissions for creating the following resources, only an
-  # administrator of the organization can run this task.
   sh "#{@exekube_cmd} rake apply_common_infra"
+end
+
+desc "[ONLY ADMIN] Fix the permissions for the common service account"
+task :fix_common_service_account_permissions => [:set_vars] do
+  # This task sets the permissions of the common service account for creating the
+  # projects and for setting the IAMs needed to manage such projects.
+  #
+  # Due to the needed permissions for setting such permissions, only an
+  # administrator of the organization must run this task.
+  sh "#{@exekube_cmd} rake fix_common_service_account_permissions"
 end

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -107,13 +107,13 @@ task :apply_common_infra => [@gcp_creds_file] do
 
   organizations_permissions = ["roles/resourcemanager.projectCreator", "roles/billing.user"]
 
-  serviceAccount = "serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com"
+  service_account = "serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com"
 
   permissions_list.each do |permission|
-    organizations_permissions.delete(permission["role"]) if organizations_permissions.include?(permission["role"]) and permission["members"].include?(serviceAccount)
+    organizations_permissions.delete(permission["role"]) if organizations_permissions.include?(permission["role"]) and permission["members"].include?(service_account)
   end
 
-  raise "The common Service Account #{serviceAccount} doesn't have the proper permissions #{organizations_permissions}" unless organizations_permissions.empty?
+  raise "The common Service Account #{service_account} doesn't have the proper permissions #{organizations_permissions}" unless organizations_permissions.empty?
 
   tfstate_bucket = %x{
     #{@exekube_cmd} gsutil ls | grep 'gs://#{ENV["TF_VAR_project_id"]}-tfstate'


### PR DESCRIPTION
The common SA has owner permissions at organization level and also at the project level.
At the organization level it needs the `owner` permissions in order to grant itself the permissions of modifying IAMs. Once the common SA has the right permissions it doesn't need to reset them again, so we can delegate this task to an operator and remove the owner permission to the SA at organization level. If the common SA doesn't have proper permissions the CI pipeline will fail at the `apply_common_infra` task.

At the project level it also has the `owner` role. This PR set the roles collected based on the audit logs queries and some test deployments. This PR also assign lower level permissions to the user SA.

The plan to proceed with this PR, as it affects to the entire infrastructure, is to merge and perform all the checks in the common-STG environment before it its promoted to production. The checks can be:

- [ ] activate audit logs for the doe dev cluster and the test organization
- [ ] rake command in the doe dev cluster
- [ ] check that the endpoints work
  - [ ] rake test_flowmanager
  - [ ] rake test_prefences
- [ ] rake destroy in the doe dev cluster
- [ ] remove all the resources left in the doe cluster manually. The project must be as cleaned as possible of resources, like a brand new project.
- [ ] Test again the rake and rake destroy commands
- [ ] See that the logs are sent to the Stackdriver
- [ ] Verify that the logs have been exported to the Google Storage Bucket
- [ ] check that all the permissions were granted at the project level an at the organization level.

Perhaps this PR also covers part of GPII-2802