### PR TITLE
GPII-3492: Allow us to (optionally) prevent destruction of the cluster. (gpii-infra)

### DIFF
--- a/gcp/live/prd/k8s/cluster/terraform.tfvars
+++ b/gcp/live/prd/k8s/cluster/terraform.tfvars
@@ -20,3 +20,14 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 node_type = "n1-highcpu-4"
+# This is to prevent accidental deletion of a long-lived cluster (e.g. due to
+# changing a parameter like 'oauth_scopes').
+#
+# If you are sure you want to destroy a cluster, do not change this variable![1]
+# Instead, see instructions in the 'cluster_protector' resource in
+# gcp/modules/gke-cluster/main.tf.
+#
+# [1] You can change this variable if you want, but it won't take effect until
+# you change 'cluster_protector'. I recommend leaving this variable alone when
+# temporarily allowing a cluster to be destroyed.
+prevent_destroy_cluster = true

--- a/gcp/live/stg/k8s/cluster/terraform.tfvars
+++ b/gcp/live/stg/k8s/cluster/terraform.tfvars
@@ -20,3 +20,14 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 node_type = "n1-highcpu-4"
+# This is to prevent accidental deletion of a long-lived cluster (e.g. due to
+# changing a parameter like 'oauth_scopes').
+#
+# If you are sure you want to destroy a cluster, do not change this variable![1]
+# Instead, see instructions in the 'cluster_protector' resource in
+# gcp/modules/gke-cluster/main.tf.
+#
+# [1] You can change this variable if you want, but it won't take effect until
+# you change 'cluster_protector'. I recommend leaving this variable alone when
+# temporarily allowing a cluster to be destroyed.
+prevent_destroy_cluster = true

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -8,6 +8,10 @@ variable "serviceaccount_key" {}
 # Terragrunt variables
 variable "node_type" {}
 
+variable "prevent_destroy_cluster" {
+  default = false
+}
+
 module "gke_cluster" {
   source             = "/exekube-modules/gke-cluster"
   project_id         = "${var.project_id}"
@@ -40,4 +44,27 @@ module "gke_cluster" {
   issue_client_certificate = false
 
   update_timeout = "30m"
+}
+
+# Workaround from
+# https://github.com/hashicorp/terraform/issues/3116#issuecomment-292038781
+# to allow us to optionally enable 'lifecycle { prevent_destroy = true }'.
+resource "random_id" "cluster_protector" {
+  count       = "${var.prevent_destroy_cluster ? 1 : 0}"
+  byte_length = 8
+
+  keepers = {
+    protected_resources = "${module.gke_cluster.stub_output_for_dependency}"
+  }
+
+  lifecycle {
+    # If you are sure you want to destroy a cluster (e.g. to re-create it from
+    # scratch or to change a parameter like 'oauth_scopes' that requires
+    # cluster re-creation):
+    #
+    # * Change the value below to 'false'
+    # * Destroy the cluster
+    # * Change the value below back to 'true'
+    prevent_destroy = true
+  }
 }


### PR DESCRIPTION
Requires https://github.com/gpii-ops/exekube/pull/23.

As punishment for my hubris in saying this feature would be simple to add, Terraform does not support variable interpolation in `lifecycle{}` blocks :(. https://github.com/hashicorp/terraform/issues/3116

Fortunately, @zero-below posted a workaround (thanks, friend!). The workaround is a little weird but with it I was able to protect a cluster, un-protect it, re-create it, and re-protect it.