### PR TITLE
Revert "Bundler is now part of exekube image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           command: |
             echo "Running GCP unit tests...";
             cd /workspace/shared/rakefiles/tests;
+            gem install bundler --no-ri --no-rdoc;
             bundle install --path "vendor/bundle";
             rake
 


### PR DESCRIPTION
This reverts commit 7ef0ee2d6181706fba297f8838291f0a7a54bed1.

The reason why bundler became (as a side effect) part of exekube image is not needed anymore, see: gpii-ops/exekube/pull/33.

Should be merged right after the gpii-ops/exekube/pull/33