### PR TITLE
Move Let's Encrypt certificate validation to DNS challenge  #2

### DIFF
--- a/gcp/live/dev/k8s/kube-system/cert-manager/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/cert-manager/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/live/prd/k8s/kube-system/cert-manager/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/cert-manager/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/live/stg/k8s/kube-system/cert-manager/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/cert-manager/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../helm-initializer",
+      "../service-account-assigner",
     ]
   }
 

--- a/gcp/modules/cert-manager/service_account_iam.tf
+++ b/gcp/modules/cert-manager/service_account_iam.tf
@@ -1,0 +1,24 @@
+data "google_service_account" "gke_cluster_node" {
+  account_id = "gke-cluster-node"
+  project    = "${var.project_id}"
+}
+
+data "google_service_account" "gke_cluster_pod_cert_manager" {
+  account_id = "gke-cluster-pod-cert-manager"
+  project    = "${var.project_id}"
+}
+
+data "google_iam_policy" "gke_cluster_pod_cert_manager" {
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+
+    members = [
+      "serviceAccount:${data.google_service_account.gke_cluster_node.email}",
+    ]
+  }
+}
+
+resource "google_service_account_iam_policy" "cert_manager_iam" {
+  service_account_id = "${data.google_service_account.gke_cluster_pod_cert_manager.name}"
+  policy_data        = "${data.google_iam_policy.gke_cluster_pod_cert_manager.policy_data}"
+}

--- a/gcp/modules/cert-manager/templates/values.yaml.tpl
+++ b/gcp/modules/cert-manager/templates/values.yaml.tpl
@@ -1,0 +1,13 @@
+image:
+  repository: ${cert_manager_repository}
+  tag: ${cert_manager_tag}
+
+createCustomResource: true
+useCrdInstallHook: false
+webhook:
+  enabled: false
+podAnnotations:
+  accounts.google.com/service-account: "${service_account}"
+  accounts.google.com/scopes: "https://www.googleapis.com/auth/cloud-platform"
+extraArgs:
+  - --issuer-ambient-credentials

