### PR TITLE
GPII-3394: Enable Stackdriver Trace

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -59,6 +59,7 @@ resource "google_project_services" "project" {
     "cloudbilling.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "cloudtrace.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",

--- a/gcp/live/prd/k8s/cluster/terraform.tfvars
+++ b/gcp/live/prd/k8s/cluster/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../stackdriver/exclusion",
+      "../stackdriver/export",
     ]
   }
 

--- a/gcp/live/stg/k8s/cluster/terraform.tfvars
+++ b/gcp/live/stg/k8s/cluster/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../stackdriver/exclusion",
+      "../stackdriver/export",
     ]
   }
 

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -28,6 +28,7 @@ module "gke_cluster" {
     "https://www.googleapis.com/auth/devstorage.read_only",
     "https://www.googleapis.com/auth/logging.write",
     "https://www.googleapis.com/auth/monitoring",
+    "https://www.googleapis.com/auth/trace.append",
   ]
 
   dashboard_disabled = true

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -16,6 +16,8 @@ ingress:
 
 datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
+enableStackdriverTrace: true
+
 resources:
   requests:
     cpu: ${requests_cpu}

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -16,6 +16,8 @@ ingress:
 
 datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
+enableStackdriverTrace: true
+
 resources:
   requests:
     cpu: ${requests_cpu}

--- a/shared/charts/gpii-flowmanager/README.md
+++ b/shared/charts/gpii-flowmanager/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `datasource_hostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
 `node_env` | flowmanager node env | `gpii.config.cloudBased.flowManager.production`
 `preferences_url` | preferences service url | `http://preferences.gpii.svc.cluster.local/preferences/%gpiiKey?merge=%merge`
+`enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
 `dnsNames` | list of host names for nginx-ingress controller | `flowmanager.test.local`

--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -31,5 +31,9 @@ spec:
           value: '{{ .Values.datasource_listen_port }}'
         - name: GPII_FLOWMANAGER_TO_PREFERENCESSERVER_URL
           value: {{ .Values.preferences_url }}
+        {{- if .Values.enableStackdriverTrace }}
+        - name: GPII_ENABLE_STACKDRIVER_TRACE
+          value: 'true'
+        {{- end}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/shared/charts/gpii-flowmanager/values.yaml
+++ b/shared/charts/gpii-flowmanager/values.yaml
@@ -11,6 +11,7 @@ datasource_hostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster
 
 node_env: gpii.config.cloudBased.flowManager.production
 preferences_url: http://preferences.gpii.svc.cluster.local/preferences/%gpiiKey?merge=%merge
+enableStackdriverTrace: false
 
 image:
   repository: gpii/universal

--- a/shared/charts/gpii-preferences/README.md
+++ b/shared/charts/gpii-preferences/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `datasource_listen_port` | data source port for preferences service | `5984`
 `datasource_hostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
 `node_env` | preferences node env | `gpii.config.preferencesServer.standalone.production`
+`enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
 `dnsNames` | list of host names for nginx-ingress controller | `preferences.test.local`

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -30,5 +30,9 @@ spec:
           value:  '{{ .Values.datasource_hostname }}'
         - name: GPII_DATASOURCE_PORT
           value: '{{ .Values.datasource_listen_port }}'
+        {{- if .Values.enableStackdriverTrace }}
+        - name: GPII_ENABLE_STACKDRIVER_TRACE
+          value: 'true'
+        {{- end}}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/shared/charts/gpii-preferences/values.yaml
+++ b/shared/charts/gpii-preferences/values.yaml
@@ -10,6 +10,7 @@ datasource_listen_port: 5984
 datasource_hostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 node_env: gpii.config.preferencesServer.standalone.production
+enableStackdriverTrace: false
 
 image:
   repository: gpii/universal


### PR DESCRIPTION
Does nothing until https://github.com/GPII/universal/pull/703 is merged.

Tested in my dev environment with GPII_ENABLE_STACKDRIVER_TRACE both enabled and disabled.

Also (unrelatedly) adds a Terragrunt module dependency I missed earlier.
