### PR TITLE
GPII-3354 - Set proper common permissions at organization level

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -108,6 +108,14 @@ data "google_iam_policy" "admin" {
   }
 
   binding {
+    role = "roles/resourcemanager.projectIamAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.project.email}",
+    ]
+  }
+
+  binding {
     role = "roles/serviceusage.serviceUsageAdmin"
 
     members = [


### PR DESCRIPTION
Patch for #190 

Add the role `roles/resourcemanager.projectIamAdmin` to the Project SA needed for the TF resource `google_logging_project_sink`