### PR TITLE
Bump locust image to 0.9.0-gpii.1

### DIFF
--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -2,7 +2,7 @@ Name: locust
 
 image:
   repository: gpii/locust
-  tag: 0.9.0-gpii.0
+  tag: 0.9.0-gpii.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Some minor changes on Locust image (see https://github.com/gpii-ops/docker-image-locust/pull/2 for details).