### PR TITLE
GPII-3609: Add missing Google services IAMs

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -139,6 +139,32 @@ data "google_iam_policy" "admin" {
       "${var.project_owner}",
     ]
   }
+
+  binding {
+    role = "roles/compute.serviceAgent"
+
+    members = [
+      "serviceAccount:service-${google_project.project.number}@compute-system.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/container.serviceAgent"
+
+    members = [
+      "serviceAccount:service-${google_project.project.number}@container-engine-robot.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/editor"
+
+    members = [
+      "serviceAccount:${google_project.project.number}-compute@developer.gserviceaccount.com",
+      "serviceAccount:${google_project.project.number}@cloudservices.gserviceaccount.com",
+      "serviceAccount:service-${google_project.project.number}@containerregistry.iam.gserviceaccount.com",
+    ]
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
This PR adds missing IAM roles for Google services. These are required for GKE to work properly.

For more details how did this happen see https://issues.gpii.net/browse/GPII-3609.
