### PR TITLE
GPII-3756: Add destroy_and_deploy_ci.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,18 +132,7 @@ common-stg-test-gcp-dev:
     - cd gcp/live/dev
     - rake clobber
     - rake configure_serviceaccount_ci_restore
-    # We need to chain the following into a single command to prevent various issues
-    # caused by subsequent after script commands when destroy task fails.
-    # More info: https://issues.gpii.net/browse/GPII-3488
-    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
-    # Terraform state encryption key is also gone with secrets, we have to destroy tfstate as well
-    - rake destroy_tfstate[locust] || true
-    - rake || (rake display_cluster_state ; false)
-    - rake test_preferences || (rake display_cluster_state ; false)
-    - rake test_flowmanager || (rake display_cluster_state ; false)
-    - rake display_cluster_state
-    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
-    - rake destroy_tfstate[locust] || true
+    - rake destroy_and_deploy_ci
   after_script:
     - cd gcp/live/dev
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
@@ -219,18 +208,7 @@ gcp-dev:
     - cd gcp/live/dev
     - rake clobber
     - rake configure_serviceaccount_ci_restore
-    # We need to chain the following into a single command to prevent various issues
-    # caused by subsequent after script commands when destroy task fails.
-    # More info: https://issues.gpii.net/browse/GPII-3488
-    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
-    # Terraform state encryption key is also gone with secrets, we have to destroy tfstate as well
-    - rake destroy_tfstate[locust] || true
-    - rake || (rake display_cluster_state ; false)
-    - rake test_preferences || (rake display_cluster_state ; false)
-    - rake test_flowmanager || (rake display_cluster_state ; false)
-    - rake display_cluster_state
-    - (rake destroy && rake destroy_secrets && rake destroy_tfstate[k8s]) || true
-    - rake destroy_tfstate[locust] || true
+    - rake destroy_and_deploy_ci
   after_script:
     - cd gcp/live/dev
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)

--- a/shared/rakefiles/ci.rake
+++ b/shared/rakefiles/ci.rake
@@ -63,4 +63,62 @@ task :configure_serviceaccount_ci_clobber => [:set_vars_ci]  do
   sh "docker volume rm -f -- #{@secrets_backup_volume}"
 end
 
+desc "[CI ONLY] Run all CI environment destroy steps"
+task :destroy_ci => [:set_vars_ci] do
+  # Try to clean up any previous incarnation of this environment.
+  #
+  # Only destroy additional resources (e.g. secrets, terraform state) if
+  # previous steps succeeded; see https://issues.gpii.net/browse/GPII-3488.
+  begin
+    Rake::Task["destroy"].reenable
+    Rake::Task["destroy"].invoke
+    Rake::Task["destroy_secrets"].reenable
+    Rake::Task["destroy_secrets"].invoke
+    # Iff destroy and destroy_secrets both succeed, we want to run all of these
+    # destroy_tfstate commands (regardless if any one destroy_tfstate fails).
+    begin
+      Rake::Task["destroy_tfstate"].reenable
+      Rake::Task["destroy_tfstate"].invoke("k8s")
+    rescue RuntimeError => err
+      puts "destroy_tfstate step failed:"
+      puts err
+      puts "Continuing."
+    end
+    begin
+      Rake::Task["destroy_tfstate"].reenable
+      Rake::Task["destroy_tfstate"].invoke("locust")
+    rescue RuntimeError => err
+      puts "destroy_tfstate step failed:"
+      puts err
+      puts "Continuing."
+    end
+  rescue RuntimeError => err
+    puts "Destroy step failed:"
+    puts err
+    puts "Continuing."
+  end
+end
+
+desc "[CI ONLY] Run all CI environment destroy and setup steps for ephemeral clusters"
+task :destroy_and_deploy_ci => [:set_vars_ci] do
+  Rake::Task["destroy_ci"].invoke
+  begin
+    Rake::Task["deploy"].invoke
+    Rake::Task["test_preferences"].invoke
+    Rake::Task["test_flowmanager"].invoke
+    Rake::Task["display_cluster_state"].invoke
+    Rake::Task["destroy_ci"].reenable
+    Rake::Task["destroy_ci"].invoke
+  rescue RuntimeError => err
+    puts "Deploy step failed:"
+    puts err
+    Rake::Task["display_cluster_state"].invoke
+    fail
+  end
+  # If everything succeeded, clean up again. (If something failed, don't clean
+  # it up; instead, leave it around for further debugging.)
+  Rake::Task["destroy_ci"].reenable
+  Rake::Task["destroy_ci"].invoke
+end
+
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -28,6 +28,7 @@ task :test_preferences => [:set_vars, :check_destroy_allowed] do
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
+  Rake::Task[:test].reenable
   Rake::Task[:test].invoke
 end
 
@@ -43,6 +44,7 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed] do
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
+  Rake::Task[:test].reenable
   Rake::Task[:test].invoke
 end
 


### PR DESCRIPTION
Per Stepan's suggestion in https://github.com/gpii-ops/gpii-infra/pull/314, I moved the CI logic for dev/ephemeral clusters into rake. Hopefully this new version is easier to understand.

The stg/prd workflow is pretty different and not as hard to read (fewer commands overall, fewer compound commands) so I left it alone.

I ran a few tests from my machine. It's hard to exercise all of the different permutations, but in general this seems to be running, aborting, and continuing as I expect.