### PR TITLE
[GPII-3642]: Enable command center and web scanner APIs

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -73,6 +73,7 @@ variable "service_apis" {
     "serviceusage.googleapis.com",
     "stackdriver.googleapis.com",
     "storage-api.googleapis.com",
+    "websecurityscanner.googleapis.com",
   ]
 }
 
@@ -308,7 +309,7 @@ locals {
   # Project owners will be empty list if var.project_owner is empty string ""
   project_owners = "${compact(list(var.project_owner))}"
 
-  # stg, prd, dev, and the projects that matches the ci_dev_project_regex variable are managed 
+  # stg, prd, dev, and the projects that matches the ci_dev_project_regex variable are managed
   # by the CI so they should have the service account and the permissions attached to it
   #
   root_project_iam = "${replace(var.project_name, var.ci_dev_project_regex, "") != "" && replace(var.project_name, "/^dev-.*/", "") == ""}"

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -98,7 +98,7 @@ task :apply_common_infra => [@gcp_creds_file] do
    "cloudbilling.googleapis.com",
    "iam.googleapis.com",
    "dns.googleapis.com",
-   "compute.googleapis.com"
+   "compute.googleapis.com",
    "securitycenter.googleapis.com"].each do |service|
      sh "#{@exekube_cmd} gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
   end

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -98,7 +98,8 @@ task :apply_common_infra => [@gcp_creds_file] do
    "cloudbilling.googleapis.com",
    "iam.googleapis.com",
    "dns.googleapis.com",
-   "compute.googleapis.com"].each do |service|
+   "compute.googleapis.com"
+   "securitycenter.googleapis.com"].each do |service|
      sh "#{@exekube_cmd} gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
   end
 


### PR DESCRIPTION
This is missing documentation for Security Findings Review process and manual scans creation, but I would prefer to merge this (so APIs stop getting disabled every time CI runs) and address missing pieces in separate PR.