### PR TITLE
GPII-3637: Fix retry loop for Locust pod termination

### DIFF
--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -10,12 +10,12 @@ task :test do
       RETRIES=10; \
       RETRY_COUNT=1; \
       while [ \"$(kubectl get pods -n locust -o json 2> /dev/null | jq -r .items[] | grep -c .)\" != \"0\" ]; do \
-        echo \"[Try $RETRY_COUNT of $RETRIES] Waiting for K8s to terminate Locust pods...\"; \
-        RETRY_COUNT=$(($RETRY_COUNT+1)); \
-        if [ \"$RETRY_COUNT\" == \"$RETRIES\" ]; then \
+        if [ \"$RETRY_COUNT\" -gt \"$RETRIES\" ]; then \
           echo \"Retry limit reached, giving up!\"; \
           exit 1; \
         fi; \
+        echo \"[Try $RETRY_COUNT of $RETRIES] Waiting for K8s to terminate Locust pods...\"; \
+        RETRY_COUNT=$(($RETRY_COUNT+1)); \
         sleep 10; \
       done'"
 


### PR DESCRIPTION
This PR:
- fixes issue with retry count being one off when waiting for Locust pod deletion
- also reorders checks so that the loop behaves imho more as expected, in particular: 
  - If the retry limit has been reached, exit without printing `Waiting for...` message
-  changed the test to more "defensive", less prone to infinite loops, `-gt` instead of `==`.