### PR TITLE
[GPII-3498]: Destroy Locust TF state before test

### DIFF
--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -34,7 +34,7 @@ resource "null_resource" "locust_swarm_session" {
         fi
         echo "Number of ready workers: $WORKERS_READY out of ${var.locust_workers}!"
         RETRY_COUNT=$(($RETRY_COUNT+1))
-        if [ "$RETRY_COUNT" -eq "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
@@ -102,7 +102,7 @@ resource "null_resource" "locust_swarm_session" {
         fi
 
         RETRY_COUNT=$(($RETRY_COUNT+1))
-        if [ "$RETRY_COUNT" -eq "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           EXIT_STATUS=1
         fi

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -2,6 +2,16 @@ task :set_test_protocol do
   @protocol = (@env == "dev" ? "http" : "https")
 end
 
+task :test do
+  sh "#{@exekube_cmd} rake xk['down live/#{@env}/locust',skip_secret_mgmt] || true"
+  Rake::Task[:destroy_tfstate].invoke('locust')
+
+  puts "Waiting for K8s to fully terminate Locust resources..."
+  sleep 45
+
+  sh "#{@exekube_cmd} rake xk['up live/#{@env}/locust',skip_secret_mgmt]"
+end
+
 desc '[TEST] Run Locust swarm against Preferences service in current cluster'
 task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol,] do
   ENV['TF_VAR_locust_target_host'] = "#{@protocol}://preferences.#{ENV['TF_VAR_domain_name']}"
@@ -9,13 +19,10 @@ task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol
   ENV['TF_VAR_locust_script'] = "preferences.py"
   ENV['TF_VAR_locust_desired_median_response_time'] = "300"
   ENV['TF_VAR_locust_desired_max_response_time'] = "2000"
+
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
-  sh "#{@exekube_cmd} rake xk[' \
-    xk down live/#{@env}/locust && \
-    echo \"Waiting for K8s to fully terminate Locust resources...\" && \
-    sleep 45 && \
-    xk up live/#{@env}/locust',skip_secret_mgmt]"
+  Rake::Task[:test].invoke
 end
 
 desc '[TEST] Run Locust swarm against Flowmanager service in current cluster'
@@ -27,13 +34,10 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed, :set_test_protocol
   ENV['TF_VAR_locust_desired_total_rps'] = "5"
   ENV['TF_VAR_locust_desired_median_response_time'] = "500"
   ENV['TF_VAR_locust_desired_max_response_time'] = "3000"
+
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
-  sh "#{@exekube_cmd} rake xk[' \
-    xk down live/#{@env}/locust && \
-    echo \"Waiting for K8s to fully terminate Locust resources...\" && \
-    sleep 45 && \
-    xk up live/#{@env}/locust',skip_secret_mgmt]"
+  Rake::Task[:test].invoke
 end
 
 # vim: et ts=2 sw=2:


### PR DESCRIPTION
This prevents `CustomerEncryptionKeyIsIncorrect` errors in situations such as described in the ticket. 