### PR TITLE
Fix infinite loop and other shell & ruby code issues in locust module

### DIFF
--- a/gcp/modules/locust/client.rb
+++ b/gcp/modules/locust/client.rb
@@ -71,5 +71,10 @@ def process_locust_result(locust_stats_file, locust_distribution_file, app_name)
     }
   end
 
-  metric_service_client.create_time_series(formatted_name, time_series)
+  begin
+    metric_service_client.create_time_series(formatted_name, time_series)
+  rescue Google::Gax::RetryError
+    puts "[ERROR]: Error while submitting metrics to Stackdriver (Google::Gax::RetryError)."
+    exit 120
+  end
 end

--- a/gcp/modules/locust/client.rb
+++ b/gcp/modules/locust/client.rb
@@ -26,10 +26,13 @@ def process_locust_result(locust_stats_file, locust_distribution_file, app_name)
     dist.include? "None Total"
   end
 
-  distributions = distributions.reverse.first
-  ["100th_percentile", "99th_percentile", "98th_percentile", "95th_percentile", "90th_percentile",
-   "80th_percentile", "75th_percentile", "66th_percentile", "50th_percentile"].each do |metric|
-    metrics[metric] = distributions.pop
+  # Only add distributions if we actually have any
+  if distributions
+    distributions = distributions.reverse.first
+    ["100th_percentile", "99th_percentile", "98th_percentile", "95th_percentile", "90th_percentile",
+     "80th_percentile", "75th_percentile", "66th_percentile", "50th_percentile"].each do |metric|
+      metrics[metric] = distributions.pop if metrics.key?(metric)
+    end
   end
 
   metric_service_client = Google::Cloud::Monitoring::Metric.new(version: :v3)

--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -98,7 +98,9 @@ resource "null_resource" "locust_swarm_session" {
         EXIT_STATUS="$?"
 
         # Sleep only if this is not the last run
-        [ "$RETRY_COUNT" -lt "$RETRIES" -a "$EXIT_STATUS" != "0" ] && sleep 10
+        if [ "$RETRY_COUNT" -lt "$RETRIES" -a "$EXIT_STATUS" != "0" ]; then
+          sleep 10
+        fi
         RETRY_COUNT=$((RETRY_COUNT+1))
       done
       [ "$EXIT_STATUS" != "0" ] && echo "Failed to post resutls to Stackdriver, retry limit reached, giving up."

--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -68,7 +68,7 @@ resource "null_resource" "locust_swarm_session" {
       echo "Processing stats..."
       SESSION_STATS=$(curl -s $LOCUST_URL/stats/requests)
       total_rps=$(echo $SESSION_STATS | jq -r ".total_rps | floor")
-      median_response_time=$(echo $SESSION_STATS | jq -r '.stats[] | select(.name == "Total").median_response_time | floor')
+      median_response_time=$(echo $SESSION_STATS | jq -r '.stats[] | select(.name == "Total").median_response_time | . // 0 | floor')
       max_response_time=$(echo $SESSION_STATS | jq -r '.stats[] | select(.name == "Total").max_response_time | floor')
       num_failures=$(echo $SESSION_STATS | jq -r '.stats[] | select(.name == "Total").num_failures')
 

--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -103,28 +103,28 @@ resource "null_resource" "locust_swarm_session" {
       done
       [ "$EXIT_STATUS" != "0" ] && echo "Failed to post resutls to Stackdriver, retry limit reached, giving up."
 
-      if [ $total_rps -lt ${var.locust_desired_total_rps} ]; then
+      if [ "$total_rps" -lt "${var.locust_desired_total_rps}" ]; then
         echo
         echo "Looks like total_rps ($total_rps) is worse than desired (${var.locust_desired_total_rps})!"
         echo "This is unacceptable!"
         EXIT_STATUS=1
       fi
 
-      if [ $median_response_time -gt ${var.locust_desired_median_response_time} ]; then
+      if [ "$median_response_time" -gt "${var.locust_desired_median_response_time}" ]; then
         echo
         echo "Looks like median_response_time ($median_response_time) is worse than desired (${var.locust_desired_median_response_time})!"
         echo "This is unacceptable!"
         EXIT_STATUS=1
       fi
 
-      if [ $max_response_time -gt ${var.locust_desired_max_response_time} ]; then
+      if [ "$max_response_time" -gt "${var.locust_desired_max_response_time}" ]; then
         echo
         echo "Looks like max_response_time ($max_response_time) is worse than desired (${var.locust_desired_max_response_time})!"
         echo "This is unacceptable!"
         EXIT_STATUS=1
       fi
 
-      if [ $num_failures -gt ${var.locust_desired_num_failures} ]; then
+      if [ "$num_failures" -gt "${var.locust_desired_num_failures}" ]; then
         echo
         echo "Looks like num_failures ($num_failures) is worse than desired (${var.locust_desired_num_failures})!"
         echo "This is unacceptable!"


### PR DESCRIPTION
This PR fixes original infinite loop when sending Locust stats to Stackdriver error and couple of subsequently discovered issues with the shell & ruby code in the locust module:

- Refactor and fix infinite loop error
- Fix shell 'unknown operand' error caused by using unquoated variables
- Fix jq 'null (null) number required' error for median_response_time
- Add catch for ruby Google::Gax::RetryError ruby error
- Fix undefined method pop for nil:NilClass error in ruby client

It's not trying to solve the problem of locust not accepting Let's encrypt staging cert, this will be handled in another PR.