### PR TITLE
GPII-3843: Wait for service to be reachable before starting the Locust tests

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -123,6 +123,7 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.service_accounts}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_cert_manager.email}",
     ]
   }
 

--- a/common/modules/gcp-project/service_accounts.tf
+++ b/common/modules/gcp-project/service_accounts.tf
@@ -12,6 +12,13 @@ resource "google_service_account" "gke_cluster_pod_default" {
   project      = "${google_project.project.project_id}"
 }
 
+# cert-manager SVC account for DNS challenge
+resource "google_service_account" "gke_cluster_pod_cert_manager" {
+  account_id   = "gke-cluster-pod-cert-manager"
+  display_name = "gke-cluster-pod-cert-manager"
+  project      = "${google_project.project.project_id}"
+}
+
 # k8s-snapshots SVC account with access to storage
 resource "google_service_account" "gke_cluster_pod_k8s_snapshots" {
   account_id   = "gke-cluster-pod-k8s-snapshots"

--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -2,7 +2,7 @@ Name: locust
 
 image:
   repository: gpii/locust
-  tag: 0.9.0-gpii.2
+  tag: 0.9.0-gpii.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
This is "fix" for failing Locust tests after cluster creation. Atm. we don't wait for or check that the services are ready, but simply rely that they will be available by the time we run the Locust test.

This PR adds a wait that the targeted service needs to be reachable from within the pods before starting the test.

Depends on https://github.com/gpii-ops/docker-image-locust/pull/4

Details about my investigation can be found at https://gist.github.com/stepanstipl/6eb26d942d7ded09f741a0b9f3677de1.

TL;DR:
- Issue is related to DNS resolution
- I wasn't yet able to pin it down to specific setting, but looks like issue with negative caching somewhere in the DNS resolution path
- Issue happens only on newly-created cluster, if the tests are run right after cluster setup, otherwise it does not happen
- I suspect race-condition before all the parts of the cluster fully comes up, helped by Alpine's way of handling DNS resolution
- Tests on my personal cluster showed required number of iterations to wait for is anything between 0 and cca 30 (therefore relatively high number of retries).

One last thing I'm trying to confirm is whether this can be reproduced before the https://github.com/gpii-ops/gpii-infra/pull/342 - move to DNS challenge PR *(as I still believe it's not related to that change, but don't have good data to back that up).*