### PR TITLE
[GPII-3585]: Improve Stackdriver Ruby client to not update resources unnecessarily

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/cluster_resource_allocatable_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/cluster_resource_allocatable_utilization.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -31,7 +31,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Cluster CPU Allocatable Utilization"
     },
     {
@@ -44,7 +43,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -63,7 +62,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Cluster RAM Allocatable Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/cluster_resource_allocatable_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/cluster_resource_allocatable_utilization.json
@@ -8,10 +8,12 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.85,
         "duration": {
-          "seconds": 180
+          "seconds": 180,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -26,8 +28,10 @@
             ]
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Cluster CPU Allocatable Utilization"
     },
     {
@@ -36,10 +40,12 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.85,
         "duration": {
-          "seconds": 180
+          "seconds": 180,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -54,8 +60,10 @@
             ]
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Cluster RAM Allocatable Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_resource_limit_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_resource_limit_utilization.json
@@ -8,22 +8,28 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.85,
         "duration": {
-          "seconds": 180
+          "seconds": 180,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
             "alignment_period": {
-              "seconds": 60
+              "seconds": 60,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_MEAN",
+            "cross_series_reducer": "REDUCE_NONE",
             "group_by_fields": []
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Container CPU Limit Utilization"
     },
     {
@@ -32,22 +38,28 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.85,
         "duration": {
-          "seconds": 180
+          "seconds": 180,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
-               "aggregations": [
+        "aggregations": [
           {
             "alignment_period": {
-              "seconds": 60
+              "seconds": 60,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_MEAN",
+            "cross_series_reducer": "REDUCE_NONE",
             "group_by_fields": []
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Container RAM Limit Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_resource_limit_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_resource_limit_utilization.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Container CPU Limit Utilization"
     },
     {
@@ -42,7 +41,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -59,7 +58,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Container RAM Limit Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_restart_rate.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_restart_rate.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Container Restart Rate"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_restart_rate.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/container_restart_rate.json
@@ -7,21 +7,29 @@
         "filter": "metric.type=\"kubernetes.io/container/restart_count\" resource.type=\"k8s_container\"",
         "comparison": "COMPARISON_GT",
         "threshold_value": 1.5,
-        "duration": {},
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
             "alignment_period": {
-              "seconds": 60
+              "seconds": 60,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_DELTA",
+            "cross_series_reducer": "REDUCE_NONE",
             "group_by_fields": []
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Container Restart Rate"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
@@ -6,14 +6,14 @@
       "condition_threshold": {
         "filter": "metric.type=\"logging.googleapis.com/user/compute.firewalls\" resource.type=\"global\"",
         "comparison": "COMPARISON_GT",
-        "threshold_value": 0,
+        "threshold_value": 0.0,
         "duration": {
           "seconds": 0,
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
-          "percent": 0
+          "count": 0,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -29,6 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Log-based compute.firewalls activity check"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Log-based compute.firewalls activity check"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/flowmanager_uptime.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/flowmanager_uptime.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -31,7 +31,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Uptime Check on flowmanager.${domain_name}"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/flowmanager_uptime.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/flowmanager_uptime.json
@@ -6,17 +6,20 @@
       "condition_threshold": {
         "filter": "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.label.host=\"flowmanager.${domain_name}\" AND resource.type=\"uptime_url\"",
         "comparison": "COMPARISON_GT",
-        "threshold_value": 1,
+        "threshold_value": 1.0,
         "duration": {
-          "seconds": 300
+          "seconds": 300,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
             "alignment_period": {
-              "seconds": 1200
+              "seconds": 1200,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_NEXT_OLDER",
             "cross_series_reducer": "REDUCE_COUNT_FALSE",
@@ -25,8 +28,10 @@
             ]
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Uptime Check on flowmanager.${domain_name}"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
@@ -3,6 +3,7 @@
   "combiner": "OR",
   "conditions": [
     {
+      "condition_threshold": null,
       "condition_absent": {
         "filter": "metric.type=\"logging.googleapis.com/user/k8s_snapshots.couchdb.snapshot_created\" resource.type=\"k8s_container\"",
         "duration": {
@@ -10,8 +11,8 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
-          "percent": 0
+          "count": 0,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -28,6 +29,7 @@
       "display_name": "Log-based snapshot_created k8s-snapshots events check for CouchDB"
     },
     {
+      "condition_threshold": null,
       "condition_absent": {
         "filter": "metric.type=\"logging.googleapis.com/user/compute.disks.createSnapshot\" resource.type=\"gce_disk\"",
         "duration": {
@@ -35,8 +37,8 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
-          "percent": 0
+          "count": 0,
+          "percent": 0.0
         },
         "aggregations": [
           {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_couchdb.json
@@ -3,7 +3,6 @@
   "combiner": "OR",
   "conditions": [
     {
-      "condition_threshold": null,
       "condition_absent": {
         "filter": "metric.type=\"logging.googleapis.com/user/k8s_snapshots.couchdb.snapshot_created\" resource.type=\"k8s_container\"",
         "duration": {
@@ -29,7 +28,6 @@
       "display_name": "Log-based snapshot_created k8s-snapshots events check for CouchDB"
     },
     {
-      "condition_threshold": null,
       "condition_absent": {
         "filter": "metric.type=\"logging.googleapis.com/user/compute.disks.createSnapshot\" resource.type=\"gce_disk\"",
         "duration": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
@@ -6,14 +6,14 @@
       "condition_threshold": {
         "filter": "metric.type=\"logging.googleapis.com/user/k8s_snapshots.error\" resource.type=\"k8s_container\"",
         "comparison": "COMPARISON_GT",
-        "threshold_value": 1,
+        "threshold_value": 1.0,
         "duration": {
           "seconds": 300,
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
-          "percent": 0
+          "count": 0,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -29,6 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Log-based errors for k8s-snapshots"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Log-based errors for k8s-snapshots"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Log-based io.k8s.core.v1.pods.exec.create activity check"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_exec.json
@@ -6,14 +6,14 @@
       "condition_threshold": {
         "filter": "metric.type=\"logging.googleapis.com/user/io.k8s.core.v1.pods.exec.create\" resource.type=\"k8s_cluster\"",
         "comparison": "COMPARISON_GT",
-        "threshold_value": 0,
+        "threshold_value": 0.0,
         "duration": {
           "seconds": 0,
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
-          "percent": 0
+          "count": 0,
+          "percent": 0.0
         },
         "aggregations": [
           {
@@ -29,6 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Log-based io.k8s.core.v1.pods.exec.create activity check"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_volume_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_volume_utilization.json
@@ -8,22 +8,28 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.85,
         "duration": {
-          "seconds": 180
+          "seconds": 180,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
             "alignment_period": {
-              "seconds": 60
+              "seconds": 60,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_MEAN",
+            "cross_series_reducer": "REDUCE_NONE",
             "group_by_fields": []
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Pod Volume Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_volume_utilization.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/pod_volume_utilization.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -29,7 +29,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Pod Volume Utilization"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/preferences_uptime.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/preferences_uptime.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [
@@ -31,7 +31,6 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "condition_absent": null,
       "display_name": "Uptime Check on preferences.${domain_name}"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/preferences_uptime.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/preferences_uptime.json
@@ -2,21 +2,24 @@
   "display_name": "Uptime Check on Preferences",
   "combiner": "OR",
   "conditions": [
-    {
+   {
       "condition_threshold": {
         "filter": "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.label.host=\"preferences.${domain_name}\" AND resource.type=\"uptime_url\"",
         "comparison": "COMPARISON_GT",
-        "threshold_value": 1,
+        "threshold_value": 1.0,
         "duration": {
-          "seconds": 300
+          "seconds": 300,
+          "nanos": 0
         },
         "trigger": {
-          "count": 1
+          "count": 1,
+          "percent": 0.0
         },
         "aggregations": [
           {
             "alignment_period": {
-              "seconds": 1200
+              "seconds": 1200,
+              "nanos": 0
             },
             "per_series_aligner": "ALIGN_NEXT_OLDER",
             "cross_series_reducer": "REDUCE_COUNT_FALSE",
@@ -25,8 +28,10 @@
             ]
           }
         ],
+        "denominator_filter": "",
         "denominator_aggregations": []
       },
+      "condition_absent": null,
       "display_name": "Uptime Check on preferences.${domain_name}"
     }
   ],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_at_raisingthefloor_org.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/alerts_at_raisingthefloor_org.json
@@ -1,9 +1,12 @@
 {
   "type": "email",
+  "display_name": "",
+  "description": "",
   "labels": {
     "email_address": "alerts+${domain_name}@raisingthefloor.org"
   },
   "user_labels": {},
+  "verification_status": "VERIFICATION_STATUS_UNSPECIFIED",
   "enabled": {
     "value": true
   }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
@@ -7,8 +7,6 @@
       "project_id": "${project_id}"
     }
   },
-  "resource_group": null,
-  "http_check": null,
   "tcp_check": {
     "port": 80
   },

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
@@ -7,18 +7,25 @@
       "project_id": "${project_id}"
     }
   },
+  "resource_group": null,
+  "http_check": null,
   "tcp_check": {
     "port": 80
   },
   "period": {
-    "seconds": 60
+    "seconds": 60,
+    "nanos": 0
   },
   "timeout": {
-    "seconds": 10
+    "seconds": 10,
+    "nanos": 0
   },
   "content_matchers": [
-    {}
+    {
+      "content": ""
+    }
   ],
   "selected_regions": [],
-  "internal_checkers": []
+  "internal_checkers": [],
+  "is_internal": false
 }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
@@ -7,22 +7,33 @@
       "project_id": "${project_id}"
     }
   },
+  "resource_group": null,
   "http_check": {
-    "path": "/preferences/carla",
     "use_ssl": ${ssl_enabled_uptime_checks ? "true" : "false"},
+    "path": "/preferences/carla",
     "port": ${ssl_enabled_uptime_checks ? "443" : "80"},
-    "auth_info": {},
+    "auth_info": {
+      "username": "",
+      "password": ""
+    },
+    "mask_headers": false,
     "headers": {}
   },
+  "tcp_check": null,
   "period": {
-    "seconds": 60
+    "seconds": 60,
+    "nanos": 0
   },
   "timeout": {
-    "seconds": 10
+    "seconds": 10,
+    "nanos": 0
   },
   "content_matchers": [
-    {}
+    {
+      "content": ""
+    }
   ],
   "selected_regions": [],
-  "internal_checkers": []
+  "internal_checkers": [],
+  "is_internal": false
 }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
@@ -7,7 +7,6 @@
       "project_id": "${project_id}"
     }
   },
-  "resource_group": null,
   "http_check": {
     "use_ssl": ${ssl_enabled_uptime_checks ? "true" : "false"},
     "path": "/preferences/carla",
@@ -19,7 +18,6 @@
     "mask_headers": false,
     "headers": {}
   },
-  "tcp_check": null,
   "period": {
     "seconds": 60,
     "nanos": 0


### PR DESCRIPTION
This implements comparison functions for Stackdriver resources to prevent unnecessary updates.
Unfortunately this task turned to be not so simple, because `google-cloud-monitoring` gem does not accept its own json primitives without some attribute correction.
I also had to update all resources to reflect their actual state in Stackdriver.