### PR TITLE
GPII-3394: Chart variable cleanups

### DIFF
--- a/gcp/modules/couchdb-prometheus-exporter/values.yaml
+++ b/gcp/modules/couchdb-prometheus-exporter/values.yaml
@@ -1,5 +1,5 @@
 replicaCount: ${replica_count}
 
-couchdb_uri: http://couchdb-svc-couchdb.gpii.svc.cluster.local:5984
-couchdb_username: ${couchdb_admin_username}
-couchdb_password: ${couchdb_admin_password}
+couchdbUri: http://couchdb-svc-couchdb.gpii.svc.cluster.local:5984
+couchdbUsername: ${couchdb_admin_username}
+couchdbPassword: ${couchdb_admin_password}

--- a/gcp/modules/gpii-dataloader/values.yaml
+++ b/gcp/modules/gpii-dataloader/values.yaml
@@ -2,4 +2,4 @@ image:
   repository: ${dataloader_repository}
   checksum: ${dataloader_checksum}
 
-couchdb_url: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"
+couchdbUrl: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -14,7 +14,7 @@ dnsNames:
 ingress:
   disable_ssl_redirect: ${disable_ssl_redirect}
 
-datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
+datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 enableStackdriverTrace: true
 

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -14,7 +14,7 @@ dnsNames:
 ingress:
   disable_ssl_redirect: ${disable_ssl_redirect}
 
-datasource_hostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
+datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 enableStackdriverTrace: true
 

--- a/shared/charts/couchdb-prometheus-exporter/README.md
+++ b/shared/charts/couchdb-prometheus-exporter/README.md
@@ -47,11 +47,11 @@ The following table lists the configurable parameters of the gpii-preferences ch
 Parameter | Description | Default
 --- | --- | ---
 `replicaCount` | desired number of pods | `1`
-`exporter_listen_port` | port for exporter service to listen on | `9984`
-`couchdb_uri` | URI for couchdb | `http://couchdb-svc-couchdb.default.svc.cluster.local:5984`
-`couchdb_username` | username for couchdb uri | `admin`
-`couchdb_password` | password for couchdb uri | `password`
-`couchdb_databases` | list of specific databases to monitor | `_all_dbs`
+`exporterListenPort` | port for exporter service to listen on | `9984`
+`couchdbUri` | URI for couchdb | `http://couchdb-svc-couchdb.default.svc.cluster.local:5984`
+`couchdbUsername` | username for couchdb uri | `admin`
+`couchdbPassword` | password for couchdb uri | `password`
+`couchdbDatabases` | list of specific databases to monitor | `_all_dbs`
 `image.repository` | container image repository | `gesellix/couchdb-prometheus-exporter`
 `image.checksum` | container image checksum | `sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -21,16 +21,16 @@ spec:
         - -couchdb.password=$(COUCHDB_PASSWORD)
         - -databases=$(COUCHDB_DATABASES)
         ports:
-        - containerPort: {{ .Values.exporter_listen_port }}
+        - containerPort: {{ .Values.exporterListenPort }}
         env:
         - name: COUCHDB_URI
-          value: {{ .Values.couchdb_uri }}
+          value: {{ .Values.couchdbUri }}
         - name: COUCHDB_USERNAME
-          value: {{ .Values.couchdb_username }}
+          value: {{ .Values.couchdbUsername }}
         - name: COUCHDB_PASSWORD
-          value: {{ .Values.couchdb_password }}
+          value: {{ .Values.couchdbPassword }}
         - name: COUCHDB_DATABASES
-          value: {{ .Values.couchdb_databases }}
+          value: {{ .Values.couchdbDatabases }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: prometheus-to-sd
@@ -39,7 +39,7 @@ spec:
         command:
           - /monitor
           - --stackdriver-prefix=custom.googleapis.com
-          - --source=couchdb:http://localhost:{{ .Values.exporter_listen_port }}
+          - --source=couchdb:http://localhost:{{ .Values.exporterListenPort }}
           - --pod-id=$(POD_NAME)
           - --namespace-id=$(POD_NAMESPACE)
         env:

--- a/shared/charts/couchdb-prometheus-exporter/values.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/values.yaml
@@ -4,11 +4,11 @@
 
 replicaCount: 1
 
-exporter_listen_port: 9984
-couchdb_uri: http://couchdb-svc-couchdb.default.svc.cluster.local:5984
-couchdb_username: admin
-couchdb_password: password
-couchdb_databases: _all_dbs
+exporterListenPort: 9984
+couchdbUri: http://couchdb-svc-couchdb.default.svc.cluster.local:5984
+couchdbUsername: admin
+couchdbPassword: password
+couchdbDatabases: _all_dbs
 
 image:
   repository: gesellix/couchdb-prometheus-exporter

--- a/shared/charts/fluentd/templates/configmap.yaml
+++ b/shared/charts/fluentd/templates/configmap.yaml
@@ -10,4 +10,3 @@ metadata:
 data:
   fluent.conf: {{ if eq .Values.logtype "elasticsearch" }}{{ toYaml (printf "%s%s" .Values.fluentdCommonConfig .Values.elasticsearch.fluentdElasticsearchConfig) | indent 2 }}{{ end }}
   {{- if eq .Values.logtype "cloudwatch" }}{{ toYaml (printf "%s%s" .Values.fluentdCommonConfig .Values.cloudwatch.fluentdCloudwatchConfig) | indent 2 }}{{ end }}
-  

--- a/shared/charts/gpii-dataloader/README.md
+++ b/shared/charts/gpii-dataloader/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters of the gpii-dataloader cha
 
 Parameter | Description | Default
 --- | --- | ---
-`couchdb_url` | couchdb url for dataloader | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii`
+`couchdbUrl` | couchdb url for dataloader | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii`
 `image.repository` | container image repository | `gpii/universal`
 `image.checksum` | container image checksum | `sha256:fa3bbf3a8255be83552da35b84a1a005d5cb3a44627510171a5a5eb11b2aea89`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`

