### PR TITLE
Use alerts-stg and alerts-prd Slack channels

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_prd_slack.js
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_prd_slack.js
@@ -1,7 +1,7 @@
 {
   "type": "slack",
   "labels": {
-    "channel_name": "#alerts"
+    "channel_name": "#alerts-prd"
   },
   "user_labels": {},
   "enabled": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_stg_slack.js
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_stg_slack.js
@@ -1,0 +1,13 @@
+{
+  "type": "slack",
+  "labels": {
+    "channel_name": "#alerts-stg"
+  },
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  },
+  "immutable": {
+    "value": true
+  }
+}


### PR DESCRIPTION
There is no need to set which channel to use by environment – since they are immutable, the one that exists in Stackdriver workspace will be picked up by alert policies and other ignored.

Things to to after this is deployed:
- [ ] Verify that previously configured Slack channel destroyed for stg and prd workspaces
- [ ] Verify that Slack notifications getting delivered properly into new channels