### PR TITLE
Sync CouchDb chart from upstream

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -54,8 +54,7 @@ module "couchdb" {
   release_values          = ""
   release_values_rendered = "${data.template_file.couchdb_values.rendered}"
 
-  chart_name   = "${var.charts_dir}/couchdb"
-  force_update = true
+  chart_name = "${var.charts_dir}/couchdb"
 }
 
 resource "null_resource" "couchdb_finish_cluster" {

--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.3.0
+version: 1.0.0
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/README.md
+++ b/shared/charts/couchdb/README.md
@@ -67,6 +67,23 @@ $ helm delete my-release
 The command removes all the Kubernetes components associated with the chart and
 deletes the release.
 
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.2.3 -> v1.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### 1.0.0
+
+This version removes the `chart` and `heritage` labels from the
+`volumeClaimTemplates` which is immutable and prevents chart from being upgraded
+(see https://github.com/helm/charts/issues/7803 for details).
+
+In order to upgrade, delete the CouchDB StatefulSet before upgrading:
+
+```bash
+$ kubectl delete statefulsets --cascade=false my-release-couchdb
+```
+
 ## Configuration
 
 The following table lists the most commonly configured parameters of the

--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               command:
                 - sh
                 - -c
-                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/
 {{- else }}
             httpGet:
               path: /

--- a/shared/charts/couchdb/values.yaml
+++ b/shared/charts/couchdb/values.yaml
@@ -120,5 +120,6 @@ couchdbConfig:
   #   q: 8 # Create 8 shards for each database
   chttpd:
     bind_address: any
-    # Uncomment the following line to disable anonymous requests
-    # require_valid_user: true
+    # chttpd.require_valid_user disables all the anonymous requests to the port
+    # 5984 when is set to true.
+    require_valid_user: false


### PR DESCRIPTION
This brings in changes from upstream CouchDB chart:
- last bits related to my work on updatability - https://github.com/helm/charts/pull/8527  PR got finally merged
- 2 other cosmetic changes where upstram was different

It also disables `force_update` on the CouchDB chart - it should not be needed anymore as the chart can now be updated without errors.

