### PR TITLE
GPII-3649: Move to our build of locust image with LE Staging certificates

### DIFF
--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -1,8 +1,8 @@
 Name: locust
 
 image:
-  repository: quay.io/honestbee/locust
-  tag: 0.7.5
+  repository: gpii/locust
+  tag: 0.9.0-gpii.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
This moves us to our build of Locust Docker image. Main reasons being:
- Support for Let's Encrypt staging certs
- Improved security (update versions and get rid of known vulnerabilities of current image)
See https://github.com/gpii-ops/docker-image-locust/pull/1 for more details.

Dependencies:
- https://github.com/gpii-ops/docker-image-locust/pull/1 PR needs to be merged first.
- tag `0.9.0-gpii.0` has to be created (which will trigger the build of docker image with given tag)

The new image has been tested using `rake test_flowmanager` and `rake test_preferences`.