--- a/shared/charts/gpii-dataloader/templates/job.yaml
+++ b/shared/charts/gpii-dataloader/templates/job.yaml
@@ -15,5 +15,5 @@ spec:
         command: [ '/app/scripts/deleteAndLoadSnapsets.sh' ]
         env:
         - name: GPII_COUCHDB_URL
-          value: '{{ .Values.couchdb_url }}'
+          value: '{{ .Values.couchdbUrl }}'
       restartPolicy: OnFailure

--- a/shared/charts/gpii-dataloader/values.yaml
+++ b/shared/charts/gpii-dataloader/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-couchdb_url: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"
+couchdbUrl: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"
 
 image:
   repository: gpii/universal

--- a/shared/charts/gpii-flowmanager/README.md
+++ b/shared/charts/gpii-flowmanager/README.md
@@ -57,8 +57,6 @@ Parameter | Description | Default
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
 `dnsNames` | list of host names for nginx-ingress controller | `flowmanager.test.local`
-`secretKeyRef.name` | name of the secret with CouchDB connection details | `couchdb-secrets`
-`secretKeyRef.key` | key of the secret with CouchDB connection details | `datasource_hostname`
 `image.repository` | container image repository | `gpii/universal`
 `image.checksum` | container image checksum | `sha256:8547f22ae8e86d7b4b09e10d9ec87b1605b47dc37904171c84555a55462f161e`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`

--- a/shared/charts/gpii-flowmanager/README.md
+++ b/shared/charts/gpii-flowmanager/README.md
@@ -47,12 +47,12 @@ The following table lists the configurable parameters of the gpii-flowmanager ch
 Parameter | Description | Default
 --- | --- | ---
 `replicaCount` | desired number of controller pods | `1`
-`svc_listen_port` | ClusterIP service port | `80`
-`flowmanager_listen_port` | port for flowmanager service to listen on | `8081`
-`datasource_listen_port` | data source port for flowmanager service | `5984`
-`datasource_hostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
-`node_env` | flowmanager node env | `gpii.config.cloudBased.flowManager.production`
-`preferences_url` | preferences service url | `http://preferences.gpii.svc.cluster.local`
+`svcListenPort` | ClusterIP service port | `80`
+`flowmanagerListenPort` | port for flowmanager service to listen on | `8081`
+`datasourceListenPort` | data source port for flowmanager service | `5984`
+`datasourceHostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
+`nodeEnv` | flowmanager node env | `gpii.config.cloudBased.flowManager.production`
+`preferencesUrl` | preferences service url | `http://preferences.gpii.svc.cluster.local`
 `enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`

