### PR TITLE
GPII-3641: Add containerregistry to common projects.

### DIFF
--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -96,6 +96,7 @@ task :apply_common_infra => [@gcp_creds_file] do
 
   ["cloudresourcemanager.googleapis.com",
    "cloudbilling.googleapis.com",
+   "containerregistry.googleapis.com",
    "iam.googleapis.com",
    "dns.googleapis.com",
    "compute.googleapis.com",


### PR DESCRIPTION
Follow up to #348. I must have manually enabled the API during testing in common-stg.