### PR TITLE
Re-enable cluster destroy protection

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -66,7 +66,6 @@ resource "random_id" "cluster_protector" {
     # * Change the value below to 'false'
     # * Destroy the cluster
     # * Change the value below back to 'true'
-    # GPII-3568 - Disabled till all our clusters are regional, should be re-enabled afterwards
-    prevent_destroy = false
+    prevent_destroy = true
   }
 }


### PR DESCRIPTION
I did not re-enable cluster destroy protection after GPII-3568, which did not help re. recent prod cluster destroy issue, re-enabling here.