### PR TITLE
GPII-3492: Temporary overrides to add prevent_destroy to GKE cluster.

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -32,7 +32,10 @@ module "gke_cluster" {
     "https://www.googleapis.com/auth/devstorage.read_only",
     "https://www.googleapis.com/auth/logging.write",
     "https://www.googleapis.com/auth/monitoring",
-    "https://www.googleapis.com/auth/trace.append",
+    # Temporarily disable this oauth_scopes change so that we can add
+    # 'prevent_destroy' to running GKE cluster in prd without forcing cluster
+    # deletion.
+    ###"https://www.googleapis.com/auth/trace.append",
   ]
 
   dashboard_disabled = true


### PR DESCRIPTION
EDIT: THIS PR SHOULD NOT BE MERGED! I am posting it to record the plan.

This is an alternative to Plan B: wait for Sergey's CouchDB Volume persistence fixes to be ready, then update gcp-prd all at once. We will use Plan B unless we (really Sergey, given the hour) agrees that this alternative is preferable.

What this does: remove the change to `oauth_scopes` that will cause the prd GKE cluster to be destroyed and re-created, while leaving in the change that turns on `prevent_destroy` for the prd GKE cluster.

I simulated the gcp-prd situation using my dev environment. I verified with `rake sh ; cd /project/live/stg/k8s/cluster ; terragrunt plan` that these changes will not destroy and re-create the GKE cluster.

Deployment plan:
- [ ] Verify no CI activity in gcp-prd
- [ ] Verify local working directory has this branch and no other unexpected modifications
- [ ] `cd gcp/live/prd`
- [ ] `RAKE_REALLY_RUN_IN_PRD=1 rake deploy_module"[k8s/cluster]"`