### PR TITLE
GPII-3824: Fix missing snapshots in dev environments

### DIFF
--- a/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
     paths = [
       "../helm-initializer",
       "../service-account-assigner",
+      "../../gpii/couchdb",
     ]
   }
 

--- a/gcp/live/prd/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
     paths = [
       "../helm-initializer",
       "../service-account-assigner",
+      "../../gpii/couchdb",
     ]
   }
 

--- a/gcp/live/stg/k8s/kube-system/k8s-snapshots/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/k8s-snapshots/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
     paths = [
       "../helm-initializer",
       "../service-account-assigner",
+      "../../gpii/couchdb",
     ]
   }
 


### PR DESCRIPTION
This PR is a quick fix to [GPII-3824 - No disk snapshots in dev environments](https://issues.gpii.net/browse/GPII-3824).

We avoid the issue of `k8s-snapshots` not picking up changes on existing volumes (ie. added annotations) by deploying `k8s-snapshots` only after `couchdb` and it's volumes have been created and annotated.