### PR TITLE
GPII-3592: Fix zonal only get-credentials

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -72,8 +72,7 @@ An environment needs some resources created in the organization before the follo
 
    Once you have the shell on your browser execute the following lines to manage the Kubernetes cluster using the embedded *kubectl* command:
 
-   1. `gcloud config set compute/zone us-central1-a`
-   1. `gcloud container clusters get-credentials k8s-cluster`
+   1. `gcloud container clusters get-credentials k8s-cluster --zone us-central1`
    1. `kubectl -n gpii get pods`
 
    It's a Debian GNU/Linux so all the `apt` commands are also available.

--- a/shared/rakefiles/xk_config.rake
+++ b/shared/rakefiles/xk_config.rake
@@ -35,12 +35,10 @@ task :configure_kubectl => [@kubectl_creds_file]
 rule @kubectl_creds_file => [@gcp_creds_file] do
   # This duplicates information in terraform code, 'k8s-cluster'
   cluster_name = 'k8s-cluster'
-  # This duplicates information in terraform code, 'zone'. Could be a variable with some plumbing.
-  zone = 'us-central1-a'
   sh "
-    existing_cluster=$(gcloud container clusters list --filter #{cluster_name} --zone #{zone} --project #{ENV["TF_VAR_project_id"]})
-    if [ $? == 0 ] && [ \"$existing_cluster\" != \"\" ]; then \
-      gcloud container clusters get-credentials #{cluster_name} --zone #{zone} --project #{ENV["TF_VAR_project_id"]}
+    existing_cluster_zone=$(gcloud container clusters list --filter #{cluster_name} --project #{ENV["TF_VAR_project_id"]} --format json | jq -er '.[0].zone')
+    if [ $? == 0 ]; then \
+      gcloud container clusters get-credentials #{cluster_name} --zone ${existing_cluster_zone} --project #{ENV["TF_VAR_project_id"]}
     fi"
 end
 


### PR DESCRIPTION
Fixes issue with Tiller in our CI/CD, which is actually caused by zonal-only support for getting credential and hardcoded zone. 

Related to recent move to regional cluster this stopped working and will manifest mainly on CI, as CI does not keep docker volumes with credentials around (can be reproduced locally by running `rake clobber`).

This PR read the actual zone (gcp uses `zone` and `region` somewhat interchangeable in `get-credentials` command and output of `clusters list`, so this will work both for zonal and regional clusters).