### PR TITLE
GPII-3701: Fix new cert-manager on AWS

### DIFF
--- a/aws/modules/deploy/charts/values/cert-manager.erb
+++ b/aws/modules/deploy/charts/values/cert-manager.erb
@@ -1,2 +1,6 @@
 rbac:
   create: true
+createCustomResource: true
+useCrdInstallHook: false
+webhook:
+  enabled: false


### PR DESCRIPTION
This makes new cert-manager work on AWS too. Missed this in #288 