### PR TITLE
GPII-3419: Fix missing credentials for google provider error

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -2,6 +2,11 @@ terraform {
   backend "gcs" {}
 }
 
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
 variable "project_id" {}
 variable "serviceaccount_key" {}
 


### PR DESCRIPTION
This should hopefully fix the issue with missing credentials error in CI.