### PR TITLE
[GPII-3697]: Use us-east1 for dev clusters, various fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,10 @@ common-stg-test-gcp-dev:
     TF_VAR_organization_name: "gpii2test"
     TF_VAR_organization_domain: "test1.gpii.net"
     TF_VAR_aws_zone_id: "Z1T3NF8J9WVBSP"
+    # We override default infra region for dev environments
+    # due to GCP resource exhaustion issues:
+    # https://issues.gpii.net/browse/GPII-3697
+    TF_VAR_infra_region: "us-east1"
     USER: "doe"
   script:
     - cd gcp/live/dev
@@ -202,6 +206,11 @@ gcp-dev:
   stage: dev
   tags:
     - gcp
+  variables:
+    # We override default infra region for dev environments
+    # due to GCP resource exhaustion issues:
+    # https://issues.gpii.net/browse/GPII-3697
+    TF_VAR_infra_region: "us-east1"
   script:
     - cd gcp/live/dev
     - rake clobber

--- a/common/modules/aws-gcp-dns/main.tf
+++ b/common/modules/aws-gcp-dns/main.tf
@@ -25,7 +25,10 @@ variable "aws_zone_id" {
 provider "google" {
   credentials = "${var.serviceaccount_key}"
   project     = "${var.project_id}"
-  region      = "us-central1"
+
+  # Hardcoded region should be fixed in favor of TF_VAR_infra_region for consistency:
+  # https://issues.gpii.net/browse/GPII-3707
+  region = "us-central1"
 }
 
 provider "aws" {

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -217,7 +217,10 @@ data "google_iam_policy" "admin" {
 provider "google" {
   credentials = "${var.serviceaccount_key}"
   project     = "${var.project_id}"
-  region      = "us-central1"
+
+  # Hardcoded region should be fixed in favor of TF_VAR_infra_region for consistency:
+  # https://issues.gpii.net/browse/GPII-3707
+  region = "us-central1"
 }
 
 # The dnsname and the dns domain must be computed for each new project created.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -74,6 +74,7 @@ An environment needs some resources created in the organization before the follo
    * You can use a different Organization or Billing Account, e.g. from a GCP Free Trial Account, with `export ORGANIZATION_ID=111111111111` and/or `export BILLING_ID=222222-222222-222222`.
 1. By default your K8s cluster and related resources will be deployed into `us-central1`.
    * You can use a different GCP region by setting `TF_VAR_infra_region` variable, for example `export TF_VAR_infra_region=us-east1`.
+   * Before changing region you need to destroy all deployed resources, TF state and secrets with `rake destroy && rake destroy_tfstate && rake destroy_secrets`.
 1. In the case of using a **dev** environment, be sure that the environment variable `$USER` is set to the same name used to name your dev project at GCP. In case of doubt ask to the ops team.
 1. `cd gpii-infra/gcp/live/dev`
 1. `rake`

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -93,7 +93,7 @@ An environment needs some resources created in the organization before the follo
 
    Once you have the shell on your browser execute the following lines to manage the Kubernetes cluster using the embedded *kubectl* command:
 
-   1. `gcloud container clusters get-credentials k8s-cluster --zone us-central1`
+   1. `gcloud container clusters get-credentials k8s-cluster --zone YOUR_CLUSTER_ZONE`
    1. `kubectl -n gpii get pods`
 
    It's a Debian GNU/Linux so all the `apt` commands are also available.

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -72,6 +72,8 @@ An environment needs some resources created in the organization before the follo
    * The `gpii-infra` clone and the `exekube` clone should be siblings in the same directory (there are some references to `../exekube`). This is useful for testing the Terraform modules allocated in the exekube's project. If you want to have those modules in your exekube container uncomment the proper line in the docker-compose.yml file before running any command.
 1. By default you'll use the RtF Organization and Billing Account.
    * You can use a different Organization or Billing Account, e.g. from a GCP Free Trial Account, with `export ORGANIZATION_ID=111111111111` and/or `export BILLING_ID=222222-222222-222222`.
+1. By default your K8s cluster and related resources will be deployed into `us-central1`.
+   * You can use a different GCP region by setting `TF_VAR_infra_region` variable, for example `export TF_VAR_infra_region=us-east1`.
 1. In the case of using a **dev** environment, be sure that the environment variable `$USER` is set to the same name used to name your dev project at GCP. In case of doubt ask to the ops team.
 1. `cd gpii-infra/gcp/live/dev`
 1. `rake`
@@ -93,7 +95,7 @@ An environment needs some resources created in the organization before the follo
 
    Once you have the shell on your browser execute the following lines to manage the Kubernetes cluster using the embedded *kubectl* command:
 
-   1. `gcloud container clusters get-credentials k8s-cluster --zone YOUR_CLUSTER_ZONE`
+   1. `gcloud container clusters get-credentials k8s-cluster --zone YOUR_INFRA_REGION`
    1. `kubectl -n gpii get pods`
 
    It's a Debian GNU/Linux so all the `apt` commands are also available.

--- a/gcp/live/dev/infra/network/terraform.tfvars
+++ b/gcp/live/dev/infra/network/terraform.tfvars
@@ -23,5 +23,8 @@ create_static_ip_address = true
 # DNS zone names are dynamic (e.g. mrtyler.dev.gcp.gpii.net) so they will be
 # injected from outside. (If they're not, defaulting to no DNS records is
 # reasonable.)
-dns_zones = {}
+dns_zones   = {}
 dns_records = {}
+
+static_ip_region = "us-east1"
+cluster_subnets  = { "0" = "us-east1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }

--- a/gcp/live/dev/infra/network/terraform.tfvars
+++ b/gcp/live/dev/infra/network/terraform.tfvars
@@ -25,5 +25,3 @@ create_static_ip_address = true
 # reasonable.)
 dns_zones   = {}
 dns_records = {}
-
-infra_region = "us-east1"

--- a/gcp/live/dev/infra/network/terraform.tfvars
+++ b/gcp/live/dev/infra/network/terraform.tfvars
@@ -26,5 +26,4 @@ create_static_ip_address = true
 dns_zones   = {}
 dns_records = {}
 
-static_ip_region = "us-east1"
-cluster_subnets  = { "0" = "us-east1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }
+infra_region = "us-east1"

--- a/gcp/live/dev/k8s/cluster/terraform.tfvars
+++ b/gcp/live/dev/k8s/cluster/terraform.tfvars
@@ -19,7 +19,4 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-node_type          = "n1-standard-2"
-initial_node_count = 2
-region             = "us-east1"
-additional_zones   = ["us-east1-b", "us-east1-c"]
+node_type = "n1-highcpu-4"

--- a/gcp/live/dev/k8s/cluster/terraform.tfvars
+++ b/gcp/live/dev/k8s/cluster/terraform.tfvars
@@ -19,4 +19,7 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-node_type = "n1-standard-2"
+node_type          = "n1-standard-2"
+initial_node_count = 2
+region             = "us-east1"
+additional_zones   = ["us-east1-b", "us-east1-c"]

--- a/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
@@ -10,4 +10,5 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-exported_logs_force_destroy = "true"
+exported_logs_force_destroy  = "true"
+exported_logs_storage_region = "us-east1"

--- a/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver/export/terraform.tfvars
@@ -11,4 +11,3 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 exported_logs_force_destroy  = "true"
-exported_logs_storage_region = "us-east1"

--- a/gcp/live/dev/secret-mgmt/terraform.tfvars
+++ b/gcp/live/dev/secret-mgmt/terraform.tfvars
@@ -12,3 +12,4 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+storage_location = "us-east1"

--- a/gcp/live/prd/infra/network/terraform.tfvars
+++ b/gcp/live/prd/infra/network/terraform.tfvars
@@ -25,3 +25,6 @@ create_static_ip_address = true
 # reasonable.)
 dns_zones = {}
 dns_records = {}
+
+static_ip_region = "us-central1"
+cluster_subnets  = { "0" = "us-central1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }

--- a/gcp/live/prd/infra/network/terraform.tfvars
+++ b/gcp/live/prd/infra/network/terraform.tfvars
@@ -25,5 +25,3 @@ create_static_ip_address = true
 # reasonable.)
 dns_zones   = {}
 dns_records = {}
-
-infra_region = "us-central1"

--- a/gcp/live/prd/infra/network/terraform.tfvars
+++ b/gcp/live/prd/infra/network/terraform.tfvars
@@ -23,8 +23,7 @@ create_static_ip_address = true
 # DNS zone names are dynamic (e.g. mrtyler.dev.gcp.gpii.net) so they will be
 # injected from outside. (If they're not, defaulting to no DNS records is
 # reasonable.)
-dns_zones = {}
+dns_zones   = {}
 dns_records = {}
 
-static_ip_region = "us-central1"
-cluster_subnets  = { "0" = "us-central1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }
+infra_region = "us-central1"

--- a/gcp/live/prd/k8s/cluster/terraform.tfvars
+++ b/gcp/live/prd/k8s/cluster/terraform.tfvars
@@ -19,10 +19,7 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-node_type = "n1-highcpu-4"
-initial_node_count = 1
-region             = "us-central1"
-additional_zones   = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
+node_type = "n1-highcpu-8"
 
 # This is to prevent accidental deletion of a long-lived cluster (e.g. due to
 # changing a parameter like 'oauth_scopes').

--- a/gcp/live/prd/k8s/cluster/terraform.tfvars
+++ b/gcp/live/prd/k8s/cluster/terraform.tfvars
@@ -20,6 +20,10 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 node_type = "n1-highcpu-4"
+initial_node_count = 1
+region             = "us-central1"
+additional_zones   = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
+
 # This is to prevent accidental deletion of a long-lived cluster (e.g. due to
 # changing a parameter like 'oauth_scopes').
 #

--- a/gcp/live/stg/infra/network/terraform.tfvars
+++ b/gcp/live/stg/infra/network/terraform.tfvars
@@ -25,3 +25,6 @@ create_static_ip_address = true
 # reasonable.)
 dns_zones = {}
 dns_records = {}
+
+static_ip_region = "us-central1"
+cluster_subnets  = { "0" = "us-central1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }

--- a/gcp/live/stg/infra/network/terraform.tfvars
+++ b/gcp/live/stg/infra/network/terraform.tfvars
@@ -25,5 +25,3 @@ create_static_ip_address = true
 # reasonable.)
 dns_zones   = {}
 dns_records = {}
-
-infra_region = "us-central1"

--- a/gcp/live/stg/infra/network/terraform.tfvars
+++ b/gcp/live/stg/infra/network/terraform.tfvars
@@ -23,8 +23,7 @@ create_static_ip_address = true
 # DNS zone names are dynamic (e.g. mrtyler.dev.gcp.gpii.net) so they will be
 # injected from outside. (If they're not, defaulting to no DNS records is
 # reasonable.)
-dns_zones = {}
+dns_zones   = {}
 dns_records = {}
 
-static_ip_region = "us-central1"
-cluster_subnets  = { "0" = "us-central1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }
+infra_region = "us-central1"

--- a/gcp/live/stg/k8s/cluster/terraform.tfvars
+++ b/gcp/live/stg/k8s/cluster/terraform.tfvars
@@ -19,10 +19,7 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-node_type = "n1-highcpu-4"
-initial_node_count = 1
-region             = "us-central1"
-additional_zones   = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
+node_type = "n1-highcpu-8"
 
 # This is to prevent accidental deletion of a long-lived cluster (e.g. due to
 # changing a parameter like 'oauth_scopes').

--- a/gcp/live/stg/k8s/cluster/terraform.tfvars
+++ b/gcp/live/stg/k8s/cluster/terraform.tfvars
@@ -20,6 +20,10 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 node_type = "n1-highcpu-4"
+initial_node_count = 1
+region             = "us-central1"
+additional_zones   = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
+
 # This is to prevent accidental deletion of a long-lived cluster (e.g. due to
 # changing a parameter like 'oauth_scopes').
 #

--- a/gcp/modules/gcp-secret-mgmt/main.tf
+++ b/gcp/modules/gcp-secret-mgmt/main.tf
@@ -10,9 +10,7 @@ variable "encryption_keys" {
   type = "list"
 }
 
-variable "storage_location" {
-  default = "us-central1"
-}
+variable "infra_region" {}
 
 module "gcp-secret-mgmt" {
   source = "/exekube-modules/gcp-secret-mgmt"
@@ -20,7 +18,7 @@ module "gcp-secret-mgmt" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
   encryption_keys    = "${var.encryption_keys}"
-  storage_location   = "${var.storage_location}"
+  storage_location   = "${var.infra_region}"
   keyring_name       = "${var.keyring_name}"
   apply_audit_config = false
 }

--- a/gcp/modules/gcp-stackdriver-export/main.tf
+++ b/gcp/modules/gcp-stackdriver-export/main.tf
@@ -34,9 +34,7 @@ variable "exported_logs_storage_class" {
   default = "REGIONAL"
 }
 
-variable "exported_logs_storage_region" {
-  default = "us-central1"
-}
+variable "infra_region" {}
 
 variable "exported_logs_expire_after" {
   default = "14"
@@ -63,7 +61,7 @@ module "gcp_stackdriver_export" {
   exports                      = "${var.exports}"
   exported_logs_force_destroy  = "${var.exported_logs_force_destroy}"
   exported_logs_storage_class  = "${var.exported_logs_storage_class}"
-  exported_logs_storage_region = "${var.exported_logs_storage_region}"
+  exported_logs_storage_region = "${var.infra_region}"
   exported_logs_expire_after   = "${var.exported_logs_expire_after}"
 
   exported_logs_encryption_key = "${lookup(data.terraform_remote_state.secret-mgmt.encryption_keys, "gcp-stackdriver-export")}"

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -8,6 +8,16 @@ variable "serviceaccount_key" {}
 # Terragrunt variables
 variable "node_type" {}
 
+variable "region" {}
+
+variable "additional_zones" {
+  type = "list"
+}
+
+variable "initial_node_count" {
+  default = 1
+}
+
 variable "prevent_destroy_cluster" {
   default = false
 }
@@ -17,13 +27,13 @@ module "gke_cluster" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
 
-  initial_node_count = 1
+  initial_node_count = "${var.initial_node_count}"
   node_type          = "${var.node_type}"
 
   kubernetes_version = "1.11.6-gke.3"
 
-  region           = "us-central1"
-  additional_zones = ["us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"]
+  region           = "${var.region}"
+  additional_zones = "${var.additional_zones}"
 
   monitoring_service = "monitoring.googleapis.com/kubernetes"
   logging_service    = "logging.googleapis.com/kubernetes"

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -8,11 +8,7 @@ variable "serviceaccount_key" {}
 # Terragrunt variables
 variable "node_type" {}
 
-variable "region" {}
-
-variable "additional_zones" {
-  type = "list"
-}
+variable "infra_region" {}
 
 variable "initial_node_count" {
   default = 1
@@ -32,8 +28,7 @@ module "gke_cluster" {
 
   kubernetes_version = "1.11.6-gke.3"
 
-  region           = "${var.region}"
-  additional_zones = "${var.additional_zones}"
+  region = "${var.infra_region}"
 
   monitoring_service = "monitoring.googleapis.com/kubernetes"
   logging_service    = "logging.googleapis.com/kubernetes"

--- a/gcp/modules/gke-network/main.tf
+++ b/gcp/modules/gke-network/main.tf
@@ -14,6 +14,10 @@ variable "project_id" {}
 variable "serviceaccount_key" {}
 variable "create_static_ip_address" {}
 
+variable "cluster_subnets" {
+  default = "10.16.0.0/20,10.17.0.0/16,10.18.0.0/16"
+}
+
 # Terragrunt variables
 variable "infra_region" {}
 
@@ -32,9 +36,13 @@ variable "dns_records" {
 module "gke_network" {
   source = "/exekube-modules/gke-network"
 
-  dns_zones                = "${var.dns_zones}"
-  dns_records              = "${var.dns_records}"
-  cluster_subnets          = { "0" = "${var.infra_region},10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }
+  dns_zones   = "${var.dns_zones}"
+  dns_records = "${var.dns_records}"
+
+  cluster_subnets = {
+    "0" = "${var.infra_region},${var.cluster_subnets}"
+  }
+
   static_ip_region         = "${var.infra_region}"
   create_static_ip_address = "${var.create_static_ip_address}"
 }

--- a/gcp/modules/gke-network/main.tf
+++ b/gcp/modules/gke-network/main.tf
@@ -15,11 +15,7 @@ variable "serviceaccount_key" {}
 variable "create_static_ip_address" {}
 
 # Terragrunt variables
-variable "static_ip_region" {}
-
-variable "cluster_subnets" {
-  type = "map"
-}
+variable "infra_region" {}
 
 variable "dns_zones" {
   default = {}
@@ -38,8 +34,8 @@ module "gke_network" {
 
   dns_zones                = "${var.dns_zones}"
   dns_records              = "${var.dns_records}"
-  cluster_subnets          = "${var.cluster_subnets}"
-  static_ip_region         = "${var.static_ip_region}"
+  cluster_subnets          = { "0" = "${var.infra_region},10.16.0.0/20,10.17.0.0/16,10.18.0.0/16" }
+  static_ip_region         = "${var.infra_region}"
   create_static_ip_address = "${var.create_static_ip_address}"
 }
 

--- a/gcp/modules/gke-network/main.tf
+++ b/gcp/modules/gke-network/main.tf
@@ -14,22 +14,19 @@ variable "project_id" {}
 variable "serviceaccount_key" {}
 variable "create_static_ip_address" {}
 
+# Terragrunt variables
+variable "static_ip_region" {}
+
+variable "cluster_subnets" {
+  type = "map"
+}
+
 variable "dns_zones" {
   default = {}
 }
 
 variable "dns_records" {
   default = {}
-}
-
-variable "cluster_subnets" {
-  default = {
-    "0" = "us-central1,10.16.0.0/20,10.17.0.0/16,10.18.0.0/16"
-  }
-}
-
-variable "static_ip_region" {
-  default = "us-central1"
 }
 
 # ------------------------------------------------------------------------------

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -101,7 +101,10 @@ task :display_cluster_info do
   puts "Flowmanager endpoint:"
   puts "  curl -k https://flowmanager.#{ENV["TF_VAR_domain_name"] }"
   puts
-  puts "Run `rake destroy` to delete all the expensive resources created by the deployment"
+  puts "Run `rake test_preferences` to execute Locust tests for Preferences."
+  puts "Run `rake test_flowmanager` to execute Locust tests for Flowmanager."
+  puts
+  puts "Run `rake destroy` to delete all the expensive resources created by the deployment."
   puts
 end
 

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -106,9 +106,10 @@ describe Vars do
     expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "us-central1")
   end
 
-  it "set_vars sets default vars for billing and organization" do
+  it "set_vars sets default vars for billing, organization and region" do
     allow(ENV).to receive(:[]=)
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    allow(ENV).to receive(:[]).with("TF_VAR_infra_region").and_return("fake-region1")
     allow(ENV).to receive(:[]).with("ORGANIZATION_ID").and_return("fake-organization-id")
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     env = "fake-env"
@@ -116,6 +117,7 @@ describe Vars do
     Vars.set_vars(env, project_type)
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_id", "fake-organization-id")
     expect(ENV).to have_received(:[]=).with("TF_VAR_billing_id", "fake-billing-id")
+    expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "fake-region1")
   end
 
   it "set_vars doesn't clobber vars that are already set (even when env=stg)" do

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -103,6 +103,7 @@ describe Vars do
     expect(ENV).to have_received(:[]=).with("BILLING_ID", "01A0E1-B0B31F-349F4F")
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_name", "gpii")
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_domain", "gpii.net")
+    expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "us-central1")
   end
 
   it "set_vars sets default vars for billing and organization" do

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -106,10 +106,9 @@ describe Vars do
     expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "us-central1")
   end
 
-  it "set_vars sets default vars for billing, organization and region" do
+  it "set_vars sets default vars for billing and organization" do
     allow(ENV).to receive(:[]=)
     allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
-    allow(ENV).to receive(:[]).with("TF_VAR_infra_region").and_return("fake-region1")
     allow(ENV).to receive(:[]).with("ORGANIZATION_ID").and_return("fake-organization-id")
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     env = "fake-env"
@@ -117,7 +116,6 @@ describe Vars do
     Vars.set_vars(env, project_type)
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_id", "fake-organization-id")
     expect(ENV).to have_received(:[]=).with("TF_VAR_billing_id", "fake-billing-id")
-    expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "fake-region1")
   end
 
   it "set_vars doesn't clobber vars that are already set (even when env=stg)" do
@@ -126,6 +124,7 @@ describe Vars do
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     allow(ENV).to receive(:[]).with("TF_VAR_organization_name").and_return("fakecorp")
     allow(ENV).to receive(:[]).with("TF_VAR_organization_domain").and_return("fake.org")
+    allow(ENV).to receive(:[]).with("TF_VAR_infra_region").and_return("fake-region1")
     env = "stg"
     project_type = "fake-project-type"
     Vars.set_vars(env, project_type)
@@ -134,6 +133,7 @@ describe Vars do
     expect(ENV).not_to have_received(:[]=).with("BILLING_ID", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_organization_name", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_organization_domain", any_args)
+    expect(ENV).not_to have_received(:[]=).with("TF_VAR_infra_region", any_args)
   end
 
   it "set_vars sets TF_VAR_nonce" do

--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -25,6 +25,8 @@ class Vars
     ENV["BILLING_ID"] = "01A0E1-B0B31F-349F4F" if ENV["BILLING_ID"].nil? # RtF Billing Account
     ENV["TF_VAR_billing_id"] = ENV["BILLING_ID"]
 
+    ENV["TF_VAR_infra_region"] = "us-central1" if ENV["TF_VAR_infra_region"].nil? # GCP region to deploy cluster and other resources
+
     @domain_name = "#{env}.gcp.#{ENV["TF_VAR_organization_domain"]}"
     if ["dev"].include?(env)
       if ENV["USER"].nil?


### PR DESCRIPTION
Summary of changes:
* Use single `TF_VAR_infra_region` variable to set region for different infra components.
* Drop deprecated `additional_zones` parameter from `gke-cluster` module.
* Use 3-node `n1-highcpu-8` clusters for stg and prd.
* Use 3-node `n1-highcpu-4` clusters for dev.
* Comment and README updates.

Deployment plan:
- [x] Schedule planned maintenance (`gke-cluster` module changes will cause cluster recreation).
- [x] Merge exekube PR.
- [ ] Disable cluster destruction protector.
- [ ] Merge this PR and let CI do its job.
- [ ] Enable cluster destruction protector.

There is a chance that switching region is not going to help with resource exhaustion issue too (#284), because initially I tried `us-west1` and got the same "Google Compute Engine does not have enough resources available" error.