### PR TITLE
GGPII-3421 - Align with upstream chart changes

### DIFF
--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.2.0
+version: 0.3.0
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "couchdb.fullname" . }}
   labels:
     app: {{ template "couchdb.name" . }}
-    chart: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -133,9 +133,7 @@ spec:
         name: database-storage
         labels:
           app: {{ template "couchdb.name" . }}
-          chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
       spec:
         accessModes:
         {{- range .Values.persistentVolume.accessModes }}


### PR DESCRIPTION
These are additional changes re. allowing CouchDB updates to align with upstream Chart and changes requested by the `helm/charts` maintainers on the PR against upstream.

I intend to merge this only after the upstream PR is merged - https://github.com/helm/charts/pull/8527