### PR TITLE
Revert "Try us-east4 for dev clusters"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,7 @@ common-stg-test-gcp-dev:
     # We override default infra region for dev environments
     # due to GCP resource exhaustion issues:
     # https://issues.gpii.net/browse/GPII-3697
-    TF_VAR_infra_region: "us-east4"
+    TF_VAR_infra_region: "us-east1"
     USER: "doe"
   script:
     - cd gcp/live/dev
@@ -213,7 +213,7 @@ gcp-dev:
     # We override default infra region for dev environments
     # due to GCP resource exhaustion issues:
     # https://issues.gpii.net/browse/GPII-3697
-    TF_VAR_infra_region: "us-east4"
+    TF_VAR_infra_region: "us-east1"
   script:
     - cd gcp/live/dev
     - rake clobber


### PR DESCRIPTION
This reverts commit df12b352666bff6389778539c18d9eb7420fdda7.

Back to `us-east1` in the light of very global KMS 🌎 