### PR TITLE
GPII-3670: Enable Istio add-on

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -41,6 +41,10 @@ module "gke_cluster" {
     "https://www.googleapis.com/auth/trace.append",
   ]
 
+  # Istio config
+  istio_disabled = false
+  istio_auth     = "AUTH_MUTUAL_TLS"
+
   dashboard_disabled = true
 
   # empty password and username disables legacy basic authentication


### PR DESCRIPTION
This PR installs Istio GKE Add-on. 

_Note: This will not change behaviour of existing application in any way, as Istio sidecar has to be injected manually or by labelling the namespace with `istio-injection=enabled`._

Requires gpii-ops/exekube/pull/44.