### PR TITLE
Upgrade GKE to 1.11 and regional clusters

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -66,6 +66,7 @@ resource "random_id" "cluster_protector" {
     # * Change the value below to 'false'
     # * Destroy the cluster
     # * Change the value below back to 'true'
+    # GPII-3568 - Disabled till all our clusters are regional, should be re-enabled afterwards
     prevent_destroy = false
   }
 }

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -66,6 +66,6 @@ resource "random_id" "cluster_protector" {
     # * Change the value below to 'false'
     # * Destroy the cluster
     # * Change the value below back to 'true'
-    prevent_destroy = true
+    prevent_destroy = false
   }
 }

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -19,10 +19,11 @@ module "gke_cluster" {
 
   initial_node_count = 1
   node_type          = "${var.node_type}"
-  kubernetes_version = "1.10.9-gke.5"
 
-  main_compute_zone = "us-central1-a"
-  additional_zones  = ["us-central1-b", "us-central1-c", "us-central1-f"]
+  kubernetes_version = "1.11.3-gke.18"
+
+  region           = "us-central1"
+  additional_zones = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
 
   monitoring_service = "monitoring.googleapis.com/kubernetes"
   logging_service    = "logging.googleapis.com/kubernetes"

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -19,8 +19,8 @@ task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr] => [:configure_serviceacco
 
   Secrets.set_secrets(@secrets)
 
-  # This is a temporary "hack", to be removed once all our clusters are
-  # migrated to the regional ones.
+  # GPII-3568 - This is a temporary "hack", to be removed once all our
+  # clusters are migrated to the regional ones.
   sh_filter "cd live/#{@env}/k8s/cluster; terragrunt state list | grep '\.cluster$' \
     && terragrunt state mv module.gke_cluster.google_container_cluster.cluster module.gke_cluster.google_container_cluster.cluster-regional; true"
 

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -19,6 +19,11 @@ task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr] => [:configure_serviceacco
 
   Secrets.set_secrets(@secrets)
 
+  # This is a temporary "hack", to be removed once all our clusters are
+  # migrated to the regional ones.
+  sh_filter "cd live/#{@env}/k8s/cluster; terragrunt state list | grep '\.cluster$' \
+    && terragrunt state mv module.gke_cluster.google_container_cluster.cluster module.gke_cluster.google_container_cluster.cluster-regional; true"
+
   sh_filter "#{@exekube_cmd} #{args[:cmd]}", !args[:preserve_stderr].nil? if args[:cmd]
 end
 


### PR DESCRIPTION
This PR upgrades GKE version to `1.11` and changes cluster type to `regional`. Depends on https://github.com/gpii-ops/exekube/pull/27.

**This will force cluster re-creation** as changing from zonal to regional cluster type requires it.

There are issues with cluster upgrade to `1.11` (see https://issues.gpii.net/browse/GPII-3568 for details), but these are effectively resolved by re-creating the cluster, therefore it makes sense to do these two changes together. *(TL;DR if you upgrade manually and your cluster is broken after  the upgrade, you'll see crashing `calico-node-*` pods and this can be resolved by deleting `globalbgpconfig` resources - `kubectl delete globalbgpconfig {asnumber,nodemeshenabled,loglevel} -n kube-system`).*

Due to way this was implemented in exekube (to preserve zonal cluster functionality and backward compatibility) additional terrafrom `state mv` is required (otherwise regional cluster creation starts before old zonal cluster is completely destroyed and this will lead to several issues). This piece of code should be removed once all our clusters are regional.