### PR TITLE
GPII-3701: Fix new cert-manager on AWS - downgrade to 0.5.2

### DIFF
--- a/aws/modules/deploy/charts/values/cert-manager.erb
+++ b/aws/modules/deploy/charts/values/cert-manager.erb
@@ -4,3 +4,5 @@ createCustomResource: true
 useCrdInstallHook: false
 webhook:
   enabled: false
+image:
+  tag: v0.5.2


### PR DESCRIPTION
This fixes the issue of non-working cert-manager on AWS by downgrading to `v0.5.2`. This seems to be latest working version, newer versions use newer version of Kubernetes client library that is not compatible with 1.8 API (the Kube version we're running on AWS).