### PR TITLE
GPII-3793: Add missing permission for the CI accounts #2

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -134,6 +134,14 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
+    role = "roles/iam.serviceAccountUser"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
+  binding {
     role = "roles/iam.serviceAccountAdmin"
 
     members = [


### PR DESCRIPTION
Looks like we need both `User` & `Admin` roles because of `iam.serviceAccounts.actAs`.