### PR TITLE
GPII-3354 Add Service Account Key Admin to allow the destroy of unused keys

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -76,6 +76,14 @@ data "google_iam_policy" "admin" {
   }
 
   binding {
+    role = "roles/iam.serviceAccountKeyAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.project.email}",
+    ]
+  }
+
+  binding {
     role = "roles/iam.serviceAccountUser"
 
     members = [


### PR DESCRIPTION
Patch for #190 