### PR TITLE
Move services to Https only

### DIFF
--- a/gcp/live/dev/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/flowmanager/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-staging"
-disable_ssl_redirect = "true"
 
 replica_count     = 2
 requests_cpu      = "250m"

--- a/gcp/live/dev/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/preferences/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-staging"
-disable_ssl_redirect = "true"
 
 replica_count     = 2
 requests_cpu      = "500m"

--- a/gcp/live/prd/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/flowmanager/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-production"
-disable_ssl_redirect = "false"
 
 replica_count     = 3
 requests_cpu      = "500m"

--- a/gcp/live/prd/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/preferences/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-production"
-disable_ssl_redirect = "false"
 
 replica_count     = 3
 requests_cpu      = "1000m"

--- a/gcp/live/stg/k8s/gpii/flowmanager/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/flowmanager/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-production"
-disable_ssl_redirect = "false"
 
 replica_count     = 3
 requests_cpu      = "500m"

--- a/gcp/live/stg/k8s/gpii/preferences/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/preferences/terraform.tfvars
@@ -20,7 +20,6 @@ terragrunt = {
 # ↓ Module configuration (empty means all default)
 
 cert_issuer_name     = "letsencrypt-production"
-disable_ssl_redirect = "false"
 
 replica_count     = 3
 requests_cpu      = "1000m"

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -12,7 +12,6 @@ variable "flowmanager_checksum" {}
 # Terragrunt variables
 variable "cert_issuer_name" {}
 
-variable "disable_ssl_redirect" {}
 variable "replica_count" {}
 variable "requests_cpu" {}
 variable "requests_memory" {}
@@ -34,7 +33,6 @@ data "template_file" "flowmanager_values" {
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
     cert_issuer_name       = "${var.cert_issuer_name}"
-    disable_ssl_redirect   = "${var.disable_ssl_redirect}"
     replica_count          = "${var.replica_count}"
     requests_cpu           = "${var.requests_cpu}"
     requests_memory        = "${var.requests_memory}"

--- a/gcp/modules/gpii-flowmanager/values.yaml
+++ b/gcp/modules/gpii-flowmanager/values.yaml
@@ -11,9 +11,6 @@ issuerRef:
 dnsNames:
 - flowmanager.${domain_name}
 
-ingress:
-  disableSslRedirect: ${disable_ssl_redirect}
-
 datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 enableStackdriverTrace: true

--- a/gcp/modules/gpii-preferences/main.tf
+++ b/gcp/modules/gpii-preferences/main.tf
@@ -12,7 +12,6 @@ variable "preferences_checksum" {}
 # Terragrunt variables
 variable "cert_issuer_name" {}
 
-variable "disable_ssl_redirect" {}
 variable "replica_count" {}
 variable "requests_cpu" {}
 variable "requests_memory" {}
@@ -34,7 +33,6 @@ data "template_file" "preferences_values" {
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
     cert_issuer_name       = "${var.cert_issuer_name}"
-    disable_ssl_redirect   = "${var.disable_ssl_redirect}"
     replica_count          = "${var.replica_count}"
     requests_cpu           = "${var.requests_cpu}"
     requests_memory        = "${var.requests_memory}"

--- a/gcp/modules/gpii-preferences/values.yaml
+++ b/gcp/modules/gpii-preferences/values.yaml
@@ -11,9 +11,6 @@ issuerRef:
 dnsNames:
 - preferences.${domain_name}
 
-ingress:
-  disableSslRedirect: ${disable_ssl_redirect}
-
 datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 
 enableStackdriverTrace: true

--- a/shared/charts/gpii-flowmanager/templates/ingress.yaml
+++ b/shared/charts/gpii-flowmanager/templates/ingress.yaml
@@ -3,10 +3,6 @@ kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: {{ template "flowmanager.name" . }}-ingress
-  {{- if .Values.ingress.disableSslRedirect }}
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  {{- end }}
 spec:
   tls:
     - hosts:

--- a/shared/charts/gpii-flowmanager/values.yaml
+++ b/shared/charts/gpii-flowmanager/values.yaml
@@ -29,9 +29,6 @@ issuerRef:
 dnsNames:
 - flowmanager.test.local
 
-ingress:
-  disableSslRedirect: false
-
 nameOverride: flowmanager
 
 ## Optional resource requests and limits for deployment

--- a/shared/charts/gpii-preferences/templates/ingress.yaml
+++ b/shared/charts/gpii-preferences/templates/ingress.yaml
@@ -3,10 +3,6 @@ kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: {{ template "preferences.name" . }}-ingress
-  {{- if .Values.ingress.disableSslRedirect }}
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-  {{- end }}
 spec:
   tls:
     - hosts:

--- a/shared/charts/gpii-preferences/values.yaml
+++ b/shared/charts/gpii-preferences/values.yaml
@@ -28,9 +28,6 @@ issuerRef:
 dnsNames:
 - preferences.test.local
 
-ingress:
-  disableSslRedirect: false
-
 nameOverride: preferences
 
 ## Optional resource requests and limits for deployment

--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -2,7 +2,7 @@ Name: locust
 
 image:
   repository: gpii/locust
-  tag: 0.9.0-gpii.1
+  tag: 0.9.0-gpii.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -1,7 +1,3 @@
-task :set_test_protocol do
-  @protocol = (@env == "dev" ? "http" : "https")
-end
-
 task :test do
   sh "#{@exekube_cmd} rake xk['down live/#{@env}/locust',skip_secret_mgmt] || true"
   Rake::Task[:destroy_tfstate].invoke('locust')
@@ -23,8 +19,8 @@ task :test do
 end
 
 desc "[TEST] Run Locust swarm against Preferences service in current cluster"
-task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol,] do
-  ENV["TF_VAR_locust_target_host"] = "#{@protocol}://preferences.#{ENV["TF_VAR_domain_name"]}"
+task :test_preferences => [:set_vars, :check_destroy_allowed] do
+  ENV["TF_VAR_locust_target_host"] = "https://preferences.#{ENV["TF_VAR_domain_name"]}"
   ENV["TF_VAR_locust_target_app"] = "preferences"
   ENV["TF_VAR_locust_script"] = "preferences.py"
   ENV["TF_VAR_locust_desired_median_response_time"] = "300"
@@ -36,8 +32,8 @@ task :test_preferences => [:set_vars, :check_destroy_allowed, :set_test_protocol
 end
 
 desc "[TEST] Run Locust swarm against Flowmanager service in current cluster"
-task :test_flowmanager => [:set_vars, :check_destroy_allowed, :set_test_protocol] do
-  ENV["TF_VAR_locust_target_host"] = "#{@protocol}://flowmanager.#{ENV["TF_VAR_domain_name"]}"
+task :test_flowmanager => [:set_vars, :check_destroy_allowed] do
+  ENV["TF_VAR_locust_target_host"] = "https://flowmanager.#{ENV["TF_VAR_domain_name"]}"
   ENV["TF_VAR_locust_target_app"] = "flowmanager"
   ENV["TF_VAR_locust_script"] = "flowmanager.py"
   ENV["TF_VAR_locust_users"] = "15"


### PR DESCRIPTION
This PR:
- Bumps Locust image to new build - `0.9.0-gpii.2` - this resolves some issues with LE Staging certs
- Moves all services to HTTPS only (in all envs) and removes code related to http support
  - this also means that tests in dev will be run against https too