### PR TITLE
GPII-3781: Add missing google provider definition

### DIFF
--- a/gcp/modules/cert-manager/main.tf
+++ b/gcp/modules/cert-manager/main.tf
@@ -7,6 +7,11 @@ variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "project_id" {}
 
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
 data "template_file" "release_values" {
   template = "${file("${path.module}/templates/values.yaml.tpl")}"
 


### PR DESCRIPTION
Missed the provider definition (again)... which fails on CI.