### PR TITLE
GPII-3756: Don't destroy env after failure.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,19 +132,20 @@ common-stg-test-gcp-dev:
     - cd gcp/live/dev
     - rake clobber
     - rake configure_serviceaccount_ci_restore
-    - rake
-    - rake test_preferences
-    - rake test_flowmanager
-  after_script:
-    # Clean up dev environment even if one of the previous steps fails
-    - cd gcp/live/dev
-    - rake display_cluster_state
     # We need to chain the following into a single command to prevent various issues
     # caused by subsequent after script commands when destroy task fails.
     # More info: https://issues.gpii.net/browse/GPII-3488
     - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
     # Terraform state encryption key is also gone with secrets, we have to destroy tfstate as well
     - rake destroy_tfstate[locust] || true
+    - rake || (rake display_cluster_state ; false)
+    - rake test_preferences || (rake display_cluster_state ; false)
+    - rake test_flowmanager || (rake display_cluster_state ; false)
+    - rake display_cluster_state
+    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
+    - rake destroy_tfstate[locust] || true
+  after_script:
+    - cd gcp/live/dev
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
     - rake clobber || true
@@ -218,19 +219,20 @@ gcp-dev:
     - cd gcp/live/dev
     - rake clobber
     - rake configure_serviceaccount_ci_restore
-    - rake
-    - rake test_preferences
-    - rake test_flowmanager
-  after_script:
-    # Clean up even if something failed.
-    - cd gcp/live/dev
-    - rake display_cluster_state
     # We need to chain the following into a single command to prevent various issues
     # caused by subsequent after script commands when destroy task fails.
     # More info: https://issues.gpii.net/browse/GPII-3488
     - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
     # Terraform state encryption key is also gone with secrets, we have to destroy tfstate as well
     - rake destroy_tfstate[locust] || true
+    - rake || (rake display_cluster_state ; false)
+    - rake test_preferences || (rake display_cluster_state ; false)
+    - rake test_flowmanager || (rake display_cluster_state ; false)
+    - rake display_cluster_state
+    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
+    - rake destroy_tfstate[locust] || true
+  after_script:
+    - cd gcp/live/dev
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
     - rake clobber || true

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -240,7 +240,7 @@ Solution is to `rake clobber` and re-authenticate. This will not affect your run
 
 ### helm_release.release: rpc error: code = Unavailable desc = transport is closing
 
-This caused by locally missing helm certificates (similarly to previous error, it usually happens when working to `stg` or `prd` environment, after `rake clobber`) and can be fixed by running `rake deploy_module['k8s/kube-system/helm-initializer']`.
+This caused by locally missing helm certificates (similarly to previous error, it usually happens when working to `stg` or `prd` environment, after `rake clobber`) and can be fixed by running `rake fetch_helm_certs`.
 
 ### helm_release.release: error creating tunnel: "could not find tiller"
 

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -82,6 +82,8 @@ task :display_cluster_state => [:configure] do
     "kubectl -n gpii get pv -o wide",
     "kubectl -n gpii get pvc -o wide",
     "kubectl -n gpii get events -o wide",
+    "kubectl -n locust get all -o wide",
+    "kubectl -n locust get events -o wide",
   ]
     sh "timeout -t 30 #{cmd}"
   end


### PR DESCRIPTION
EDIT: Tested this in CI: https://gitlab.com/gpii-ops/gpii-infra/pipelines/49777249. It failed due to unrelated reasons, but the logic looks correct so far (destroyed things first, continuing in spite of failure; ran display_cluster_state when rake failed, then exited).