### PR TITLE
Service Account assigner

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -240,15 +240,6 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
-    role = "roles/storage.objectViewer"
-
-    members = [
-      "serviceAccount:${google_service_account.gke_cluster_node.email}",
-      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
-    ]
-  }
-
-  binding {
     role = "roles/cloudtrace.agent"
 
     members = [
@@ -257,14 +248,11 @@ data "google_iam_policy" "combined" {
     ]
   }
 
-  # TODO: This is required for k8s snapshots, once Service Assigner is in
-  # k8s-snapshots should get their own dedicated svc account
   binding {
     role = "roles/compute.storageAdmin"
 
     members = [
-      "serviceAccount:${google_service_account.gke_cluster_node.email}",
-      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_k8s_snapshots.email}",
     ]
   }
 

--- a/common/modules/gcp-project/service_accounts.tf
+++ b/common/modules/gcp-project/service_accounts.tf
@@ -11,3 +11,10 @@ resource "google_service_account" "gke_cluster_pod_default" {
   display_name = "gke-cluster-pod-default"
   project      = "${google_project.project.project_id}"
 }
+
+# k8s-snapshots SVC account with access to storage
+resource "google_service_account" "gke_cluster_pod_k8s_snapshots" {
+  account_id   = "gke-cluster-pod-k8s-snapshots"
+  display_name = "gke-cluster-pod-k8s-snapshots"
+  project      = "${google_project.project.project_id}"
+}