--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -19,18 +19,18 @@ spec:
         image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.flowmanager_listen_port }}
+        - containerPort: {{ .Values.flowmanagerListenPort }}
         env:
         - name: NODE_ENV
-          value: {{ .Values.node_env }}
+          value: {{ .Values.nodeEnv }}
         - name: GPII_FLOWMANAGER_LISTEN_PORT
-          value: '{{ .Values.flowmanager_listen_port }}'
+          value: '{{ .Values.flowmanagerListenPort }}'
         - name: GPII_DATASOURCE_HOSTNAME
-          value: '{{ .Values.datasource_hostname }}'
+          value: '{{ .Values.datasourceHostname }}'
         - name: GPII_DATASOURCE_PORT
-          value: '{{ .Values.datasource_listen_port }}'
+          value: '{{ .Values.datasourceListenPort }}'
         - name: GPII_FLOWMANAGER_TO_PREFERENCESSERVER_URL
-          value: {{ .Values.preferences_url }}
+          value: {{ .Values.preferencesUrl }}
         {{- if .Values.enableStackdriverTrace }}
         - name: GPII_ENABLE_STACKDRIVER_TRACE
           value: 'true'

--- a/shared/charts/gpii-flowmanager/templates/ingress.yaml
+++ b/shared/charts/gpii-flowmanager/templates/ingress.yaml
@@ -19,4 +19,4 @@ spec:
         - path: /
           backend:
             serviceName: {{ template "flowmanager.name" . }}
-            servicePort: {{ .Values.svc_listen_port }}
+            servicePort: {{ .Values.svcListenPort }}

--- a/shared/charts/gpii-flowmanager/templates/service.yaml
+++ b/shared/charts/gpii-flowmanager/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.svc_listen_port }}
-    targetPort: {{ .Values.flowmanager_listen_port }}
+    port: {{ .Values.svcListenPort }}
+    targetPort: {{ .Values.flowmanagerListenPort }}
   type: ClusterIP

--- a/shared/charts/gpii-flowmanager/values.yaml
+++ b/shared/charts/gpii-flowmanager/values.yaml
@@ -4,13 +4,13 @@
 
 replicaCount: 1
 
-svc_listen_port: 80
-flowmanager_listen_port: 8081
-datasource_listen_port: 5984
-datasource_hostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local"
+svcListenPort: 80
+flowmanagerListenPort: 8081
+datasourceListenPort: 5984
+datasourceHostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
-node_env: gpii.config.cloudBased.flowManager.production
-preferences_url: http://preferences.gpii.svc.cluster.local
+nodeEnv: gpii.config.cloudBased.flowManager.production
+preferencesUrl: http://preferences.gpii.svc.cluster.local
 enableStackdriverTrace: false
 
 image:

--- a/shared/charts/gpii-flowmanager/values.yaml
+++ b/shared/charts/gpii-flowmanager/values.yaml
@@ -29,10 +29,6 @@ issuerRef:
 dnsNames:
 - flowmanager.test.local
 
-secretKeyRef:
-  name: couchdb-secrets
-  key: datasource_hostname
-
 ingress:
   disable_ssl_redirect: false
 

--- a/shared/charts/gpii-preferences/README.md
+++ b/shared/charts/gpii-preferences/README.md
@@ -56,8 +56,6 @@ Parameter | Description | Default
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
 `dnsNames` | list of host names for nginx-ingress controller | `preferences.test.local`
