### PR TITLE
[GPII-3625]: Remove tiller_wait_period from helm-initializer

### DIFF
--- a/gcp/modules/helm-initializer/main.tf
+++ b/gcp/modules/helm-initializer/main.tf
@@ -8,15 +8,10 @@ variable tiller_namespace {
   default = "kube-system"
 }
 
-variable tiller_wait_period {
-  default = "60"
-}
-
 # Install Tiller in kube-system namespace with cluster-admin access to all namespaces
 module "system_tiller" {
   source = "/exekube-modules/helm-initializer"
 
   secrets_dir        = "${var.secrets_dir}"
   tiller_namespace   = "${var.tiller_namespace}"
-  tiller_wait_period = "${var.tiller_wait_period}"
 }

--- a/gcp/modules/helm-initializer/main.tf
+++ b/gcp/modules/helm-initializer/main.tf
@@ -12,6 +12,6 @@ variable tiller_namespace {
 module "system_tiller" {
   source = "/exekube-modules/helm-initializer"
 
-  secrets_dir        = "${var.secrets_dir}"
-  tiller_namespace   = "${var.tiller_namespace}"
+  secrets_dir      = "${var.secrets_dir}"
+  tiller_namespace = "${var.tiller_namespace}"
 }


### PR DESCRIPTION
This is alternative to https://github.com/gpii-ops/gpii-infra/pull/268.
Corresponding exekube part: https://github.com/gpii-ops/exekube/pull/35.