### PR TITLE
GPII-2802 - Add viewer role to the cloud-admin group

### DIFF
--- a/gcp/PERMISSIONS.md
+++ b/gcp/PERMISSIONS.md
@@ -18,7 +18,8 @@ Accounts and permissions
   1. Billing Account Administrator
   1. Support Account Administrator
   1. Organization Policy Administrator
-  1. Owner
+  1. Viewer
+  1. Owner (not attached by default)
 
 ### [DEV_USER]@raisingthefloor.org
 

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -13,7 +13,8 @@ cloud_admin_organization_permissions = [
   "roles/billing.admin",
   "roles/cloudsupport.admin",
   "roles/orgpolicy.policyAdmin",
-  "roles/resourcemanager.organizationAdmin"
+  "roles/resourcemanager.organizationAdmin",
+  "roles/viewer"
 ]
 
 task :refresh_common_infra, [:project_type] => [@gcp_creds_file, @app_default_creds_file, :configure_extra_tf_vars] do | taskname, args|


### PR DESCRIPTION
For convenience we attached the "viewer" role to the cloud-admin group