-`secretKeyRef.name` | name of the secret with CouchDB connection details | `couchdb-secrets`
-`secretKeyRef.key` | key of the secret with CouchDB connection details | `datasource_hostname`
 `image.repository` | container image repository | `gpii/universal`
 `image.checksum` | container image checksum | `sha256:f279c6ab7fa1c19e5f358a6a3d87a970eaf8d615c8b6181851fa086b6229b3a1`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`

--- a/shared/charts/gpii-preferences/README.md
+++ b/shared/charts/gpii-preferences/README.md
@@ -47,11 +47,11 @@ The following table lists the configurable parameters of the gpii-preferences ch
 Parameter | Description | Default
 --- | --- | ---
 `replicaCount` | desired number of controller pods | `1`
-`svc_listen_port` | ClusterIP service port | `80`
-`preferences_listen_port` | port for preferences service to listen on | `8081`
-`datasource_listen_port` | data source port for preferences service | `5984`
-`datasource_hostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
-`node_env` | preferences node env | `gpii.config.preferencesServer.standalone.production`
+`svcListenPort` | ClusterIP service port | `80`
+`preferencesListenPort` | port for preferences service to listen on | `8081`
+`datasourceListenPort` | data source port for preferences service | `5984`
+`datasourceHostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
+`nodeEnv` | preferences node env | `gpii.config.preferencesServer.standalone.production`
 `enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
 `issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
 `issuerRef.kind` | kind of the cert-manager issuer | `Issuer`

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -20,16 +20,16 @@ spec:
         image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.preferences_listen_port }}
+        - containerPort: {{ .Values.preferencesListenPort }}
         env:
         - name: NODE_ENV
-          value: {{ .Values.node_env }}
+          value: {{ .Values.nodeEnv }}
         - name: GPII_PREFERENCESSERVER_LISTEN_PORT
-          value: '{{ .Values.preferences_listen_port }}'
+          value: '{{ .Values.preferencesListenPort }}'
         - name: GPII_DATASOURCE_HOSTNAME
-          value:  '{{ .Values.datasource_hostname }}'
+          value:  '{{ .Values.datasourceHostname }}'
         - name: GPII_DATASOURCE_PORT
-          value: '{{ .Values.datasource_listen_port }}'
+          value: '{{ .Values.datasourceListenPort }}'
         {{- if .Values.enableStackdriverTrace }}
         - name: GPII_ENABLE_STACKDRIVER_TRACE
           value: 'true'

--- a/shared/charts/gpii-preferences/templates/ingress.yaml
+++ b/shared/charts/gpii-preferences/templates/ingress.yaml
@@ -19,4 +19,4 @@ spec:
         - path: /
           backend:
             serviceName: {{ template "preferences.name" . }}
-            servicePort: {{ .Values.svc_listen_port }}
+            servicePort: {{ .Values.svcListenPort }}

--- a/shared/charts/gpii-preferences/templates/service.yaml
+++ b/shared/charts/gpii-preferences/templates/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.svc_listen_port }}
-    targetPort: {{ .Values.preferences_listen_port }}
+    port: {{ .Values.svcListenPort }}
+    targetPort: {{ .Values.preferencesListenPort }}
   type: ClusterIP

--- a/shared/charts/gpii-preferences/values.yaml
+++ b/shared/charts/gpii-preferences/values.yaml
@@ -4,12 +4,12 @@
 
 replicaCount: 1
 
-svc_listen_port: 80
-preferences_listen_port: 8081
-datasource_listen_port: 5984
-datasource_hostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local"
+svcListenPort: 80
+preferencesListenPort: 8081
+datasourceListenPort: 5984
+datasourceHostname: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
-node_env: gpii.config.preferencesServer.standalone.production
+nodeEnv: gpii.config.preferencesServer.standalone.production
 enableStackdriverTrace: false
 
 image:

--- a/shared/charts/gpii-preferences/values.yaml
+++ b/shared/charts/gpii-preferences/values.yaml
@@ -28,10 +28,6 @@ issuerRef:
 dnsNames:
 - preferences.test.local
 
-secretKeyRef:
-  name: couchdb-secrets
-  key: datasource_hostname
-
 ingress:
   disable_ssl_redirect: false
 


### PR DESCRIPTION
This removes an unused variable I discovered while working on GPII-3394 and a naming inconsistency Stepan noticed while reviewing my work on GPII-3394.

I used this atrocious one-liner plus manual tweaking to revert some false positives (also, BSD sed's '-i' flag was giving me trouble):

```
unset expr ; for var in $(git grep '`\S\+_' shared/ | grep -v '/_stats' | grep -v rotate_secrets | awk -F'`' '{print $2}') ; do camel_var=$(echo $var | ruby -pne 'gsub(/_(\w)/){$1.upcase}') ; expr="${expr} -e s/$var/$camel_var/g" ; done ; for file in $(find shared/ -type f) $(find . -name values.yaml) ; do sed $expr -i FFFUUU $file ; done ; find . -name '*FFFUUU' | xargs rm
```

I deployed my dev environment from scratch and it came up so hopefully that means I renamed everything correctly.