### PR TITLE
[GPII-3616]: Fix for deploy_module / destroy_module tasks to ignore module dependencies

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -269,7 +269,6 @@ There may be a situation, when we want to roll back entire DB data set to anothe
 * Scale CouchDB stateful set to 0 replicas with `kubectl --namespace gpii scale statefulset couchdb-couchdb --replicas=0`. This will cause K8s to terminate all CouchDB pods, all PDs that were mounted into them will be released. **This will prevent flowmanager and preferences services from processing customer requests!**
    * You may also want to scale `flowmanager` and `preferences` deployments to 0 replicas as well with `kubectl --namespace gpii scale deployment preferences --replicas=0` and `kubectl --namespace gpii scale deployment flowmanager --replicas=0`. This will give you time to verify that DB restoration is successful before allowing the DB to receive traffic again.
 * Destroy `k8s-snapshots` module with `rake destroy_module["k8s/kube-system/k8s-snapshots"]` to prevent new snapshots from being created while you working with disks.
-   * NOTE: Because of https://issues.gpii.net/browse/GPII-3616, you'll need to comment out the `dependencies` block in `terraform.tfvars` first. Otherwise, this command will destroy the whole cluster!
 * Open Google Cloud console, go to "Compute Engine" -> "Disks".
 * Now, repeat for every CouchDB disk name you collected:
    * Save disk name, type, size, zone and description.

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -221,7 +221,7 @@ task :deploy_module, [:module] => [:set_vars] do |taskname, args|
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise
   end
-  sh "#{@exekube_cmd} rake xk['up live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['apply live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
 desc "[ADVANCED] Destroy provided module in the cluster -- rake destroy_module['k8s/kube-system/cert-manager']"
@@ -233,7 +233,7 @@ task :destroy_module, [:module] => [:set_vars, :check_destroy_allowed] do |taskn
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise
   end
-  sh "#{@exekube_cmd} rake xk['down live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['destroy live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
 # vim: et ts=2 sw=2:


### PR DESCRIPTION
Corresponding exekube PR: https://github.com/gpii-ops/exekube/pull/36.