### PR TITLE
[GPII-3697]: Revert "Use n1-highcpu-4 nodes for dev clusters"

### DIFF
--- a/gcp/live/dev/k8s/cluster/terraform.tfvars
+++ b/gcp/live/dev/k8s/cluster/terraform.tfvars
@@ -19,10 +19,4 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-# Team decided to temporarily change node flavor for dev clusters
-# until GCP resource exhaustion issue is solved:
-# https://issues.gpii.net/browse/GPII-3697
-#
-# node_type = "n1-standard-2"
-
-node_type = "n1-highcpu-4"
+node_type = "n1-standard-2"


### PR DESCRIPTION
Reverts gpii-ops/gpii-infra#283.
https://gitlab.com/gpii-ops/gpii-infra/-/jobs/157507990
