### PR TITLE
Fix reverted dns change - stuck state

### DIFF
--- a/gcp/modules/cert-manager/main.tf
+++ b/gcp/modules/cert-manager/main.tf
@@ -5,6 +5,13 @@ terraform {
 variable "nonce" {}
 variable "secrets_dir" {}
 variable "charts_dir" {}
+variable "project_id" {}
+variable "serviceaccount_key" {}
+
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
 
 module "cert-manager" {
   source           = "/exekube-modules/helm-release"


### PR DESCRIPTION
Looks like previously created resource is in a state and needs these credentials to refresh, even though it's been removed by reverting the previous change.