### PR TITLE
GPII-3756: display_cluster_state

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,6 +138,7 @@ common-stg-test-gcp-dev:
   after_script:
     # Clean up dev environment even if one of the previous steps fails
     - cd gcp/live/dev
+    - rake display_cluster_state
     # We need to chain the following into a single command to prevent various issues
     # caused by subsequent after script commands when destroy task fails.
     # More info: https://issues.gpii.net/browse/GPII-3488
@@ -223,6 +224,7 @@ gcp-dev:
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/dev
+    - rake display_cluster_state
     # We need to chain the following into a single command to prevent various issues
     # caused by subsequent after script commands when destroy task fails.
     # More info: https://issues.gpii.net/browse/GPII-3488
@@ -316,6 +318,7 @@ gcp-stg:
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/stg
+    - rake display_cluster_state
     # Destroy Locust module (used for smoke tests) and its TF state
     - rake destroy_module[locust] || true
     - rake destroy_tfstate[locust] || true
@@ -416,6 +419,7 @@ gcp-prd:
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/prd
+    - rake display_cluster_state
     # Destroy Locust module (used for smoke tests) and its TF state
     - rake destroy_module[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
     - rake destroy_tfstate[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ gcp-setup:
   script:
     - docker version
     - docker-compose version
-    - docker pull gpii/exekube:0.4.0-google
+    - pushd gcp/live/dev/ && rake update_exekube && popd
     - docker images | grep exekube
     - ruby --version
     - bundle version

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -72,6 +72,7 @@ Users who already had an RtF email address/Google account usually have performed
 ### Interacting with an environment
 
 1. `rake display_cluster_info` shows some helpful links.
+1. `rake display_cluster_state` shows debugging info about the current state of the cluster. This output can be helpful when asking for help.
 1. `rake sh` opens an interactive shell inside a container on the local host that is configured to communicate with your cluster (e.g. via `kubectl` commands).
    * `rake sh` has some issues with interactive commands (e.g. `less` and `vi`) -- see https://issues.gpii.net/browse/GPII-3407.
 1. `rake plain_sh` is like `rake sh`, but not all configuration is performed. This can be helpful for debugging (e.g. when `rake sh` does not work) and with interactive commands.

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -108,6 +108,11 @@ task :display_cluster_info => [:set_vars] do
   puts
 end
 
+desc "Display debugging info about the current state of the cluster"
+task :display_cluster_state => [:set_vars] do
+  sh "#{@exekube_cmd} rake display_cluster_state"
+end
+
 task :check_destroy_allowed do
   if ["prd"].include?(@env)
     if ENV["RAKE_REALLY_DESTROY_IN_PRD"].nil?

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -71,6 +71,22 @@ task :destroy_sa_keys => [@gcp_creds_file, :configure_extra_tf_vars] do
   "
 end
 
+task :display_cluster_state => [:configure] do
+  puts
+  puts "**************"
+  puts "Cluster state:"
+  puts "**************"
+  puts
+  for cmd in [
+    "kubectl -n gpii get all",
+    "kubectl -n gpii get pv",
+    "kubectl -n gpii get pvc",
+    "kubectl -n gpii get events",
+  ]
+    sh "timeout -t 30 #{cmd}"
+  end
+end
+
 # This task attaches the owner role to the current user
 task :grant_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
   sh "
@@ -84,3 +100,5 @@ task :revoke_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
     gcloud projects remove-iam-policy-binding \"$TF_VAR_project_id\" --member user:\"$TF_VAR_auth_user_email\" --role roles/owner
   "
 end
+
+# vim: et ts=2 sw=2:

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -78,10 +78,10 @@ task :display_cluster_state => [:configure] do
   puts "**************"
   puts
   for cmd in [
-    "kubectl -n gpii get all",
-    "kubectl -n gpii get pv",
-    "kubectl -n gpii get pvc",
-    "kubectl -n gpii get events",
+    "kubectl -n gpii get all -o wide",
+    "kubectl -n gpii get pv -o wide",
+    "kubectl -n gpii get pvc -o wide",
+    "kubectl -n gpii get events -o wide",
   ]
     sh "timeout -t 30 #{cmd}"
   end


### PR DESCRIPTION
There's a lot that can be tweaked here (running more/fewer/different commands? do we want to wait 30s * N commands if the cluster is completely broken? `-o json`?) but here is a first pass.

The `-n locust` commands are probably not very useful until I reorganize destruction (part of my plan for GPII-3756).

Sample output from stg (because I don't have a dev cluster up ATM):
```
[tyler@toaster:~/rtf/gpii-infra/gcp/live/stg]$ rake display_cluster_state
docker-compose run --rm xk rake display_cluster_state
gcloud config set project $TF_VAR_project_id
Updated property [core/project].

**************
Cluster state:
**************

timeout -t 30 kubectl -n gpii get all -o wide
NAME                                                READY     STATUS      RESTARTS   AGE       IP           NODE                                         NOMINATED NODE
pod/couchdb-couchdb-0                               2/2       Running     0          10d       10.17.1.9    gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/couchdb-couchdb-1                               2/2       Running     0          10d       10.17.0.9    gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/couchdb-couchdb-2                               2/2       Running     0          10d       10.17.2.16   gke-k8s-cluster-default-pool-fc3f21f1-449r   <none>
pod/couchdb-prometheus-exporter-65d7cc9cf6-wc5mn    2/2       Running     0          10d       10.17.1.11   gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/dataloader-2fg48                                0/1       Completed   0          4d        10.17.0.52   gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/flowmanager-76dfd4669d-cc8vg                    1/1       Running     0          4d        10.17.2.44   gke-k8s-cluster-default-pool-fc3f21f1-449r   <none>
pod/flowmanager-76dfd4669d-hzpsp                    1/1       Running     0          4d        10.17.0.54   gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/flowmanager-76dfd4669d-xnpcm                    1/1       Running     0          4d        10.17.1.57   gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/nginx-ingress-controller-5776579446-4mqsm       1/1       Running     0          10d       10.17.1.7    gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/nginx-ingress-controller-5776579446-bgbcz       1/1       Running     0          10d       10.17.2.19   gke-k8s-cluster-default-pool-fc3f21f1-449r   <none>
pod/nginx-ingress-controller-5776579446-kp4p7       1/1       Running     1          10d       10.17.0.21   gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/nginx-ingress-controller-5776579446-tcbdk       1/1       Running     2          5d        10.17.1.55   gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/nginx-ingress-default-backend-597f469c8-jjvgd   1/1       Running     0          10d       10.17.0.6    gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/nginx-ingress-default-backend-597f469c8-q26jd   1/1       Running     0          10d       10.17.1.8    gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>
pod/preferences-7b7866b459-bcpw7                    1/1       Running     0          4d        10.17.2.45   gke-k8s-cluster-default-pool-fc3f21f1-449r   <none>
pod/preferences-7b7866b459-qsl5h                    1/1       Running     0          4d        10.17.0.53   gke-k8s-cluster-default-pool-0dee4216-rxhd   <none>
pod/preferences-7b7866b459-qtp7x                    1/1       Running     0          4d        10.17.1.56   gke-k8s-cluster-default-pool-bfdfbaed-g440   <none>

NAME                                    TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                      AGE       SELECTOR
service/couchdb-couchdb                 ClusterIP      None            <none>          5984/TCP                     10d       app=couchdb,release=couchdb
service/couchdb-svc-couchdb             ClusterIP      10.18.75.107    <none>          5984/TCP                     10d       app=couchdb,release=couchdb
service/flowmanager                     ClusterIP      10.18.155.126   <none>          80/TCP                       10d       app=flowmanager
service/nginx-ingress-controller        LoadBalancer   10.18.191.109   104.154.45.98   80:32262/TCP,443:30075/TCP   10d       app=nginx-ingress,component=controller,release=nginx-ingress
service/nginx-ingress-default-backend   ClusterIP      10.18.70.81     <none>          80/TCP                       10d       app=nginx-ingress,component=default-backend,release=nginx-ingress
service/preferences                     ClusterIP      10.18.196.51    <none>          80/TCP                       10d       app=preferences

NAME                                            DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE       CONTAINERS                                     IMAGES                                                                                                                                                          SELECTOR
deployment.apps/couchdb-prometheus-exporter     1         1         1            1           10d       couchdb-prometheus-exporter,prometheus-to-sd   gesellix/couchdb-prometheus-exporter@sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2,gcr.io/google-containers/prometheus-to-sd:v0.3.2   app=couchdb-prometheus-exporter
deployment.apps/flowmanager                     3         3         3            3           10d       flowmanager                                    gpii/universal@sha256:1fd9d347f40d26b71e3e37132a4e4293576fde8798bcb4eaba2f291c0b899c14                                                                          app=flowmanager
deployment.apps/nginx-ingress-controller        4         4         4            4           10d       nginx-ingress-controller                       quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.15.0                                                                                           app=nginx-ingress,component=controller,release=nginx-ingress
deployment.apps/nginx-ingress-default-backend   2         2         2            2           10d       nginx-ingress-default-backend                  k8s.gcr.io/defaultbackend:1.3                                                                                                                                   app=nginx-ingress,component=default-backend,release=nginx-ingress
deployment.apps/preferences                     3         3         3            3           10d       preferences                                    gpii/universal@sha256:1fd9d347f40d26b71e3e37132a4e4293576fde8798bcb4eaba2f291c0b899c14                                                                          app=preferences

NAME                                                      DESIRED   CURRENT   READY     AGE       CONTAINERS                                     IMAGES                                                                                                                                                          SELECTOR
replicaset.apps/couchdb-prometheus-exporter-65d7cc9cf6    1         1         1         10d       couchdb-prometheus-exporter,prometheus-to-sd   gesellix/couchdb-prometheus-exporter@sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2,gcr.io/google-containers/prometheus-to-sd:v0.3.2   app=couchdb-prometheus-exporter,pod-template-hash=2183775792
replicaset.apps/flowmanager-57ffb6b6ff                    0         0         0         6d        flowmanager                                    gpii/universal@sha256:cc031f92a0d02b39460f541b7e94376f2fd996ffb17c99fd1716c5d47fa46eb2                                                                          app=flowmanager,pod-template-hash=1399626299
replicaset.apps/flowmanager-6969dd7d67                    0         0         0         5d        flowmanager                                    gpii/universal@sha256:8a88f6dac65f4039d63e38036396bc6fac7fa6b7b6047096b70d3ad60e715e5a                                                                          app=flowmanager,pod-template-hash=2525883823
replicaset.apps/flowmanager-76dfd4669d                    3         3         3         4d        flowmanager                                    gpii/universal@sha256:1fd9d347f40d26b71e3e37132a4e4293576fde8798bcb4eaba2f291c0b899c14                                                                          app=flowmanager,pod-template-hash=3289802258
replicaset.apps/nginx-ingress-controller-5776579446       4         4         4         10d       nginx-ingress-controller                       quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.15.0                                                                                           app=nginx-ingress,component=controller,pod-template-hash=1332135002,release=nginx-ingress
replicaset.apps/nginx-ingress-default-backend-597f469c8   2         2         2         10d       nginx-ingress-default-backend                  k8s.gcr.io/defaultbackend:1.3                                                                                                                                   app=nginx-ingress,component=default-backend,pod-template-hash=153902574,release=nginx-ingress
replicaset.apps/preferences-5664c69b88                    0         0         0         5d        preferences                                    gpii/universal@sha256:8a88f6dac65f4039d63e38036396bc6fac7fa6b7b6047096b70d3ad60e715e5a                                                                          app=preferences,pod-template-hash=1220725644
replicaset.apps/preferences-7b7866b459                    3         3         3         4d        preferences                                    gpii/universal@sha256:1fd9d347f40d26b71e3e37132a4e4293576fde8798bcb4eaba2f291c0b899c14                                                                          app=preferences,pod-template-hash=3634226015
replicaset.apps/preferences-c96ff8b96                     0         0         0         6d        preferences                                    gpii/universal@sha256:cc031f92a0d02b39460f541b7e94376f2fd996ffb17c99fd1716c5d47fa46eb2                                                                          app=preferences,pod-template-hash=752994652

NAME                               DESIRED   CURRENT   AGE       CONTAINERS                              IMAGES
statefulset.apps/couchdb-couchdb   3         3         10d       couchdb,couchdb-statefulset-assembler   couchdb:2.2.0,kocolosk/couchdb-statefulset-assembler:1.1.0

NAME                                                           REFERENCE                             TARGETS           MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/nginx-ingress-controller   Deployment/nginx-ingress-controller   47%/50%, 3%/50%   2         4         4          10d

NAME                   DESIRED   SUCCESSFUL   AGE       CONTAINERS        IMAGES                                                                                   SELECTOR
job.batch/dataloader   1         1            4d        gpii-dataloader   gpii/universal@sha256:1fd9d347f40d26b71e3e37132a4e4293576fde8798bcb4eaba2f291c0b899c14   controller-uid=b6c22adb-3619-11e9-a03f-42010a8000db
timeout -t 30 kubectl -n gpii get pv -o wide
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                                     STORAGECLASS   REASON    AGE
pvc-9f68ef52-fd37-11e8-8c39-42010a80009f   10Gi       RWO            Delete           Bound     gpii/database-storage-couchdb-couchdb-0   pd-ssd                   10d
pvc-9f829990-fd37-11e8-8c39-42010a80009f   10Gi       RWO            Delete           Bound     gpii/database-storage-couchdb-couchdb-1   pd-ssd                   10d
pvc-9f91dcfe-fd37-11e8-8c39-42010a80009f   10Gi       RWO            Delete           Bound     gpii/database-storage-couchdb-couchdb-2   pd-ssd                   10d
timeout -t 30 kubectl -n gpii get pvc -o wide
NAME                                 STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
database-storage-couchdb-couchdb-0   Bound     pvc-9f68ef52-fd37-11e8-8c39-42010a80009f   10Gi       RWO            pd-ssd         10d
database-storage-couchdb-couchdb-1   Bound     pvc-9f829990-fd37-11e8-8c39-42010a80009f   10Gi       RWO            pd-ssd         10d
database-storage-couchdb-couchdb-2   Bound     pvc-9f91dcfe-fd37-11e8-8c39-42010a80009f   10Gi       RWO            pd-ssd         10d
timeout -t 30 kubectl -n gpii get events -o wide
LAST SEEN   FIRST SEEN   COUNT     NAME                                 KIND      SUBOBJECT                  TYPE      REASON      SOURCE                                                MESSAGE
54m         54m          1         couchdb-couchdb-1.1586f76ce476d370   Pod       spec.containers{couchdb}   Warning   Unhealthy   kubelet, gke-k8s-cluster-default-pool-0dee4216-rxhd   Liveness probe failed: rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "process_linux.go:87: adding pid 3684298 to cgroups caused \"failed to write 3684298 to cgroup.procs: write /sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/pod2ecbdd51-3173-11e9-bb70-42010a800085/fa95a5e6684341606d9da022677de872e4f30f196c68e90b9814fab5189a5702/cgroup.procs: invalid argument\""


5m        4d        947       flowmanager-ingress.1585bc775a0e52b1   Ingress             Warning   Translate   loadbalancer-controller   error while evaluating the ingress spec: service "gpii/flowmanager" is type "ClusterIP", expected "NodePort" or "LoadBalancer"
5m        4d        948       preferences-ingress.1585bc775a0cf3d6   Ingress             Warning   Translate   loadbalancer-controller   error while evaluating the ingress spec: service "gpii/preferences" is type "ClusterIP", expected "NodePort" or "LoadBalancer"
```