### PR TITLE
[GPII-3494]: Check for cluster membership instead of pod status in finish_cluster

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -60,14 +60,15 @@ resource "null_resource" "couchdb_finish_cluster" {
 
   provisioner "local-exec" {
     command = <<EOF
-      RETRIES=10
+      RETRIES=15
       RETRY_COUNT=1
-      while [ "$PODS_READY" != "true" ]; do
-        PODS_READY="true"
-        echo "[Try $RETRY_COUNT of $RETRIES] Waiting for all CouchDB pods to become Running..."
-        for STATUS in $(kubectl get pods --namespace ${var.release_namespace} -l app=couchdb -o jsonpath='{.items[*].status.phase}'); do
-          if [ "$STATUS" != "Running" ]; then
-            PODS_READY="false"
+      while [ "$CLUSTER_READY" != "true" ]; do
+        CLUSTER_READY="true"
+        echo "[Try $RETRY_COUNT of $RETRIES] Waiting for all CouchDB pods to join the cluster..."
+        for CLUSTER_MEMBERS in $(kubectl exec --namespace gpii couchdb-couchdb-0 -c couchdb -- curl -s http://${var.secret_couchdb_admin_username}:${var.secret_couchdb_admin_password}@127.0.0.1:5984/_membership 2>/dev/null | jq -r .cluster_nodes[] | grep -c .); do
+          echo "$CLUSTER_MEMBERS of ${var.replica_count}" pods have joined the cluster.
+          if [ "$CLUSTER_MEMBERS" != "${var.replica_count}" ]; then
+            CLUSTER_READY="false"
           fi
         done
         RETRY_COUNT=$(($RETRY_COUNT+1))
@@ -75,7 +76,7 @@ resource "null_resource" "couchdb_finish_cluster" {
           echo "Retry limit reached, giving up!"
           exit 1
         fi
-        if [ "$PODS_READY" == "false" ]; then
+        if [ "$CLUSTER_READY" == "false" ]; then
           sleep 10
         fi
       done
@@ -86,7 +87,7 @@ resource "null_resource" "couchdb_finish_cluster" {
           kubectl exec --namespace ${var.release_namespace} couchdb-couchdb-0 -c couchdb -- \
           curl -s http://${var.secret_couchdb_admin_username}:${var.secret_couchdb_admin_password}@127.0.0.1:5984/_cluster_setup \
           -X POST -H 'Content-Type: application/json' -d '{"action": "finish_cluster"}')
-        echo "[Try $RETRY_COUNT of $RETRIES] CouchDB returned: $RESULT"
+        echo "[Try $RETRY_COUNT of $RETRIES] Posting \"finish_cluster\", CouchDB returned: $RESULT"
         STATUS=$(echo $RESULT | jq ".reason")
         RETRY_COUNT=$(($RETRY_COUNT+1))
         if [ "$RETRY_COUNT" -eq "$RETRIES" ]; then

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -71,7 +71,7 @@ resource "null_resource" "couchdb_finish_cluster" {
           CLUSTER_READY="false"
         fi
         RETRY_COUNT=$(($RETRY_COUNT+1))
-        if [ "$RETRY_COUNT" -eq "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
@@ -89,7 +89,7 @@ resource "null_resource" "couchdb_finish_cluster" {
         echo "[Try $RETRY_COUNT of $RETRIES] Posting \"finish_cluster\", CouchDB returned: $RESULT"
         STATUS=$(echo $RESULT | jq ".reason")
         RETRY_COUNT=$(($RETRY_COUNT+1))
-        if [ "$RETRY_COUNT" -eq "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi


### PR DESCRIPTION
This should prevent us from having split-brain scenarios caused by untimely executed `finish_cluster` action.