### PR TITLE
GPII-3394 Alert if couchdb metrics aren't making it to Stackdriver.

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -140,7 +140,7 @@ An environment needs some resources created in the organization before the follo
 
 We use [Stackdriver Beta Monitoring](https://cloud.google.com/monitoring/kubernetes-engine/) to collect various system metrics, navigate through them with [Kubernetes Dashboard](https://app.google.stackdriver.com/kubernetes), and send alerts when they violate thresholds that are being set by [Stackdriver Alerting Policies](https://app.google.stackdriver.com/policies).
 
-Due to the lack of Terraform integration we use [Ruby client](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-alerting/client.rb) to apply / update / destroy Stackdriver's resource primitives from their [json configs](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-alerting/resources).
+Due to the lack of Terraform integration we use [Ruby client](https://github.com/gpii-ops/gpii-infra/blob/master/shared/rakefiles/stackdriver.rb) to apply / update / destroy Stackdriver's resource primitives from their [json configs](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-monitoring/resources).
 
 ### One-time Stackdriver Workspace setup
 
@@ -160,11 +160,12 @@ Manual workspace configuration is required in case you never used Stackdriver in
    * [Notification channels](https://app.google.stackdriver.com/settings/accounts/notifications/email) (only email notification channel type is currently supported, all notification channels are being applied to every alert policy).
    * [Uptime checks](https://app.google.stackdriver.com/uptime).
    * [Alert policies](https://app.google.stackdriver.com/policies).
-1. Run `TF_VAR_stackdriver_debug=1 rake deploy_module['k8s/stackdriver/alerting']`.
+1. Run `TF_VAR_stackdriver_debug=1 rake deploy_module['k8s/stackdriver/monitoring']`.
 1. You will find json blobs for all supported Stackdriver resources in the output.
-1. To add new resource config into `gcp-stackdriver-alerting` module:
-   * Copy json blob that you obtained on previous step into proper [resource directory](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-alerting/resources). Give a meaningful name to a new resource file. You can use `jq` to help with formatting.
-   * Remove all `name` attributes.
+1. To add new resource config into `gcp-stackdriver-monitoring` module:
+   * Copy json blob that you obtained on previous step into proper [resource directory](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/modules/gcp-stackdriver-monitoring/resources). Give a meaningful name to a new resource file. You can use `jq` to help with formatting.
+   * Remove all `name`, `creation_record`, and `mutation_record` attributes.
+   * Set `notification_channels` to `[]` (this value will be populated dynamically later).
    * Repeat from **step 2.** All newly configured resources will be synced with Stackriver.
 1. In case you added new email notification channel, you may want to authorize new sender to post to [Alerts Group](https://groups.google.com/a/raisingthefloor.org/forum/#!pendingmsg/alerts). Follow the link, select new message and click "Post and always allow future messages from author(s)" button.
 

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
@@ -1,0 +1,43 @@
+{
+  "display_name": "couchdb_prometheus_exporter exports a metric",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_absent": {
+        "filter": "metric.type=\"custom.googleapis.com/couchdb/httpd_node_up\" resource.type=\"gke_container\"",
+        "duration": {
+          "seconds": 300,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 60,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_MEAN",
+            "cross_series_reducer": "REDUCE_SUM",
+            "group_by_fields": [
+
+            ]
+          }
+        ]
+      },
+      "display_name": "custom/couchdb/httpd_node_up"
+    }
+  ],
+  "documentation": {
+    "content": "This test verifies that metrics from couchdb are being exported by couchdb-prometheus-exporter and ingested by Stackdriver.\n\nIf this test fails in isolation, check the logs for couchdb-prometheus-exporter. (If couchdb itself is down, other tests are probably failing!)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {
+  },
+  "enabled": {
+    "value": true
+  }
+}

--- a/shared/rakefiles/stackdriver.rb
+++ b/shared/rakefiles/stackdriver.rb
@@ -80,7 +80,15 @@ def compare_alert_policies(stackdriver_alert_policy, alert_policy)
     condition.delete("condition_threshold") if condition["condition_threshold"] == nil
   end
 
-  return stackdriver_alert_policy != alert_policy
+  policy_changed = (stackdriver_alert_policy != alert_policy)
+  if @debug_mode and policy_changed
+    puts "[DEBUG] alert policy has changed. Old:"
+    puts debug_output(alert_policy)
+    puts "New:"
+    puts debug_output(stackdriver_alert_policy)
+  end
+
+  return policy_changed
 end
 
 def compare_uptime_checks(stackdriver_uptime_check, uptime_check)
@@ -89,7 +97,15 @@ def compare_uptime_checks(stackdriver_uptime_check, uptime_check)
     stackdriver_uptime_check.delete(attribute) if value == nil or attribute == "name"
   end
 
-  return stackdriver_uptime_check != uptime_check
+  uptime_check_changed = (stackdriver_uptime_check != uptime_check)
+  if @debug_mode and uptime_check_changed
+    puts "[DEBUG] uptime check has changed. Old:"
+    puts debug_output(uptime_check)
+    puts "New:"
+    puts debug_output(stackdriver_uptime_check)
+  end
+
+  return uptime_check_changed
 end
 
 def compare_notification_channels(stackdriver_notification_channel, notification_channel)
@@ -99,7 +115,7 @@ def compare_notification_channels(stackdriver_notification_channel, notification
 end
 
 def debug_output(resource)
-  return resource.to_hash.to_json
+  return JSON.pretty_generate(resource.to_hash)
 end
 
 def process_log_based_metrics(log_based_metrics = [])


### PR DESCRIPTION
Thanks to Sergey (and Stepan) for helping me find an alerting policy that worked in spite of Stackdriver weirdness.

How I tested:
* Deploy alerting policy with `rake`.
* Deploy again and see that policy is not updated.
* `helm delete --purge couchdb-prometheus-exporter`
* See that alert is triggered after 5 minutes of no metrics.
* `rake` to re-deploy alerting couchdb-prometheus-exporter.
* See that alert recovers when metrics return.