### PR TITLE
Remove Terragrunt volume for common, add destroy_sa_keys after script for common stg, prd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,9 @@ common-stg:
     - rake configure_serviceaccount_ci_restore
     - rake apply_common_infra
     - rake apply_infra
+  after_script:
+    - cd common/live/stg
+    - rake destroy_sa_keys
   environment:
     name: stg
   only:
@@ -171,6 +174,9 @@ common-prd:
     - rake configure_serviceaccount_ci_restore
     - rake apply_common_infra
     - rake apply_infra
+  after_script:
+    - cd common/live/prd
+    - rake destroy_sa_keys
   environment:
     name: prd
   only:

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -45,7 +45,6 @@ services:
       - ../shared/rakefiles:/rakefiles
       - secrets:/project/live/${ENV}/secrets
       - helm:/root/.helm
-      - terragrunt:/root/.terragrunt
       - gcloud:/root/.config/gcloud
       - kube:/root/.kube
       - aws:/root/.aws
@@ -64,8 +63,6 @@ volumes:
     name: ${TF_VAR_project_id}-${USER}-secrets
   helm:
     name: ${TF_VAR_project_id}-${USER}-helm
-  terragrunt:
-    name: ${TF_VAR_project_id}-${USER}-terragrunt
   gcloud:
     name: ${TF_VAR_project_id}-${USER}-gcloud
   kube:


### PR DESCRIPTION
This should fix recent build failures.
Adding `destroy_sa_keys` step is unrelated and is something that I found accidentally when debugging original issue.