### PR TITLE
GPII-3354 - Set proper common permissions at organization level

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -123,7 +123,6 @@ data "google_iam_policy" "admin" {
       "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
     ]
   }
-
 }
 
 provider "google" {

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -123,6 +123,14 @@ data "google_iam_policy" "admin" {
       "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
     ]
   }
+
+  binding {
+    role = "roles/resourcemanager.projectIamAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.project.email}",
+    ]
+  }
 }
 
 provider "google" {

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -123,14 +123,6 @@ data "google_iam_policy" "admin" {
       "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
     ]
   }
-
-  binding {
-    role = "roles/resourcemanager.projectIamAdmin"
-
-    members = [
-      "serviceAccount:${google_service_account.project.email}",
-    ]
-  }
 }
 
 provider "google" {

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -112,7 +112,6 @@ data "google_iam_policy" "admin" {
 
     members = [
       "serviceAccount:${google_service_account.project.email}",
-      "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
     ]
   }
 
@@ -125,13 +124,6 @@ data "google_iam_policy" "admin" {
     ]
   }
 
-  binding {
-    role = "roles/resourcemanager.projectIamAdmin"
-
-    members = [
-      "serviceAccount:projectowner@${var.project_id}.iam.gserviceaccount.com",
-    ]
-  }
 }
 
 provider "google" {

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -92,6 +92,7 @@ task :apply_common_infra => [@gcp_creds_file] do
                                "roles/billing.user",
                                "roles/iam.organizationRoleViewer",
                                "roles/iam.serviceAccountAdmin",
+                               "roles/iam.serviceAccountKeyAdmin",
                                "roles/resourcemanager.projectCreator",
                                "roles/resourcemanager.projectIamAdmin",
                                "roles/serviceusage.serviceUsageAdmin"]
@@ -119,6 +120,7 @@ task :fix_common_service_account_permissions => [@gcp_creds_file] do
    "roles/billing.user",
    "roles/iam.organizationRoleViewer",
    "roles/iam.serviceAccountAdmin",
+   "roles/iam.serviceAccountKeyAdmin",
    "roles/resourcemanager.projectCreator",
    "roles/resourcemanager.projectIamAdmin",
    "roles/serviceusage.serviceUsageAdmin"].each do |role|

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -1,3 +1,8 @@
+organizations_permissions = [
+  "roles/iam.organizationRoleViewer",
+  "roles/resourcemanager.projectCreator"
+]
+
 task :refresh_common_infra, [:project_type] => [@gcp_creds_file] do | taskname, args|
 
   next if args[:project_type] == "common"
@@ -88,14 +93,6 @@ task :apply_common_infra => [@gcp_creds_file] do
     #{@exekube_cmd} gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} --format=json
   }
   permissions_list = JSON.parse(permissions_list_json)["bindings"]
-  organizations_permissions = ["roles/billing.projectManager",
-                               "roles/billing.user",
-                               "roles/iam.organizationRoleViewer",
-                               "roles/iam.serviceAccountAdmin",
-                               "roles/iam.serviceAccountKeyAdmin",
-                               "roles/resourcemanager.projectCreator",
-                               "roles/resourcemanager.projectIamAdmin",
-                               "roles/serviceusage.serviceUsageAdmin"]
   service_account = "serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com"
   permissions_list.each do |permission|
     organizations_permissions.delete(permission["role"]) if organizations_permissions.include?(permission["role"]) and permission["members"].include?(service_account)
@@ -116,16 +113,18 @@ task :apply_common_infra => [@gcp_creds_file] do
 end
 
 task :fix_common_service_account_permissions => [@gcp_creds_file] do
-  ["roles/billing.projectManager",
-   "roles/billing.user",
-   "roles/iam.organizationRoleViewer",
-   "roles/iam.serviceAccountAdmin",
-   "roles/iam.serviceAccountKeyAdmin",
-   "roles/resourcemanager.projectCreator",
-   "roles/resourcemanager.projectIamAdmin",
-   "roles/serviceusage.serviceUsageAdmin"].each do |role|
+  organizations_permissions.each do |role|
     sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
       --member serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com --role #{role}"
   end
+
+  # The billing account is owned by the organization 247149361674
+  # (raisingthefloor.org), that means that the permissions are inherited from
+  # such organization. All the SA that need a billing permission must be in this
+  # organization IAM settings.
+  # Go to the https://console.cloud.google.com/billing/ to see the permissions
+  # granted to which SA for using billing services.
+  sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding 247149361674 \
+    --member serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com --role roles/billing.user"
 end
 

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -88,7 +88,13 @@ task :apply_common_infra => [@gcp_creds_file] do
     #{@exekube_cmd} gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} --format=json
   }
   permissions_list = JSON.parse(permissions_list_json)["bindings"]
-  organizations_permissions = ["roles/resourcemanager.projectCreator", "roles/billing.user"]
+  organizations_permissions = ["roles/billing.projectManager",
+                               "roles/billing.user",
+                               "roles/iam.organizationRoleViewer",
+                               "roles/iam.serviceAccountAdmin",
+                               "roles/resourcemanager.projectCreator",
+                               "roles/resourcemanager.projectIamAdmin",
+                               "roles/serviceusage.serviceUsageAdmin"]
   service_account = "serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com"
   permissions_list.each do |permission|
     organizations_permissions.delete(permission["role"]) if organizations_permissions.include?(permission["role"]) and permission["members"].include?(service_account)
@@ -109,7 +115,13 @@ task :apply_common_infra => [@gcp_creds_file] do
 end
 
 task :fix_common_service_account_permissions => [@gcp_creds_file] do
-  ["roles/resourcemanager.projectCreator", "roles/billing.user"].each do |role|
+  ["roles/billing.projectManager",
+   "roles/billing.user",
+   "roles/iam.organizationRoleViewer",
+   "roles/iam.serviceAccountAdmin",
+   "roles/resourcemanager.projectCreator",
+   "roles/resourcemanager.projectIamAdmin",
+   "roles/serviceusage.serviceUsageAdmin"].each do |role|
     sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
       --member serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com --role #{role}"
   end

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -1,5 +1,6 @@
 organizations_permissions = [
   "roles/iam.organizationRoleViewer",
+  "roles/resourcemanager.projectIamAdmin",
   "roles/resourcemanager.projectCreator"
 ]
 


### PR DESCRIPTION
Patch for #190 
@stepanstipl and I discovered that the common SA of the testing organization had owner permissions inherited by an admin group, making all my old tests not valid. This PR sets the proper permissions of the common SA at the organization level an also at the project level.