### PR TITLE
[GPII-3516]: Use auth user email for Stackdriver notifications

### DIFF
--- a/gcp/live/dev/k8s/stackdriver/monitoring/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/monitoring/terraform.tfvars
@@ -20,4 +20,7 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 ssl_enabled_uptime_checks = false
-notification_email = "alerts+dev@raisingthefloor.org"
+
+# This variable is empty, so it can be overridden by TF_VAR_auth_user_email in module,
+# because Terragrunt does not support interpolations here.
+notification_email = ""

--- a/gcp/live/dev/k8s/stackdriver/monitoring/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/monitoring/terraform.tfvars
@@ -20,3 +20,4 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 ssl_enabled_uptime_checks = false
+notification_email = "alerts+dev@raisingthefloor.org"

--- a/gcp/live/prd/k8s/stackdriver/monitoring/terraform.tfvars
+++ b/gcp/live/prd/k8s/stackdriver/monitoring/terraform.tfvars
@@ -20,3 +20,4 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 ssl_enabled_uptime_checks = true
+notification_email = "alerts+prd@raisingthefloor.org"

--- a/gcp/live/stg/k8s/stackdriver/monitoring/terraform.tfvars
+++ b/gcp/live/stg/k8s/stackdriver/monitoring/terraform.tfvars
@@ -20,3 +20,4 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 ssl_enabled_uptime_checks = true
+notification_email = "alerts+stg@raisingthefloor.org"

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -7,6 +7,7 @@ variable "project_id" {}
 variable "serviceaccount_key" {}
 
 # Enables debug mode when TF_VAR_stackdriver_debug is not empty
+
 variable "stackdriver_debug" {
   default = ""
 }

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -2,7 +2,6 @@ terraform {
   backend "gcs" {}
 }
 
-variable "env" {}
 variable "nonce" {}
 variable "domain_name" {}
 variable "project_id" {}
@@ -28,7 +27,7 @@ resource "template_dir" "resources" {
     project_id                = "${var.project_id}"
     domain_name               = "${var.domain_name}"
     ssl_enabled_uptime_checks = "${var.ssl_enabled_uptime_checks}"
-    notification_email        = "${var.env == "dev" ? var.auth_user_email : var.notification_email}"
+    notification_email        = "${var.notification_email != "" ? var.notification_email : var.auth_user_email}"
   }
 }
 

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -2,13 +2,16 @@ terraform {
   backend "gcs" {}
 }
 
+variable "env" {}
 variable "nonce" {}
 variable "domain_name" {}
 variable "project_id" {}
 variable "serviceaccount_key" {}
+variable "auth_user_email" {}
 
-# Terragrunt variable
+# Terragrunt variables
 variable "ssl_enabled_uptime_checks" {}
+variable "notification_email" {}
 
 # Enables debug mode when TF_VAR_stackdriver_debug is not empty
 variable "stackdriver_debug" {
@@ -23,6 +26,7 @@ resource "template_dir" "resources" {
     project_id                = "${var.project_id}"
     domain_name               = "${var.domain_name}"
     ssl_enabled_uptime_checks = "${var.ssl_enabled_uptime_checks}"
+    notification_email        = "${var.env == "dev" ? var.auth_user_email : var.notification_email}"
   }
 }
 

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -10,10 +10,12 @@ variable "serviceaccount_key" {}
 variable "auth_user_email" {}
 
 # Terragrunt variables
-variable "ssl_enabled_uptime_checks" {}
+
 variable "notification_email" {}
+variable "ssl_enabled_uptime_checks" {}
 
 # Enables debug mode when TF_VAR_stackdriver_debug is not empty
+
 variable "stackdriver_debug" {
   default = ""
 }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/email.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/notification_channels/email.json
@@ -3,7 +3,7 @@
   "display_name": "",
   "description": "",
   "labels": {
-    "email_address": "alerts+${domain_name}@raisingthefloor.org"
+    "email_address": "${notification_email}"
   },
   "user_labels": {},
   "verification_status": "VERIFICATION_STATUS_UNSPECIFIED",


### PR DESCRIPTION
This switches Stackdriver's email notification channel to use auth user email for dev clusters.
Unfortunately Terragrunt interpolations [are not supported](https://github.com/gruntwork-io/terragrunt#interpolation-syntax) in module configuration block, so I had to add condition on `env` directly into `gcp-stackdriver-monitoring` module.

I also used `alerts+ENV@raisingthefloor.org` instead of `alerts+DOMAIN_NAME@raisingthefloor.org` to set notification email for all environments on Terragrunt level.