### PR TITLE
GPII-3843: Create individual DNS records for preferences & flowmanager

### DIFF
--- a/gcp/modules/gpii-flowmanager/dns.tf
+++ b/gcp/modules/gpii-flowmanager/dns.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "network" {
+  backend = "gcs"
+
+  config {
+    credentials    = "${var.serviceaccount_key}"
+    bucket         = "${var.project_id}-tfstate"
+    prefix         = "${var.env}/infra/network"
+    encryption_key = "/dev/null"
+  }
+}
+
+resource "google_dns_record_set" "flowmanager-dns" {
+  name         = "flowmanager.${var.domain_name}."
+  project      = "${var.project_id}"
+  managed_zone = "${replace(var.domain_name, ".", "-")}"
+
+  type    = "A"
+  ttl     = 300
+  rrdatas = ["${data.terraform_remote_state.network.static_ip_address}"]
+}

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -2,6 +2,10 @@ terraform {
   backend "gcs" {}
 }
 
+variable "env" {}
+variable "serviceaccount_key" {}
+variable "project_id" {}
+
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "domain_name" {}

--- a/gcp/modules/gpii-preferences/dns.tf
+++ b/gcp/modules/gpii-preferences/dns.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "network" {
+  backend = "gcs"
+
+  config {
+    credentials    = "${var.serviceaccount_key}"
+    bucket         = "${var.project_id}-tfstate"
+    prefix         = "${var.env}/infra/network"
+    encryption_key = "/dev/null"
+  }
+}
+
+resource "google_dns_record_set" "preferences-dns" {
+  name         = "preferences.${var.domain_name}."
+  project      = "${var.project_id}"
+  managed_zone = "${replace(var.domain_name, ".", "-")}"
+
+  type    = "A"
+  ttl     = 300
+  rrdatas = ["${data.terraform_remote_state.network.static_ip_address}"]
+}

--- a/gcp/modules/gpii-preferences/main.tf
+++ b/gcp/modules/gpii-preferences/main.tf
@@ -2,6 +2,10 @@ terraform {
   backend "gcs" {}
 }
 
+variable "env" {}
+variable "serviceaccount_key" {}
+variable "project_id" {}
+
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "domain_name" {}


### PR DESCRIPTION
This is to resolve the issue with DNS challenge and failing wildcard DNS/locust tests [GPII-3843](https://issues.gpii.net/browse/GPII-3843).

The observed behavior is "by design", although not all DNS servers implement this consistently. There's a whole RFC just to clarify wildcard records - https://tools.ietf.org/html/rfc4592. This behavior is usually referenced as "Empty Non-terminals".

This PR:
- Creates individual specific DNS records for both preferences and flowmanager, which resolves the problem of non-working wildcard when `_acme-challenge` TXT record exists. More about this can be found in my notes on investifaton - https://gist.github.com/stepanstipl/6eb26d942d7ded09f741a0b9f3677de1.
- Reduces TTL to 300s - in my experience shorter TTL increases agility when any infra changes are needed and can help reduce downtime when accidents happen.

This is to be deployed before we roll-out the DNS challenge again, to give DNS some time to settle (we have TTL of 1h on the original records).

FInally the cleanup of the unused wildcard record will be done as part of post-Istio cleanup (as that will move away from using the static IP allocated by exekube module completely)