### PR TITLE
GPII-3601: Add timeout to kubectl delete for PVCs

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -147,7 +147,7 @@ resource "null_resource" "couchdb_destroy_pvcs" {
     command = <<EOF
       if [ "${var.execute_destroy_pvcs}" == "true" ]; then
         for PVC in $(kubectl get pvc --namespace ${var.release_namespace} -o json | jq --raw-output '.items[] | select(.metadata.name | startswith("database-storage-couchdb")) | .metadata.name'); do
-          kubectl --namespace ${var.release_namespace} delete --ignore-not-found --grace-period=600 pvc $PVC
+          timeout -t 600 kubectl --namespace ${var.release_namespace} delete --ignore-not-found --grace-period=300 pvc $PVC
         done
       fi
     EOF


### PR DESCRIPTION
This adds very simple timeout to `kubectl delete pvc` to prevent this getting stuck forever - (see [GPII-3601](https://issues.gpii.net/browse/GPII-3601)).
