### PR TITLE
Node pool - phase 2

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -199,7 +199,9 @@ data "google_iam_policy" "combined" {
     role = "roles/editor"
 
     members = [
+      # TODO: Remove default account in cleanup phase
       "serviceAccount:${google_project.project.number}-compute@developer.gserviceaccount.com",
+
       "serviceAccount:${google_project.project.number}@cloudservices.gserviceaccount.com",
       "serviceAccount:service-${google_project.project.number}@containerregistry.iam.gserviceaccount.com",
     ]
@@ -210,6 +212,51 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.project_owners}",
+    ]
+  }
+
+  binding {
+    role = "roles/logging.logWriter"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/monitoring.metricWriter"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/monitoring.viewer"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/storage.objectViewer"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+    ]
+  }
+
+  binding {
+    role = "roles/cloudtrace.agent"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
     ]
   }
 

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -199,9 +199,6 @@ data "google_iam_policy" "combined" {
     role = "roles/editor"
 
     members = [
-      # TODO: Remove default account in cleanup phase
-      "serviceAccount:${google_project.project.number}-compute@developer.gserviceaccount.com",
-
       "serviceAccount:${google_project.project.number}@cloudservices.gserviceaccount.com",
       "serviceAccount:service-${google_project.project.number}@containerregistry.iam.gserviceaccount.com",
     ]

--- a/common/modules/gcp-project/service_accounts.tf
+++ b/common/modules/gcp-project/service_accounts.tf
@@ -1,0 +1,13 @@
+# GKE node service account used by nodes and service-account-assigner
+resource "google_service_account" "gke_cluster_node" {
+  account_id   = "gke-cluster-node"
+  display_name = "gke-cluster-node"
+  project      = "${google_project.project.project_id}"
+}
+
+# Default service account for pods
+resource "google_service_account" "gke_cluster_pod_default" {
+  account_id   = "gke-cluster-pod-default"
+  display_name = "gke-cluster-pod-default"
+  project      = "${google_project.project.project_id}"
+}

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -8,11 +8,11 @@ variable "serviceaccount_key" {}
 # Terragrunt variables
 variable "node_type" {}
 
-variable "infra_region" {}
-
-variable "initial_node_count" {
+variable "node_count" {
   default = 1
 }
+
+variable "infra_region" {}
 
 variable "prevent_destroy_cluster" {
   default = false
@@ -28,23 +28,12 @@ module "gke_cluster" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
 
-  initial_node_count = "${var.initial_node_count}"
-  node_type          = "${var.node_type}"
-
   kubernetes_version = "1.11.6-gke.3"
 
   region = "${var.infra_region}"
 
   monitoring_service = "monitoring.googleapis.com/kubernetes"
   logging_service    = "logging.googleapis.com/kubernetes"
-
-  oauth_scopes = [
-    "https://www.googleapis.com/auth/compute",
-    "https://www.googleapis.com/auth/devstorage.read_only",
-    "https://www.googleapis.com/auth/logging.write",
-    "https://www.googleapis.com/auth/monitoring",
-    "https://www.googleapis.com/auth/trace.append",
-  ]
 
   # Istio config
   istio_disabled = false
@@ -60,9 +49,9 @@ module "gke_cluster" {
 
   update_timeout = "30m"
 
-  primary_pool_min_node_count     = "${var.initial_node_count}"
-  primary_pool_max_node_count     = "${var.initial_node_count}"
-  primary_pool_initial_node_count = "${var.initial_node_count}"
+  primary_pool_min_node_count     = "${var.node_count}"
+  primary_pool_max_node_count     = "${var.node_count}"
+  primary_pool_initial_node_count = "${var.node_count}"
   primary_pool_machine_type       = "${var.node_type}"
   primary_pool_oauth_scopes       = ["cloud-platform"]
   primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -18,6 +18,11 @@ variable "prevent_destroy_cluster" {
   default = false
 }
 
+data "google_service_account" "gke_cluster_node" {
+  account_id = "gke-cluster-node"
+  project    = "${var.project_id}"
+}
+
 module "gke_cluster" {
   source             = "/exekube-modules/gke-cluster"
   project_id         = "${var.project_id}"
@@ -54,6 +59,13 @@ module "gke_cluster" {
   issue_client_certificate = false
 
   update_timeout = "30m"
+
+  primary_pool_min_node_count     = "${var.initial_node_count}"
+  primary_pool_max_node_count     = "${var.initial_node_count}"
+  primary_pool_initial_node_count = "${var.initial_node_count}"
+  primary_pool_machine_type       = "${var.node_type}"
+  primary_pool_oauth_scopes       = ["cloud-platform"]
+  primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"
 }
 
 # Workaround from

--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/templates/pod_disruption_budget.yaml
+++ b/shared/charts/couchdb/templates/pod_disruption_budget.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: {{ template "couchdb.name" . }}
+      release: {{ .Release.Name }}

--- a/shared/charts/gpii-flowmanager/Chart.yaml
+++ b/shared/charts/gpii-flowmanager/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-flowmanager
-version: 0.0.1
+version: 0.0.2
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Flowmanager Service.

--- a/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
+++ b/shared/charts/gpii-flowmanager/templates/pod_disruption_budget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "flowmanager.name" . }}
+  labels:
+    app: {{ template "flowmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: preferences

--- a/shared/charts/gpii-preferences/Chart.yaml
+++ b/shared/charts/gpii-preferences/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-preferences
-version: 0.0.1
+version: 0.0.2
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Preferences Service.

--- a/shared/charts/gpii-preferences/templates/pod_disruption_budget.yaml
+++ b/shared/charts/gpii-preferences/templates/pod_disruption_budget.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "preferences.name" . }}
+  labels:
+    app: {{ template "preferences.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: preferences


### PR DESCRIPTION
This is 2nd part of moving over to Node Pools to manage nodes of GKE Clusters

It's part of the story described in #327.

**This PR**:
- Removes default GKE Cluster Node Pool (f6ffdbd)
- Removes permissions for default Compute service account (934a1bc)

This PR should be merged only after gpii-ops/exekube#47, #327 and gpii-ops/exekube#48. See #327 for more details.