### PR TITLE
GPII-3793: Add missing permission for the CI accounts

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -134,7 +134,7 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
-    role = "roles/iam.serviceAccountUser"
+    role = "roles/iam.serviceAccountAdmin"
 
     members = [
       "${local.service_accounts}",


### PR DESCRIPTION
The CI account needs `iam.serviceAccounts.setIamPolicy` permission on the Service Accounts within the project re. the service-account-assigner change, therefore `roles/iam.serviceAccountAdmin` role. 