### PR TITLE
[GPII-3610]: Rescue Google::Gax::RetryError in Stackdriver client

### DIFF
--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -33,10 +33,12 @@ resource "null_resource" "apply_stackdriver_lbm" {
           resources = read_resources("${path.module}/resources")
           apply_resources(resources)
         '
-        if [ "$?" != "0" ]; then
-          STACKDRIVER_DID_NOT_FAIL="false"
+        STACKDRIVER_EXIT_STATUS="$?"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
+          exit 1
+        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+           STACKDRIVER_DID_NOT_FAIL="false"
         fi
-
         if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
@@ -67,10 +69,12 @@ resource "null_resource" "destroy_stackdriver_lbm" {
           require "/rakefiles/stackdriver.rb"
           destroy_resources({"log_based_metrics"=>[]})
         '
-        if [ "$?" != "0" ]; then
-          STACKDRIVER_DID_NOT_FAIL="false"
+        STACKDRIVER_EXIT_STATUS="$?"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
+          exit 1
+        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+           STACKDRIVER_DID_NOT_FAIL="false"
         fi
-
         if [ "$RETRY_COUNT" == "$RETRIES" ]; then
           echo "Retry limit reached, giving up!"
           exit 1

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "apply_stackdriver_lbm" {
           STACKDRIVER_DEADLINE_EXCEEDED="true"
         elif [ "$STACKDRIVER_EXIT_STATUS" != "0" ]; then
           exit $STACKDRIVER_EXIT_STATUS
-        fis
+        fi
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -34,11 +34,11 @@ resource "null_resource" "apply_stackdriver_lbm" {
           apply_resources(resources)
         '
         STACKDRIVER_EXIT_STATUS="$?"
-        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
-          exit 1
-        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DEADLINE_EXCEEDED="true"
-        fi
+        if [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+          STACKDRIVER_DEADLINE_EXCEEDED="true"
+        elif [ "$STACKDRIVER_EXIT_STATUS" != "0" ]; then
+          exit $STACKDRIVER_EXIT_STATUS
+        fis
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
@@ -70,10 +70,10 @@ resource "null_resource" "destroy_stackdriver_lbm" {
           destroy_resources({"log_based_metrics"=>[]})
         '
         STACKDRIVER_EXIT_STATUS="$?"
-        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
-          exit 1
-        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DEADLINE_EXCEEDED="true"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+          STACKDRIVER_DEADLINE_EXCEEDED="true"
+        elif [ "$STACKDRIVER_EXIT_STATUS" != "0" ]; then
+          exit $STACKDRIVER_EXIT_STATUS
         fi
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -25,8 +25,8 @@ resource "null_resource" "apply_stackdriver_lbm" {
 
       RETRIES=5
       RETRY_COUNT=1
-      while [ "$STACKDRIVER_DID_NOT_FAIL" != "true" ]; do
-        STACKDRIVER_DID_NOT_FAIL="true"
+      while [ "$STACKDRIVER_DEADLINE_EXCEEDED" != "false" ]; do
+        STACKDRIVER_DEADLINE_EXCEEDED="false"
         echo "[Try $RETRY_COUNT of $RETRIES] Applying Stackdriver resources..."
         ruby -e '
           require "/rakefiles/stackdriver.rb"
@@ -37,13 +37,13 @@ resource "null_resource" "apply_stackdriver_lbm" {
         if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
           exit 1
         elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DID_NOT_FAIL="false"
+           STACKDRIVER_DEADLINE_EXCEEDED="true"
         fi
-        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
-        if [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           sleep 10
         fi
         RETRY_COUNT=$(($RETRY_COUNT+1))
@@ -62,8 +62,8 @@ resource "null_resource" "destroy_stackdriver_lbm" {
 
       RETRIES=5
       RETRY_COUNT=1
-      while [ "$STACKDRIVER_DID_NOT_FAIL" != "true" ]; do
-        STACKDRIVER_DID_NOT_FAIL="true"
+      while [ "$STACKDRIVER_DEADLINE_EXCEEDED" != "false" ]; do
+        STACKDRIVER_DEADLINE_EXCEEDED="false"
         echo "[Try $RETRY_COUNT of $RETRIES] Destroying Stackdriver resources..."
         ruby -e '
           require "/rakefiles/stackdriver.rb"
@@ -73,13 +73,13 @@ resource "null_resource" "destroy_stackdriver_lbm" {
         if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
           exit 1
         elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DID_NOT_FAIL="false"
+           STACKDRIVER_DEADLINE_EXCEEDED="true"
         fi
-        if [ "$RETRY_COUNT" == "$RETRIES" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
-        if [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           sleep 10
         fi
         RETRY_COUNT=$(($RETRY_COUNT+1))

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -50,8 +50,8 @@ resource "null_resource" "apply_stackdriver_monitoring" {
 
       RETRIES=10
       RETRY_COUNT=1
-      while [ "$STACKDRIVER_DID_NOT_FAIL" != "true" ]; do
-        STACKDRIVER_DID_NOT_FAIL="true"
+      while [ "$STACKDRIVER_DEADLINE_EXCEEDED" != "false" ]; do
+        STACKDRIVER_DEADLINE_EXCEEDED="false"
         echo "[Try $RETRY_COUNT of $RETRIES] Applying Stackdriver resources..."
         ruby -e '
           require "/rakefiles/stackdriver.rb"
@@ -62,13 +62,13 @@ resource "null_resource" "apply_stackdriver_monitoring" {
         if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
           exit 1
         elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DID_NOT_FAIL="false"
+           STACKDRIVER_DEADLINE_EXCEEDED="true"
         fi
-        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
-        if [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           sleep 10
         fi
         RETRY_COUNT=$(($RETRY_COUNT+1))
@@ -89,8 +89,8 @@ resource "null_resource" "destroy_stackdriver_monitoring" {
 
       RETRIES=5
       RETRY_COUNT=1
-      while [ "$STACKDRIVER_DID_NOT_FAIL" != "true" ]; do
-        STACKDRIVER_DID_NOT_FAIL="true"
+      while [ "$STACKDRIVER_DEADLINE_EXCEEDED" != "false" ]; do
+        STACKDRIVER_DEADLINE_EXCEEDED="false"
         echo "[Try $RETRY_COUNT of $RETRIES] Destroying Stackdriver resources..."
         ruby -e '
           require "/rakefiles/stackdriver.rb"
@@ -100,13 +100,13 @@ resource "null_resource" "destroy_stackdriver_monitoring" {
         if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
           exit 1
         elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DID_NOT_FAIL="false"
+           STACKDRIVER_DEADLINE_EXCEEDED="true"
         fi
-        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
         fi
-        if [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
+        if [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           sleep 10
         fi
         RETRY_COUNT=$(($RETRY_COUNT+1))

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -58,10 +58,12 @@ resource "null_resource" "apply_stackdriver_monitoring" {
           resources = read_resources("${path.module}/resources_rendered")
           apply_resources(resources)
         '
-        if [ "$?" != "0" ]; then
-          STACKDRIVER_DID_NOT_FAIL="false"
+        STACKDRIVER_EXIT_STATUS="$?"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
+          exit 1
+        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+           STACKDRIVER_DID_NOT_FAIL="false"
         fi
-
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
           echo "Retry limit reached, giving up!"
           exit 1
@@ -94,10 +96,12 @@ resource "null_resource" "destroy_stackdriver_monitoring" {
           require "/rakefiles/stackdriver.rb"
           destroy_resources({"uptime_checks"=>[],"alert_policies"=>[],"notification_channels"=>[]})
         '
-        if [ "$?" != "0" ]; then
-          STACKDRIVER_DID_NOT_FAIL="false"
+        STACKDRIVER_EXIT_STATUS="$?"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
+          exit 1
+        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+           STACKDRIVER_DID_NOT_FAIL="false"
         fi
-
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DID_NOT_FAIL" == "false" ]; then
           echo "Retry limit reached, giving up!"
           exit 1

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -59,10 +59,10 @@ resource "null_resource" "apply_stackdriver_monitoring" {
           apply_resources(resources)
         '
         STACKDRIVER_EXIT_STATUS="$?"
-        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
-          exit 1
-        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DEADLINE_EXCEEDED="true"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+          STACKDRIVER_DEADLINE_EXCEEDED="true"
+        elif [ "$STACKDRIVER_EXIT_STATUS" != "0" ]; then
+          exit $STACKDRIVER_EXIT_STATUS
         fi
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"
@@ -97,10 +97,10 @@ resource "null_resource" "destroy_stackdriver_monitoring" {
           destroy_resources({"uptime_checks"=>[],"alert_policies"=>[],"notification_channels"=>[]})
         '
         STACKDRIVER_EXIT_STATUS="$?"
-        if [ "$STACKDRIVER_EXIT_STATUS" == "1" ]; then
-          exit 1
-        elif [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
-           STACKDRIVER_DEADLINE_EXCEEDED="true"
+        if [ "$STACKDRIVER_EXIT_STATUS" == "120" ]; then
+          STACKDRIVER_DEADLINE_EXCEEDED="true"
+        elif [ "$STACKDRIVER_EXIT_STATUS" != "0" ]; then
+          exit $STACKDRIVER_EXIT_STATUS
         fi
         if [ "$RETRY_COUNT" == "$RETRIES" ] && [ "$STACKDRIVER_DEADLINE_EXCEEDED" == "true" ]; then
           echo "Retry limit reached, giving up!"


### PR DESCRIPTION
Changed Stackdriver client to prevent it from leaving scary stack traces in CI logs.
Changed shell code to retry only in case of deadline exceeded errors.