### PR TITLE
Node Pool - phase 1

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -199,7 +199,9 @@ data "google_iam_policy" "combined" {
     role = "roles/editor"
 
     members = [
+      # TODO: Remove default account in cleanup phase
       "serviceAccount:${google_project.project.number}-compute@developer.gserviceaccount.com",
+
       "serviceAccount:${google_project.project.number}@cloudservices.gserviceaccount.com",
       "serviceAccount:service-${google_project.project.number}@containerregistry.iam.gserviceaccount.com",
     ]
@@ -210,6 +212,51 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.project_owners}",
+    ]
+  }
+
+  binding {
+    role = "roles/logging.logWriter"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/monitoring.metricWriter"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/monitoring.viewer"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.objectViewer"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudtrace.agent"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
     ]
   }
 

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -260,6 +260,17 @@ data "google_iam_policy" "combined" {
     ]
   }
 
+  # TODO: This is required for k8s snapshots, once Service Assigner is in
+  # k8s-snapshots should get their own dedicated svc account
+  binding {
+    role = "roles/compute.storageAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
   audit_config {
     service = "allServices"
 

--- a/common/modules/gcp-project/service_accounts.tf
+++ b/common/modules/gcp-project/service_accounts.tf
@@ -1,0 +1,13 @@
+# GKE node service account used by nodes and service-account-assigner
+resource "google_service_account" "gke_cluster_node" {
+  account_id   = "gke-cluster-node"
+  display_name = "gke-cluster-node"
+  project      = "${google_project.project.project_id}"
+}
+
+# Default service account for pods
+resource "google_service_account" "gke_cluster_pod_default" {
+  account_id   = "gke-cluster-pod-default"
+  display_name = "gke-cluster-pod-default"
+  project      = "${google_project.project.project_id}"
+}

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -18,6 +18,11 @@ variable "prevent_destroy_cluster" {
   default = false
 }
 
+data "google_service_account" "gke_cluster_node" {
+  account_id = "gke-cluster-node"
+  project    = "${var.project_id}"
+}
+
 module "gke_cluster" {
   source             = "/exekube-modules/gke-cluster"
   project_id         = "${var.project_id}"
@@ -54,6 +59,13 @@ module "gke_cluster" {
   issue_client_certificate = false
 
   update_timeout = "30m"
+
+  primary_pool_min_node_count     = "${var.initial_node_count}"
+  primary_pool_max_node_count     = "${var.initial_node_count}"
+  primary_pool_initial_node_count = "${var.initial_node_count}"
+  primary_pool_machine_type       = "${var.node_type}"
+  primary_pool_oauth_scopes       = ["cloud-platform"]
+  primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"
 }
 
 # Workaround from

--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/templates/pod_disruption_budget.yaml
+++ b/shared/charts/couchdb/templates/pod_disruption_budget.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: {{ template "couchdb.name" . }}
+      release: {{ .Release.Name }}

--- a/shared/charts/gpii-flowmanager/Chart.yaml
+++ b/shared/charts/gpii-flowmanager/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-flowmanager
-version: 0.0.1
+version: 0.0.2
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Flowmanager Service.

--- a/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
+++ b/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "flowmanager.name" . }}
+  labels:
+    app: {{ template "flowmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: preferences

--- a/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
+++ b/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
@@ -11,4 +11,4 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app: preferences
+      app: flowmanager

--- a/shared/charts/gpii-preferences/Chart.yaml
+++ b/shared/charts/gpii-preferences/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-preferences
-version: 0.0.1
+version: 0.0.2
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Preferences Service.

--- a/shared/charts/gpii-preferences/templates/pod_disruption_budget.yaml
+++ b/shared/charts/gpii-preferences/templates/pod_disruption_budget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "preferences.name" . }}
+  labels:
+    app: {{ template "preferences.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: preferences


### PR DESCRIPTION
This PR is overarching for the move over to using Node Pool to manage instances within GKE Clusters. The actual rollout is split into 2 phases (to reduce complexity and provide no-downtime deployment).

This is a prerequisite for deploying Service Account Assigner (and moving over to ACME DNS challenge and deploying Istio).

The whole Node Pool rollout consists of following steps and corresponding PRs (in order):

- [x] 1. **Merge exekube PR gpii-ops/exekube#47 - GPII-3419: Add primary Node Pool**
  This adds support for Node Pool in exekube.

- [ ] 2. **Deploy Primary Node Pool - this PR**
  This creates Primary Node pool with instances.

- [ ] 3. **Cordon and drain old nodes**
  This removes any running workload from old "Default" nodes.
 
   ```console
    # Get list of old nodes
    old_nodes=($(kubectl get nodes -o name | grep default-pool))

    # Cordon all old nodes to prevent any workloads being scheduled on those
    for node in ${old_nodes[*]}; do
      kubectl cordon "${node}"
    done

    # Drain all old nodes (this respects PodDisruptionBudgets)
    for node in ${old_nodes[*]}; do
      kubectl drain --ignore-daemonsets --delete-local-data=true "${node}"
    done
    ```

- [ ] 4. **Verify that draining was successful**
    - Only 5 system pods (DaemonSets) running in kube-system on old nodes, nothing else
    - Services still work

- [ ] 5. **Merge exekube PR gpii-ops/exekube#48 - GPII-3419: Remove Default GKE Cluster Node Pool**
  This removes default Node Pool in exekube.

- [ ] 6. **Remove Default Node Pool - PR #328 - Node pool - phase 2**
  This removes default Node Pool.

- [ ] 7. **Verify that only new nodes are used 😄:**
    - Services are still working
    - Only nodes from the new pool are in the cluster

- [ ] 8. **Create a ticket to set up monitoring for failed/stuck cluster upgrades**
  We should monitor and alert if cluster or node pool  upgrade, or any other long-running operation on cluster, gets stuck or fails.

**This PR:**
- **Creates service accounts for GKE nodes and pods**
- **Moves away from default Compute svc account**
  This account is too wide open (with `roles/editor`)
- **Adds PodDisruptionBudgets for core services**
  This allows for performing Cluster maintenance operations (like `drain`) while keeping services available.
- **Adds primary Node Pool**
- **Enables Auto-upgrade on cluster nodes**
  Atm. nodes are not upgraded, and this results in an inconsistent state of node versions across different environments and potential security implications. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades.
- **Enables Auto-repair on cluster nodes**
  See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair.
- **Enables Metadata concealment**
  This improves security by hiding GCP/GKE metadata that should not be accessible to node workloads - See https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment.

Moving over to Node Pools and introducing PodDisruptionBudgets, together with features like Node Auto-upgrade and Auto-repair, should put us in a significantly better position to perform no-downtime cluster maintenance tasks and keeping clusters up-to-date and consistent.

I've tested the whole process on my dev cluster and it resulted in a no-downtime rollout.