### PR TITLE
Disable destroy prevention for gke-cluster

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -65,6 +65,6 @@ resource "random_id" "cluster_protector" {
     # * Change the value below to 'false'
     # * Destroy the cluster
     # * Change the value below back to 'true'
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }


### PR DESCRIPTION
This is a part of the deployment plan for https://github.com/gpii-ops/gpii-infra/pull/204.