### PR TITLE
[GPII-3566]: Enable Stackdriver Slack notifications for stg, prd

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -155,6 +155,14 @@ Manual workspace configuration is required in case you never used Stackdriver in
 1. Click "Save Chart". Select existing one or new Dashboard. Click "Save".
 1. Your Stackdriver Dashboard should be now available in [Dashboard Manager](https://app.google.stackdriver.com/dashboards).
 
+### To receive notifications in Slack:
+1. Go to [Workspace Notification Settings - Slack](https://app.google.stackdriver.com/settings/accounts/notifications/slack/).
+1. Click "Add Slack Channel".
+1. Click "Authorize Stackdriver" – this will redirect to Slack's authentication page.
+1. Click "Authorize".
+1. Enter channel name including "#". Click "Test Connection" and then "Save".
+1. Now you can use new notification channel in `gcp-stackdriver-monitoring` module. Here is example json: `{"type":"slack","labels":{"channel_name":"#alerts"},"user_labels":{},"enabled":{"value":true},"immutable":{"value":true}}`.
+
 ## FAQ / Troubleshooting
 
 ### Errors trying to enable/disable Google Cloud APIs

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_slack.js
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_slack.js
@@ -1,0 +1,13 @@
+{
+  "type": "slack",
+  "labels": {
+    "channel_name": "#alerts"
+  },
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  },
+  "immutable": {
+    "value": true
+  }
+}

--- a/shared/rakefiles/stackdriver.rb
+++ b/shared/rakefiles/stackdriver.rb
@@ -45,6 +45,8 @@ end
 def get_notification_channel_identifier(notification_channel)
   if notification_channel["labels"]["email_address"]
     result = notification_channel["labels"]["email_address"]
+  elsif notification_channel["labels"]["channel_name"]
+    result = notification_channel["labels"]["channel_name"]
   end
 
   return result
@@ -131,14 +133,22 @@ def process_notification_channels(notification_channels = [])
 
     if stackdriver_notification_channels[notification_channel_identifier]
       notification_channel["name"] = stackdriver_notification_channels[notification_channel_identifier]["name"]
-      puts "Updating notification channel \"#{notification_channel_identifier}\"..."
-      notification_channel_service_client.update_notification_channel(notification_channel)
+      unless notification_channel["immutable"]
+        puts "Updating notification channel \"#{notification_channel_identifier}\"..."
+        notification_channel_service_client.update_notification_channel(notification_channel)
+      else
+        puts "Skipping update of notification channel \"#{notification_channel_identifier}\"..."
+      end
     else
-      puts "Creating notification channel \"#{notification_channel_identifier}\"..."
-      notification_channel = notification_channel_service_client.create_notification_channel(formatted_parent, notification_channel)
+      unless notification_channel["immutable"]
+        puts "Creating notification channel \"#{notification_channel_identifier}\"..."
+        notification_channel = notification_channel_service_client.create_notification_channel(formatted_parent, notification_channel)
+      else
+        puts "Skipping creation of notification channel \"#{notification_channel_identifier}\"..."
+      end
     end
 
-    processed_notification_channels[notification_channel_identifier] = notification_channel["name"]
+    processed_notification_channels[notification_channel_identifier] = notification_channel["name"] if notification_channel["name"]
   end
 
   stackdriver_notification_channels.each do |name, notification_channel|

--- a/shared/rakefiles/stackdriver.rb
+++ b/shared/rakefiles/stackdriver.rb
@@ -137,14 +137,14 @@ def process_notification_channels(notification_channels = [])
         puts "Updating notification channel \"#{notification_channel_identifier}\"..."
         notification_channel_service_client.update_notification_channel(notification_channel)
       else
-        puts "Skipping update of notification channel \"#{notification_channel_identifier}\"..."
+        puts "Skipping update of immutable notification channel \"#{notification_channel_identifier}\"..."
       end
     else
       unless notification_channel["immutable"]
         puts "Creating notification channel \"#{notification_channel_identifier}\"..."
         notification_channel = notification_channel_service_client.create_notification_channel(formatted_parent, notification_channel)
       else
-        puts "Skipping creation of notification channel \"#{notification_channel_identifier}\"..."
+        puts "Skipping creation of immutable notification channel \"#{notification_channel_identifier}\"..."
       end
     end
 


### PR DESCRIPTION
I authorized Stackdriver to send notifications to RTF Slack *#alerts* channel for `gpii-gcp-stg` and `gpii-gcp-prd` projects (see instructions in [updated README](https://github.com/natarajaya/gpii-infra/blob/5fa2511d3e639e970a354101d2c8f8cbda4cbf24/gcp/README.md#to-receive-notifications-in-slack)).
This adds Slack notification channel config and changes to Stackdriver Ruby client to work properly with Slack notification channels.