--- a/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/live/dev/k8s/kube-system/service-account-assigner/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/service-account-assigner/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//service-account-assigner"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/live/prd/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/live/prd/k8s/kube-system/service-account-assigner/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/service-account-assigner/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//service-account-assigner"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/live/stg/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/live/stg/k8s/kube-system/service-account-assigner/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/service-account-assigner/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//service-account-assigner"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/modules/k8s-snapshots/main.tf
+++ b/gcp/modules/k8s-snapshots/main.tf
@@ -5,6 +5,7 @@ terraform {
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "project_id" {}
+variable "serviceaccount_key" {}
 
 provider "google" {
   project     = "${var.project_id}"

--- a/gcp/modules/k8s-snapshots/service_account_iam.tf
+++ b/gcp/modules/k8s-snapshots/service_account_iam.tf
@@ -1,0 +1,24 @@
+data "google_service_account" "gke_cluster_node" {
+  account_id = "gke-cluster-node"
+  project    = "${var.project_id}"
+}
+
+data "google_service_account" "gke_cluster_pod_k8s_snapshots" {
+  account_id = "gke-cluster-pod-k8s-snapshots"
+  project    = "${var.project_id}"
+}
+
+data "google_iam_policy" "pod_k8s_snapshots" {
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+
+    members = [
+      "serviceAccount:${data.google_service_account.gke_cluster_node.email}",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "pod_k8s_snapshots_iam" {
+  service_account_id = "${data.google_service_account.gke_cluster_pod_k8s_snapshots.name}"
+  policy_data        = "${data.google_iam_policy.pod_k8s_snapshots.policy_data}"
+}

--- a/gcp/modules/k8s-snapshots/templates/values.yaml.tpl
+++ b/gcp/modules/k8s-snapshots/templates/values.yaml.tpl
@@ -1,0 +1,2 @@
+serviceAccount: "${ service_account }"
+useClaimName: true

--- a/gcp/modules/k8s-snapshots/values.yaml
+++ b/gcp/modules/k8s-snapshots/values.yaml
@@ -1,1 +1,0 @@
-useClaimName: true

--- a/gcp/modules/service-account-assigner/main.tf
+++ b/gcp/modules/service-account-assigner/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "secrets_dir" {}
+variable "charts_dir" {}
+variable "project_id" {}
+variable "serviceaccount_key" {}
+
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
+data "template_file" "release_values" {
+  template = "${file("${path.module}/templates/values.yaml.tpl")}"
+
+  vars = {
+    default_service_account = "${data.google_service_account.gke_cluster_pod_default.email}"
+  }
+}
+
+module "service_account_assigner" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name      = "service-account-assigner"
+  release_namespace = "kube-system"
+
+  release_values          = ""
+  release_values_rendered = "${data.template_file.release_values.rendered}"
+
+  chart_name = "${var.charts_dir}/service-account-assigner"
+}

--- a/gcp/modules/service-account-assigner/service_account_iam.tf
+++ b/gcp/modules/service-account-assigner/service_account_iam.tf
@@ -1,0 +1,24 @@
+data "google_service_account" "gke_cluster_node" {
+  account_id = "gke-cluster-node"
+  project    = "${var.project_id}"
+}
+
+data "google_service_account" "gke_cluster_pod_default" {
+  account_id = "gke-cluster-pod-default"
+  project    = "${var.project_id}"
+}
+
+data "google_iam_policy" "pod_default" {
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+
+    members = [
+      "serviceAccount:${data.google_service_account.gke_cluster_node.email}",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "pod_default_iam" {
+  service_account_id = "${data.google_service_account.gke_cluster_pod_default.name}"
+  policy_data        = "${data.google_iam_policy.pod_default.policy_data}"
+}

--- a/gcp/modules/service-account-assigner/templates/values.yaml.tpl
+++ b/gcp/modules/service-account-assigner/templates/values.yaml.tpl
@@ -1,0 +1,4 @@
+defaultServiceAccount: "${ default_service_account }"
+# See https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes
+defaultScopes:
+- https://www.googleapis.com/auth/cloud-platform

--- a/shared/charts/k8s-snapshots/Chart.yaml
+++ b/shared/charts/k8s-snapshots/Chart.yaml
@@ -1,5 +1,5 @@
 name: k8s-snapshots
-version: 0.0.1
+version: 0.0.2
 appVersion: v2.0
 home: https://github.com/gpii-ops/gpii-infra
 description: Chart for k8s-snapshots – AWS and GCP volume backup utility

--- a/shared/charts/k8s-snapshots/README.md
+++ b/shared/charts/k8s-snapshots/README.md
@@ -1,7 +1,7 @@
 # K8s-snapshots
 
-K8s-snapshots is an AWS and GCP volume backup utility.
-Check out more at [project homepage](https://github.com/miracle2k/k8s-snapshots).
+K8s-snapshots is an AWS and GCP volume backup utility.  Check out more at
+[project homepage](https://github.com/miracle2k/k8s-snapshots).
 
 ## TL;DR;
 
@@ -11,9 +11,12 @@ $ helm install path_to_chart/k8s-snapshots
 
 ## Introduction
 
-This chart bootstraps k8s-snapshots deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps k8s-snapshots deployment on a
+[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
 
 ## Prerequisites
+
   - Kubernetes 1.8+ with Beta APIs enabled
 
 ## Installing the Chart
@@ -24,7 +27,9 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release path_to_chart/k8s-snapshots
 ```
 
-The command deploys k8s-snapshots on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys k8s-snapshots on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -36,18 +41,22 @@ To uninstall/delete the `my-release` deployment:
 $ helm delete my-release
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
 
 ## Configuration
 
-The following table lists the configurable parameters of the gpii-dataloader chart and their default values.
+The following table lists the configurable parameters of the gpii-dataloader
+chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`image.repository` | container image repository | `elsdoerfer/k8s-snapshots`
-`image.tag` | container image tag | `v2.0`
-`image.pullPolicy` | container image pullPolicy | `IfNotPresent`
-`useClaimName` | If `true`, set USE_CLAIM_NAME environment variable for deployment | `true`
-`runOnMasters` | If `true`, apply toleration to run on master nodes to deployment | `false`
-`rbac.create` | If `true`, create and use RBAC resources | `true`
-`replicaCount` | desired number of deployment pods | `1`
+| Parameter          | Description                                                       | Default                    |
+|--------------------|-------------------------------------------------------------------|----------------------------|
+| `image.repository` | container image repository                                        | `elsdoerfer/k8s-snapshots` |
+| `image.tag`        | container image tag                                               | `v2.0`                     |
+| `image.pullPolicy` | container image pullPolicy                                        | `IfNotPresent`             |
+| `useClaimName`     | If `true`, set USE_CLAIM_NAME environment variable for deployment | `true`                     |
+| `runOnMasters`     | If `true`, apply toleration to run on master nodes to deployment  | `false`                    |
+| `rbac.create`      | If `true`, create and use RBAC resources                          | `true`                     |
+| `replicaCount`     | desired number of deployment pods                                 | `1`                        |
+| `serviceAccount`   | GCP Service Account to be assigned to pod                         | `default`                  |
+| `scopes`           | GCP Scopes to be assigned to pod                                  | `cloud-platform`           |

--- a/shared/charts/k8s-snapshots/templates/deployment.yaml
+++ b/shared/charts/k8s-snapshots/templates/deployment.yaml
@@ -9,6 +9,9 @@ spec:
     metadata:
       labels:
         app: {{ template "k8s-snapshots.name" . }}
+      annotations:
+        {{ if .Values.serviceAccount }}accounts.google.com/service-account: {{ .Values.serviceAccount }}{{ end }}
+        {{ if .Values.scopes }}accounts.google.com/scopes: {{ .Values.scopes }}{{ end }}
     spec:
       containers:
       - name: k8s-snapshots

--- a/shared/charts/k8s-snapshots/values.yaml
+++ b/shared/charts/k8s-snapshots/values.yaml
@@ -17,3 +17,6 @@ useClaimName: true
 runOnMasters: false
 
 nameOverride: k8s-snapshots
+
+serviceAccount: default
+scopes: https://www.googleapis.com/auth/cloud-platform

--- a/shared/charts/service-account-assigner/.helmignore
+++ b/shared/charts/service-account-assigner/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/shared/charts/service-account-assigner/Chart.yaml
+++ b/shared/charts/service-account-assigner/Chart.yaml
@@ -1,0 +1,12 @@
+name: service-account-assigner
+version: v0.1.0
+appVersion: v0.0.1
+description: A Helm chart for k8s-gke-service-account-assigner
+home: https://github.com/imduffy15/k8s-gke-service-account-assigner
+keywords:
+  - k8s-gke-service-account-assigner
+  - gcp
+  - gke
+  - service account
+sources:
+  - https://github.com/imduffy15/k8s-gke-service-account-assigner

--- a/shared/charts/service-account-assigner/README.md
+++ b/shared/charts/service-account-assigner/README.md
@@ -1,0 +1,51 @@
+# service-account-assigner chart
+
+K8s-gke-service-account-assigner provides Google Service Account Tokens to
+containers running inside a kubernetes cluster based on annotations.
+
+This is achieved by acting as an proxy between pods and Google instance metadata
+API. See https://github.com/imduffy15/k8s-gke-service-account-assigner for more
+details.
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their
+default values.
+
+| Parameter               | Description                                    | Default                                          |
+|-------------------------|------------------------------------------------|--------------------------------------------------|
+| `image.repository`      | container image repository                     | `gpii/k8s-gke-service-account-assigner`          |
+| `image.pullPolicy`      | container image PullPolicy                     | `IfNotPresent`                                   |
+| `image.tag`             | container image tag                            | `master-gpii.1`                                  |
+| `defaultServiceAccount` | default service account to be assigned to pods | `default`                                        |
+| `defaultScopes`         | list of default scopes to be assigned to pods  | `https://www.googleapis.com/auth/cloud-platform` |
+
+## Installing the Chart
+
+GKE nodes have to use service account with
+`roles/iam.serviceAccountTokenCreator` role on all service accounts that are to
+be used by K8s pods and with `https://www.googleapis.com/auth/cloud-platform`
+scope enabled (see https://github.com/imduffy15/k8s-gke-service-account-assigner
+for more details).
+
+To install the chart with the release name `my-release`:
+
+```sh
+$ helm install --name my-release
+path_to_chart/service-account-assigner
+```
+
+The command deploys service-account-assigner on the Kubernetes cluster in the
+default configuration. The [configuration](#configuration) section lists the
+parameters that can be configured during installation.
+
+## Un-installing the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```sh
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.

--- a/shared/charts/service-account-assigner/templates/_helpers.tpl
+++ b/shared/charts/service-account-assigner/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "service_account_assigner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "service_account_assigner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "service_account_assigner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "helm-toolkit.utils.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/shared/charts/service-account-assigner/templates/daemon_set.yaml
+++ b/shared/charts/service-account-assigner/templates/daemon_set.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "service_account_assigner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+    helm.sh/chart: {{ include "service_account_assigner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      hostNetwork: true
+      serviceAccountName: {{ include "service_account_assigner.fullname" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - "--iptables=true"
+        - "--host-ip=$(HOST_IP)"
+        - "--node=$(NODE_NAME)"
+        - "--log-format=json"
+        - "--default-scopes={{ include "helm-toolkit.utils.joinListWithComma" .Values.defaultScopes }}"
+        - "--default-service-account={{ .Values.defaultServiceAccount }}"
+        - "--enable-metadata-proxy"
+        securityContext:
+          privileged: true
+          capabilities:
+            drop:
+            - all
+            add:
+            - CAP_NET_ADMIN
+            - CAP_NET_RAW
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - containerPort: 8181
+          hostPort: 8181
+          name: http

--- a/shared/charts/service-account-assigner/templates/role.yaml
+++ b/shared/charts/service-account-assigner/templates/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "service_account_assigner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+    helm.sh/chart: {{ include "service_account_assigner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list

--- a/shared/charts/service-account-assigner/templates/role_binding.yaml
+++ b/shared/charts/service-account-assigner/templates/role_binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "service_account_assigner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+    helm.sh/chart: {{ include "service_account_assigner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "service_account_assigner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "service_account_assigner.fullname" . }}

--- a/shared/charts/service-account-assigner/templates/service_account.yaml
+++ b/shared/charts/service-account-assigner/templates/service_account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "service_account_assigner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "service_account_assigner.name" . }}
+    helm.sh/chart: {{ include "service_account_assigner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/shared/charts/service-account-assigner/values.yaml
+++ b/shared/charts/service-account-assigner/values.yaml
@@ -1,0 +1,10 @@
+# Default values for certmerge-operator
+image:
+  repository: gpii/service-account-assigner
+  tag: master-gpii.1
+  pullPolicy: IfNotPresent
+
+defaultServiceAccount: default
+# See https://cloud.google.com/sdk/gcloud/reference/beta/compute/instances/set-scopes
+defaultScopes:
+- https://www.googleapis.com/auth/cloud-platform

--- a/shared/charts/service-account-assigner/values.yaml
+++ b/shared/charts/service-account-assigner/values.yaml
@@ -1,7 +1,7 @@
 # Default values for certmerge-operator
 image:
   repository: gpii/service-account-assigner
-  tag: master-gpii.1
+  tag: 0.0.2-gpii.0
   pullPolicy: IfNotPresent
 
 defaultServiceAccount: default


### PR DESCRIPTION
This PR deploys GKE K8s Service Account assigner (https://github.com/imduffy15/k8s-gke-service-account-assigner) that allows assigning of GCP service accounts directly to individual pods via acting as a proxy in a path to GCP metadata service. *(This is prerequisite for moving over to DNS based ACME challenge for obtaining certificates (and Istio).)*

This PR also makes K8s-snapshots use dedicated service account, as this allows us to drop `storageAdmin` role from the default node service account.

This PR depends on gpii-ops/docker-image-service-account-assigner#2 and gpii-ops/k8s-gke-service-account-assigner#1.

This PR:
- Adds Service Account assigner Helm chart
- Adds and deploys service-account-assigner Terraform module
- Adds dedicated service account for k8s-snapshots
- Adds support for and sets service account for k8s-snapshots (Helm chart and module)

Tests done:
- Service Account assigner is deployed and running, and able to assign individual service accounts to pods
- GKE Metadata Concealment is still in path and works (see gpii-ops/k8s-gke-service-account-assigner#1 for more details)
- GKE metadata-agent is running and works (some restarts are expected, see https://issues.gpii.net/browse/GPII-3815)
- K8s-snapshots is running and snapshots are happening (there's still issue with no snapshots in dev after creation - see https://issues.gpii.net/browse/GPII-3824