### PR TITLE
[GPII-3516]: Update k8s_snapshots_errors policy

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/k8s_snapshots_errors.json
@@ -8,7 +8,7 @@
         "comparison": "COMPARISON_GT",
         "threshold_value": 1.0,
         "duration": {
-          "seconds": 300,
+          "seconds": 900,
           "nanos": 0
         },
         "trigger": {


### PR DESCRIPTION
It takes about half of the alignment period for the policy to cool down.  
So, increasing duration threshold to 10 minutes would've been enough, but I decided to add another 5 mins on top of that.
This is the simplest way I can think of to make the policy skip intermittent errors, but still fire in case errors keep appearing in logs.
