### PR TITLE
[GPII-3611]: Update uptime check resources to reflect their actual state in Stackdriver

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/flowmanager.json
@@ -18,11 +18,7 @@
     "seconds": 10,
     "nanos": 0
   },
-  "content_matchers": [
-    {
-      "content": ""
-    }
-  ],
+  "content_matchers": [],
   "selected_regions": [],
   "internal_checkers": [],
   "is_internal": false

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/uptime_checks/preferences.json
@@ -11,10 +11,7 @@
     "use_ssl": ${ssl_enabled_uptime_checks ? "true" : "false"},
     "path": "/preferences/carla",
     "port": ${ssl_enabled_uptime_checks ? "443" : "80"},
-    "auth_info": {
-      "username": "",
-      "password": ""
-    },
+    "auth_info": null,
     "mask_headers": false,
     "headers": {}
   },
@@ -26,11 +23,7 @@
     "seconds": 10,
     "nanos": 0
   },
-  "content_matchers": [
-    {
-      "content": ""
-    }
-  ],
+  "content_matchers": [],
   "selected_regions": [],
   "internal_checkers": [],
   "is_internal": false


### PR DESCRIPTION
The issue caused by Google changing data model for Stackdriver uptime checks primitive.
We have pinned down version of `google-cloud-monitoring` gem, but it did not help.

There is no guarantee that updated data model will be stable, because Stackdriver is in Beta and under active development. But, since we all agreed to not invest more time in current Stackdriver client implementation, I don't have a better solution at the moment.