### PR TITLE
[GPII-2863]: Update log-based metrics, alert policies

### DIFF
--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls.json
@@ -1,0 +1,4 @@
+{
+  "name": "compute.firewalls",
+  "filter": "resource.type=\"gce_firewall_rule\" AND (jsonPayload.event_subtype=\"compute.firewalls.insert\" OR jsonPayload.event_subtype=\"compute.firewalls.patch\")"
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/disks_createsnapshot.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/disks_createsnapshot.json
@@ -1,0 +1,4 @@
+{
+  "name": "compute.disks.createSnapshot",
+  "filter": "resource.type=\"gce_disk\" AND protoPayload.methodName=\"v1.compute.disks.createSnapshot\""
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/pods_exec_create.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/pods_exec_create.json
@@ -1,0 +1,4 @@
+{
+  "name": "io.k8s.core.v1.pods.exec.create",
+  "filter": "resource.type=\"k8s_cluster\" AND protoPayload.methodName=\"io.k8s.core.v1.pods.exec.create\""
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "Firewalls Activity Check",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/compute.firewalls\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Log-based compute.firewalls activity check"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=jsonPayload.event_subtype%3D%22compute.firewalls.insert%22%20OR%20jsonPayload.event_subtype%3D%22compute.firewalls.patch%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "K8s-snapshots Check for CouchDB",
+  "display_name": "Snapshots Check for CouchDB",
   "combiner": "OR",
   "conditions": [
     {
@@ -25,7 +25,32 @@
           }
         ]
       },
-      "display_name": "Log based \"snapshot_created\" events for CouchDB"
+      "display_name": "Log-based snapshot_created k8s-snapshots events check for CouchDB"
+    },
+    {
+      "condition_absent": {
+        "filter": "metric.type=\"logging.googleapis.com/user/compute.disks.createSnapshot\" resource.type=\"gce_disk\"",
+        "duration": {
+          "seconds": 300,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ]
+      },
+      "display_name": "Log based compute.disks.createSnapshot events check"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
@@ -50,7 +50,7 @@
           }
         ]
       },
-      "display_name": "Log based compute.disks.createSnapshot events check"
+      "display_name": "Log-based compute.disks.createSnapshot events check"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
@@ -29,7 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log based errors for k8s-snapshots"
+      "display_name": "Log-based errors for k8s-snapshots"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
@@ -29,7 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log based io.k8s.core.v1.pods.exec.create activity check"
+      "display_name": "Log-based io.k8s.core.v1.pods.exec.create activity check"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "Pod Exec Check",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/io.k8s.core.v1.pods.exec.create\" resource.type=\"k8s_cluster\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 60,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Log based io.k8s.core.v1.pods.exec.create activity check"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22k8s_cluster%22%20AND%20protoPayload.methodName%3D%22io.k8s.core.v1.pods.exec.create%22%0A)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}


### PR DESCRIPTION
Changes included in this PR:
- New log-based metric and alert policy to monitor audit events for `kubectl exec` (which is the only way to get a shell into running container, because we do not allow ssh access to worker nodes).
- Changes to CouchDB module to perform cluster finalization using port forwarding instead of `kubectl exec` .
- Log-based metric and alert policy to monitor firewall patch / insert events, though I am not sure if this is necessary (mostly because now, if person has edit access to firewall rules, they can also edit alert policies).
- New log-based metric to count `compute.disks.createSnapshot` audit events, added condition on that metric to CouchDB snapshots check policy, to improve its reliability (track actual snapshot creation events and not just records from `k8s-snapshots` logs).