### PR TITLE
GPII-3394:  Tighten desired_max_response_time.

### DIFF
--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -28,7 +28,7 @@ task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol
   ENV['TF_VAR_locust_target_app'] = "preferences"
   ENV['TF_VAR_locust_script'] = "preferences.py"
   ENV['TF_VAR_locust_desired_median_response_time'] = "300"
-  ENV['TF_VAR_locust_desired_max_response_time'] = "2000"
+  ENV['TF_VAR_locust_desired_max_response_time'] = "1000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -43,7 +43,7 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed, :set_test_protocol
   ENV['TF_VAR_locust_users'] = "15"
   ENV['TF_VAR_locust_desired_total_rps'] = "5"
   ENV['TF_VAR_locust_desired_median_response_time'] = "500"
-  ENV['TF_VAR_locust_desired_max_response_time'] = "3000"
+  ENV['TF_VAR_locust_desired_max_response_time'] = "1000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -22,28 +22,28 @@ task :test do
   sh "#{@exekube_cmd} rake xk['up live/#{@env}/locust',skip_secret_mgmt]"
 end
 
-desc '[TEST] Run Locust swarm against Preferences service in current cluster'
+desc "[TEST] Run Locust swarm against Preferences service in current cluster"
 task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol,] do
-  ENV['TF_VAR_locust_target_host'] = "#{@protocol}://preferences.#{ENV['TF_VAR_domain_name']}"
-  ENV['TF_VAR_locust_target_app'] = "preferences"
-  ENV['TF_VAR_locust_script'] = "preferences.py"
-  ENV['TF_VAR_locust_desired_median_response_time'] = "300"
-  ENV['TF_VAR_locust_desired_max_response_time'] = "1000"
+  ENV["TF_VAR_locust_target_host"] = "#{@protocol}://preferences.#{ENV["TF_VAR_domain_name"]}"
+  ENV["TF_VAR_locust_target_app"] = "preferences"
+  ENV["TF_VAR_locust_script"] = "preferences.py"
+  ENV["TF_VAR_locust_desired_median_response_time"] = "300"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "1000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
   Rake::Task[:test].invoke
 end
 
-desc '[TEST] Run Locust swarm against Flowmanager service in current cluster'
+desc "[TEST] Run Locust swarm against Flowmanager service in current cluster"
 task :test_flowmanager => [:set_vars, :check_destroy_allowed, :set_test_protocol] do
-  ENV['TF_VAR_locust_target_host'] = "#{@protocol}://flowmanager.#{ENV['TF_VAR_domain_name']}"
-  ENV['TF_VAR_locust_target_app'] = "flowmanager"
-  ENV['TF_VAR_locust_script'] = "flowmanager.py"
-  ENV['TF_VAR_locust_users'] = "15"
-  ENV['TF_VAR_locust_desired_total_rps'] = "5"
-  ENV['TF_VAR_locust_desired_median_response_time'] = "500"
-  ENV['TF_VAR_locust_desired_max_response_time'] = "1000"
+  ENV["TF_VAR_locust_target_host"] = "#{@protocol}://flowmanager.#{ENV["TF_VAR_domain_name"]}"
+  ENV["TF_VAR_locust_target_app"] = "flowmanager"
+  ENV["TF_VAR_locust_script"] = "flowmanager.py"
+  ENV["TF_VAR_locust_users"] = "15"
+  ENV["TF_VAR_locust_desired_total_rps"] = "5"
+  ENV["TF_VAR_locust_desired_median_response_time"] = "500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "1000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke


### PR DESCRIPTION
I tightened up the `TF_VAR_locust_desired_max_response_time` values. Failing the build when the outlier behavior occurs is a pretty big hammer, but it is a simple way to ensure that we see the outlier behavior when it occurs during deployment.

I also created dashboards in dev-gitlab-runner, stg, and prd for locust stats (flowmanager and preferences). I consulted these dashboards, as well as Trace data, to determine a safe-ish value for desired_max_response_time.

You may review the commits separately if the noise from normalizing the quotes is too distracting :).