--- a/gcp/modules/cert-manager/values.yaml
+++ b/gcp/modules/cert-manager/values.yaml
@@ -1,8 +1,0 @@
-image:
-  repository: ${cert_manager_repository}
-  tag: ${cert_manager_tag}
-
-createCustomResource: true
-useCrdInstallHook: false
-webhook:
-  enabled: false

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -5,6 +5,7 @@ terraform {
 variable "env" {}
 variable "serviceaccount_key" {}
 variable "project_id" {}
+variable "auth_user_email" {}
 
 variable "secrets_dir" {}
 variable "charts_dir" {}
@@ -12,9 +13,6 @@ variable "domain_name" {}
 
 variable "flowmanager_repository" {}
 variable "flowmanager_checksum" {}
-
-# Terragrunt variables
-variable "cert_issuer_name" {}
 
 variable "replica_count" {}
 variable "requests_cpu" {}
@@ -32,8 +30,13 @@ provider "google" {
   credentials = "${var.serviceaccount_key}"
 }
 
+locals {
+  user_email = "${var.auth_user_email != "" ? var.auth_user_email : "dev-null@raisingthefloor.org"}"
+  acme_email = "${var.env == "prd" || var.env == "stg" ? "ops@raisingthefloor.org" : local.user_email}"
+}
+
 data "template_file" "flowmanager_values" {
-  template = "${file("values.yaml")}"
+  template = "${file("${path.module}/templates/values.yaml.tpl")}"
 
   vars {
     domain_name            = "${var.domain_name}"
@@ -41,12 +44,14 @@ data "template_file" "flowmanager_values" {
     flowmanager_checksum   = "${var.flowmanager_checksum}"
     couchdb_admin_username = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password = "${var.secret_couchdb_admin_password}"
-    cert_issuer_name       = "${var.cert_issuer_name}"
     replica_count          = "${var.replica_count}"
     requests_cpu           = "${var.requests_cpu}"
     requests_memory        = "${var.requests_memory}"
     limits_cpu             = "${var.limits_cpu}"
     limits_memory          = "${var.limits_memory}"
+    project_id             = "${var.project_id}"
+    acme_server            = "${var.env == "prd" || var.env == "stg" ? "https://acme-v02.api.letsencrypt.org/directory" : "https://acme-staging-v02.api.letsencrypt.org/directory"}"
+    acme_email             = "${local.acme_email}"
   }
 }
 

--- a/gcp/modules/gpii-flowmanager/templates/values.yaml.tpl
+++ b/gcp/modules/gpii-flowmanager/templates/values.yaml.tpl
@@ -1,15 +1,16 @@
 replicaCount: ${replica_count}
 
 image:
-  repository: ${preferences_repository}
-  checksum: ${preferences_checksum}
+  repository: ${flowmanager_repository}
+  checksum: ${flowmanager_checksum}
 
-issuerRef:
-  name: ${cert_issuer_name}
-  kind: ClusterIssuer
+acme:
+  clouddnsProject: ${project_id}
+  server: "${acme_server}"
+  email: "${acme_email}"
 
 dnsNames:
-- preferences.${domain_name}
+- flowmanager.${domain_name}
 
 datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 

--- a/gcp/modules/gpii-preferences/templates/values.yaml.tpl
+++ b/gcp/modules/gpii-preferences/templates/values.yaml.tpl
@@ -1,15 +1,16 @@
 replicaCount: ${replica_count}
 
 image:
-  repository: ${flowmanager_repository}
-  checksum: ${flowmanager_checksum}
+  repository: ${preferences_repository}
+  checksum: ${preferences_checksum}
 
-issuerRef:
-  name: ${cert_issuer_name}
-  kind: ClusterIssuer
+acme:
+  clouddnsProject: ${project_id}
+  server: "${acme_server}"
+  email: "${acme_email}"
 
 dnsNames:
-- flowmanager.${domain_name}
+- preferences.${domain_name}
 
 datasourceHostname: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local"
 

--- a/shared/charts/gpii-flowmanager/Chart.yaml
+++ b/shared/charts/gpii-flowmanager/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-flowmanager
-version: 0.0.2
+version: 0.1.0
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Flowmanager Service.

--- a/shared/charts/gpii-flowmanager/README.md
+++ b/shared/charts/gpii-flowmanager/README.md
@@ -44,23 +44,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the gpii-flowmanager chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`replicaCount` | desired number of controller pods | `1`
-`svcListenPort` | ClusterIP service port | `80`
-`flowmanagerListenPort` | port for flowmanager service to listen on | `8081`
-`datasourceListenPort` | data source port for flowmanager service | `5984`
-`datasourceHostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
-`nodeEnv` | flowmanager node env | `gpii.config.cloudBased.flowManager.production`
-`preferencesUrl` | preferences service url | `http://preferences.gpii.svc.cluster.local`
-`enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
-`issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
-`issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
-`dnsNames` | list of host names for nginx-ingress controller | `flowmanager.test.local`
-`disableSslRedirect` | disable nginx-ingress redirection to HTTPS | `false`
-`image.repository` | container image repository | `gpii/universal`
-`image.checksum` | container image checksum | `sha256:8547f22ae8e86d7b4b09e10d9ec87b1605b47dc37904171c84555a55462f161e`
-`image.pullPolicy` | container image pullPolicy | `IfNotPresent`
-`rollingUpdate.maxSurge` | maximum number of pods that can be created over the desired number during rolling update | `25%`
-`rollingUpdate.maxUnavailable` | maximum number of pods that can become unavailable during rolling update | `0`
-`resources` | optional resource requests and limits for deployment | `{}`
+| Parameter                      | Description                                                                              | Default                                                                   |
+| `acme.clouddnsProject`         | required GCP project id to use for CLoudDNS                                              | -                                                                         |
+| `acme.email`                   | optional email to use for registration with certificate issuer                           | `dev-null@raisingthefloor.org`                                                |
+| `acme.server                   | optional ACME server for certificate issuer                                              | `https://acme-staging-v02.api.letsencrypt.org/directory`                  |
+| `datasourceHostname`           | data source hostname for preferences service                                             | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`        |
+| `datasourceListenPort`         | data source port for flowmanager service                                                 | `5984`                                                                    |
+| `disableSslRedirect`           | disable nginx-ingress redirection to HTTPS                                               | `false`                                                                   |
+| `dnsNames`                     | list of host names for nginx-ingress controller                                          | `flowmanager.test.local`                                                  |
+| `enableStackdriverTrace`       | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/)                          | `false`                                                                   |
+| `flowmanagerListenPort`        | port for flowmanager service to listen on                                                | `8081`                                                                    |
+| `image.checksum`               | container image checksum                                                                 | `sha256:8547f22ae8e86d7b4b09e10d9ec87b1605b47dc37904171c84555a55462f161e` |
+| `image.pullPolicy`             | container image pullPolicy                                                               | `IfNotPresent`                                                            |
+| `image.repository`             | container image repository                                                               | `gpii/universal`                                                          |
+| `nodeEnv`                      | flowmanager node env                                                                     | `gpii.config.cloudBased.flowManager.production`                           |
+| `preferencesUrl`               | preferences service url                                                                  | `http://preferences.gpii.svc.cluster.local`                               |
+| `replicaCount`                 | desired number of controller pods                                                        | `1`                                                                       |
+| `resources`                    | optional resource requests and limits for deployment                                     | `{}`                                                                      |
+| `rollingUpdate.maxSurge`       | maximum number of pods that can be created over the desired number during rolling update | `25%`                                                                     |
+| `rollingUpdate.maxUnavailable` | maximum number of pods that can become unavailable during rolling update                 | `0`                                                                       |
+| `svcListenPort`                | ClusterIP service port                                                                   | `80`                                                                      |
+|--------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|

--- a/shared/charts/gpii-flowmanager/templates/certificate.yaml
+++ b/shared/charts/gpii-flowmanager/templates/certificate.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   secretName: {{ template "flowmanager.name" . }}-tls
   issuerRef:
-    name: {{ .Values.issuerRef.name }}
-    kind: {{ .Values.issuerRef.kind }}
+    name: letsencrypt-{{ template "flowmanager.name" . }}
+    kind: Issuer
   dnsNames:
   {{ toYaml .Values.dnsNames | indent 2 }}
   acme:
     config:
-    - http01:
-        ingressClass: nginx
+    - dns01:
+        provider: default
       domains:
       {{ toYaml .Values.dnsNames | indent 6 }}

--- a/shared/charts/gpii-flowmanager/templates/issuer.yaml
+++ b/shared/charts/gpii-flowmanager/templates/issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: letsencrypt-{{ template "flowmanager.name" . }}
+  labels:
+    app: {{ template "flowmanager.name" . }}
+spec:
+  acme:
+    server: {{ .Values.acme.server }}
+    email: {{ .Values.acme.email }}
+    privateKeySecretRef:
+      name: letsencrypt-{{ template "flowmanager.name" . }}
+    dns01:
+      providers:
+      - name: default
+        clouddns:
+          project: {{ required "A valid GCP Project id required for acme.clouddnsProject!" .Values.acme.clouddnsProject }}

--- a/shared/charts/gpii-flowmanager/values.yaml
+++ b/shared/charts/gpii-flowmanager/values.yaml
@@ -22,9 +22,10 @@ rollingUpdate:
   maxSurge: 25%
   maxUnavailable: 25%
 
-issuerRef:
-  name: letsencrypt-production
-  kind: Issuer
+acme:
+  server: https://acme-staging-v02.api.letsencrypt.org/directory
+  email: dev-null@raisingthefloor.org
+  clouddnsProject:
 
 dnsNames:
 - flowmanager.test.local

--- a/shared/charts/gpii-preferences/Chart.yaml
+++ b/shared/charts/gpii-preferences/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-preferences
-version: 0.0.2
+version: 0.1.0
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Preferences Service.

--- a/shared/charts/gpii-preferences/README.md
+++ b/shared/charts/gpii-preferences/README.md
@@ -44,22 +44,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the gpii-preferences chart and their default values.
 
-Parameter | Description | Default
---- | --- | ---
-`replicaCount` | desired number of controller pods | `1`
-`svcListenPort` | ClusterIP service port | `80`
-`preferencesListenPort` | port for preferences service to listen on | `8081`
-`datasourceListenPort` | data source port for preferences service | `5984`
-`datasourceHostname` | data source hostname for preferences service | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`
-`nodeEnv` | preferences node env | `gpii.config.preferencesServer.standalone.production`
-`enableStackdriverTrace` | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/) | `false`
-`issuerRef.name` | name of the cert-manager issuer | `letsencrypt-production`
-`issuerRef.kind` | kind of the cert-manager issuer | `Issuer`
-`dnsNames` | list of host names for nginx-ingress controller | `preferences.test.local`
-`disableSslRedirect` | disable nginx-ingress redirection to HTTPS | `false`
-`image.repository` | container image repository | `gpii/universal`
-`image.checksum` | container image checksum | `sha256:f279c6ab7fa1c19e5f358a6a3d87a970eaf8d615c8b6181851fa086b6229b3a1`
-`image.pullPolicy` | container image pullPolicy | `IfNotPresent`
-`rollingUpdate.maxSurge` | maximum number of pods that can be created over the desired number during rolling update | `25%`
-`rollingUpdate.maxUnavailable` | maximum number of pods that can become unavailable during rolling update | `0`
-`resources` | optional resource requests and limits for deployment | `{}`
+| Parameter                      | Description                                                                              | Default                                                                   |
+| `acme.clouddnsProject`         | required GCP project id to use for CLoudDNS                                              | -                                                                         |
+| `acme.email`                   | optional email to use for registration with certificate issuer                           | `dev-null@raisingthefloor.org`                                                |
+| `acme.server                   | optional ACME server for certificate issuer                                              | `https://acme-staging-v02.api.letsencrypt.org/directory`                  |
+| `datasourceHostname`           | data source hostname for preferences service                                             | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local`        |
+| `datasourceListenPort`         | data source port for preferences service                                                 | `5984`                                                                    |
+| `disableSslRedirect`           | disable nginx-ingress redirection to HTTPS                                               | `false`                                                                   |
+| `dnsNames`                     | list of host names for nginx-ingress controller                                          | `preferences.test.local`                                                  |
+| `enableStackdriverTrace`       | enable [GCP Stackdriver Trace](https://cloud.google.com/trace/)                          | `false`                                                                   |
+| `image.checksum`               | container image checksum                                                                 | `sha256:f279c6ab7fa1c19e5f358a6a3d87a970eaf8d615c8b6181851fa086b6229b3a1` |
+| `image.pullPolicy`             | container image pullPolicy                                                               | `IfNotPresent`                                                            |
+| `image.repository`             | container image repository                                                               | `gpii/universal`                                                          |
+| `nodeEnv`                      | preferences node env                                                                     | `gpii.config.preferencesServer.standalone.production`                     |
+| `preferencesListenPort`        | port for preferences service to listen on                                                | `8081`                                                                    |
+| `replicaCount`                 | desired number of controller pods                                                        | `1`                                                                       |
+| `resources`                    | optional resource requests and limits for deployment                                     | `{}`                                                                      |
+| `rollingUpdate.maxSurge`       | maximum number of pods that can be created over the desired number during rolling update | `25%`                                                                     |
+| `rollingUpdate.maxUnavailable` | maximum number of pods that can become unavailable during rolling update                 | `0`                                                                       |
+| `svcListenPort`                | ClusterIP service port                                                                   | `80`                                                                      |
+|--------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|

--- a/shared/charts/gpii-preferences/templates/certificate.yaml
+++ b/shared/charts/gpii-preferences/templates/certificate.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   secretName: {{ template "preferences.name" . }}-tls
   issuerRef:
-    name: {{ .Values.issuerRef.name }}
-    kind: {{ .Values.issuerRef.kind }}
+    name: letsencrypt-{{ template "preferences.name" . }}
+    kind: Issuer
   dnsNames:
   {{ toYaml .Values.dnsNames | indent 2 }}
   acme:
     config:
-    - http01:
-        ingressClass: nginx
+    - dns01:
+        provider: default
       domains:
       {{ toYaml .Values.dnsNames | indent 6 }}

--- a/shared/charts/gpii-preferences/templates/issuer.yaml
+++ b/shared/charts/gpii-preferences/templates/issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: letsencrypt-{{ template "preferences.name" . }}
+  labels:
+    app: {{ template "preferences.name" . }}
+spec:
+  acme:
+    server: {{ .Values.acme.server }}
+    email: {{ .Values.acme.email }}
+    privateKeySecretRef:
+      name: letsencrypt-{{ template "preferences.name" . }}
+    dns01:
+      providers:
+      - name: default
+        clouddns:
+          project: {{ required "A valid GCP Project id required for acme.clouddnsProject!" .Values.acme.clouddnsProject }}

--- a/shared/charts/gpii-preferences/values.yaml
+++ b/shared/charts/gpii-preferences/values.yaml
@@ -21,9 +21,10 @@ rollingUpdate:
   maxSurge: 25%
   maxUnavailable: 25%
 
-issuerRef:
-  name: letsencrypt-production
-  kind: Issuer
+acme:
+  server: https://acme-staging-v02.api.letsencrypt.org/directory
+  email: dev-null@raisingthefloor.org
+  clouddnsProject:
 
 dnsNames:
 - preferences.test.local


### PR DESCRIPTION
This is just updated original  PR #342, since we solved the issue with wildcard DNS. CP of original text:

This PR moves Let's Encrypt ACME certificate validation to DNS challenge (prereq to Istio deployment). It also addresses couple of related issues (see [GPII-3781](https://issues.gpii.net/browse/GPII-3781) for detials ).

Changes introduced:
- Change ACME validation method to `dns01`
- ~Add dedicated service account for `cert-manager` for DNS challenge~ - this has already been merged in
- Move `cert-manager` (Cluster)Issuer inside `gpii-flowmanager` and `gpii-preferences` charts
- Change email used for Let's encrypt to `ops@`, or individual user emails for non-prod/stg envs

Since current implementation of ClusterIssuer will leave resources behind, cleanup should be done in non-ephemeral envs:
```
kubectl delete clusterissuer letsencrypt-production
kubectl delete clusterissuer letsencrypt-production
```

- [ ] Cleanup STG
- [ ] Cleanup PRD