### PR TITLE
Fix issue with missing CRDs in cert-manager

### DIFF
--- a/shared/charts/cert-manager/README.md
+++ b/shared/charts/cert-manager/README.md
@@ -23,6 +23,12 @@ To install the chart with the release name `my-release`:
 $ kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
+## IMPORTANT: if you are deploying into a namespace that **already exists**,
+## you MUST ensure the namespace has an additional label on it in order for
+## the deployment to succeed
+$ kubectl label namespace <deployment-namespace> certmanager.k8s.io/disable-validation="true"
+
+## Install the cert-manager helm chart
 $ helm install --name my-release stable/cert-manager
 ```
 

--- a/shared/charts/cert-manager/charts/webhook/templates/pki.yaml
+++ b/shared/charts/cert-manager/charts/webhook/templates/pki.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  selfsigned: {}
+  selfSigned: {}
 
 ---
 
@@ -29,6 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "webhook.rootCACertificate" . }}
+  duration: 43800h # 5y
   issuerRef:
     name: {{ include "webhook.selfSignedIssuer" . }}
   commonName: "ca.webhook.cert-manager"
@@ -66,6 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "webhook.servingCertificate" . }}
+  duration: 8760h # 1y
   issuerRef:
     name: {{ include "webhook.rootCAIssuer" . }}
   dnsNames:

--- a/shared/charts/cert-manager/requirements.lock
+++ b/shared/charts/cert-manager/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: webhook
+  repository: file://webhook
+  version: v0.6.3
+digest: sha256:77dcd917e3112dfc7ddb3f1cca72bb337f067706b1020dec0fda4a2d41a945bf
+generated: 2019-02-05T13:43:12.838251554Z

--- a/shared/charts/cert-manager/templates/00-namespace.yaml
+++ b/shared/charts/cert-manager/templates/00-namespace.yaml
@@ -1,9 +1,0 @@
-{{ if .Values.createNamespaceResource }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Release.Namespace | quote }}
-  labels:
-    name: {{ .Release.Namespace | quote }}
-    certmanager.k8s.io/disable-validation: "true"
-{{- end }}

--- a/shared/charts/cert-manager/templates/challenge-crd.yaml
+++ b/shared/charts/cert-manager/templates/challenge-crd.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  name: challenges.certmanager.k8s.io
 {{- if and (semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer) (.Values.useCrdInstallHook) }}
   annotations:
     "helm.sh/hook": crd-install
@@ -13,20 +13,15 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
+  - JSONPath: .status.state
+    name: State
     type: string
-  - JSONPath: .spec.secretName
-    name: Secret
+  - JSONPath: .spec.dnsName
+    name: Domain
     type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
+  - JSONPath: .status.reason
+    name: Reason
     type: string
-    priority: 1
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
-    type: string
-    priority: 1
   - JSONPath: .metadata.creationTimestamp
     description: |-
       CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
@@ -36,11 +31,8 @@ spec:
     type: date
   group: certmanager.k8s.io
   version: v1alpha1
-  scope: Namespaced
   names:
-    kind: Certificate
-    plural: certificates
-    shortNames:
-    - cert
-    - certs
-{{- end }}
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced
+{{- end -}}

--- a/shared/charts/cert-manager/templates/clusterissuer-crd.yaml
+++ b/shared/charts/cert-manager/templates/clusterissuer-crd.yaml
@@ -9,7 +9,6 @@ metadata:
 {{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
-    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:

--- a/shared/charts/cert-manager/templates/issuer-crd.yaml
+++ b/shared/charts/cert-manager/templates/issuer-crd.yaml
@@ -9,7 +9,6 @@ metadata:
 {{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
-    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:

--- a/shared/charts/cert-manager/templates/order-crd.yaml
+++ b/shared/charts/cert-manager/templates/order-crd.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  name: orders.certmanager.k8s.io
 {{- if and (semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer) (.Values.useCrdInstallHook) }}
   annotations:
     "helm.sh/hook": crd-install
@@ -13,18 +13,15 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.secretName
-    name: Secret
+  - JSONPath: .status.state
+    name: State
     type: string
   - JSONPath: .spec.issuerRef.name
     name: Issuer
     type: string
     priority: 1
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
+  - JSONPath: .status.reason
+    name: Reason
     type: string
     priority: 1
   - JSONPath: .metadata.creationTimestamp
@@ -36,11 +33,8 @@ spec:
     type: date
   group: certmanager.k8s.io
   version: v1alpha1
-  scope: Namespaced
   names:
-    kind: Certificate
-    plural: certificates
-    shortNames:
-    - cert
-    - certs
+    kind: Order
+    plural: orders
+  scope: Namespaced
 {{- end }}

--- a/shared/charts/cert-manager/templates/rbac.yaml
+++ b/shared/charts/cert-manager/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]

--- a/shared/charts/cert-manager/values.yaml
+++ b/shared/charts/cert-manager/values.yaml
@@ -54,10 +54,10 @@ extraEnv: []
 # - name: SOME_VAR
 #   value: 'some value'
 
-resources: {}
-  # requests:
-  #   cpu: 10m
-  #   memory: 32Mi
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
 
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
This PR:
- Adds missing CRDs (`challenges` and `orders`). *I missed this previously because the upstream chart moved to manual CRD management but left the old CRD code, without the new CRDs, in the chart itself.*
- Updates CRDs to the ones from 0.6.1 (previously they stayed on some old version)
- Syncs other minor changes from 0.6.1 chart (webhook/pki, resources, rbac finalizers)

Another issue popped up - our tests do not test https for dev environments, that's also why this was missed, it will be solved as part of https://issues.gpii.net/browse/GPII-3668.