### PR TITLE
[GPII-3642]: Add :grant_org_admin, :revoke_org_admin tasks

### DIFF
--- a/gcp/PERMISSIONS.md
+++ b/gcp/PERMISSIONS.md
@@ -83,12 +83,12 @@ If you are an operator and you need to assign new permissions to your user in or
 
 This can be done with the following rake commands:
 
-* `rake grant_owner_role` attaches the owner role in the current project to the current user account.
-* `rake revoke_owner_role` removes the owner role in the current project from the current user account.
-* `rake grant_super_powers` attaches organization-level super user roles to the current user account.
-* `rake revoke_super_powers` removes organization-level super user roles from the current user account.
+* `rake grant_project_admin` attaches the owner role in the current project to the current user account.
+* `rake revoke_project_admin` removes the owner role in the current project from the current user account.
+* `rake grant_org_admin` attaches organization-level super user roles to the current user account.
+* `rake revoke_org_admin` removes organization-level super user roles from the current user account.
 
 Or if you working with other developer's dev project:
 
-* `USER=<developer_user> rake grant_owner_role`
-* `USER=<developer_user> rake revoke_owner_role`
+* `USER=<developer_user> rake grant_project_admin`
+* `USER=<developer_user> rake revoke_project_admin`

--- a/gcp/PERMISSIONS.md
+++ b/gcp/PERMISSIONS.md
@@ -41,7 +41,7 @@ Accounts and permissions
 
   *Note that the `projectowner@gpii-common-prd.iam.gserviceaccount.com` is the owner of the gpii-common-prd project*
 
-### [PROJECT_NUMBER]-compute@developer.gserviceaccount.com   
+### [PROJECT_NUMBER]-compute@developer.gserviceaccount.com
 
   Compute Engine default service account
 
@@ -54,34 +54,38 @@ Accounts and permissions
   1. Editor
 
 ### service-[PROJECT_NUMBER]@compute-system.iam.gserviceaccount.com (Google-managed service account)
-  
+
   Google-managed service account used to access the APIs of Google Cloud Platform services.
 
   1. Compute Engine Service Agent
-  
+
 ### service-[PROJECT_NUMBER]@container-engine-robot.iam.gserviceaccount.com (Google-managed service account)
-  
-  Google-managed service account used to access the APIs of Google Cloud Platform services. 
+
+  Google-managed service account used to access the APIs of Google Cloud Platform services.
 
   1. Kubernetes Engine Service Agent
 
 ### service-[PROJECT_NUMBER]@containerregistry.iam.gserviceaccount.com (Google-managed service account)
 
-  Google-managed service account used to access the APIs of Google Cloud Platform services. 
+  Google-managed service account used to access the APIs of Google Cloud Platform services.
 
   1. Editor
 
 Privilege escalation
 ====================
 
-If you are an operator and you need to assign new permissions to your user in order to make changes in a cluster you will need to attach some IAM roles to your user.
+If you are an operator and you need to assign new permissions to your user in order to make changes in a cluster or if you want to manage Security Command Center settings or security sources, you will need to attach the following IAM roles to your user:
 
-Rake commands:
+* `roles/owner` in the current project.
+* `roles/iam.serviceAccountAdmin` in the current organization.
+* `roles/securitycenter.admin` in the current organization.
 
-  * `rake grant_owner_role` Attaches the owner role to the current user account
-  * `rake revoke_owner_role` Removes the owner role from the current user account
+This can be done with the following rake commands:
 
-  In the case of a developer's dev project:
+* `rake grant_super_powers` attaches the owner role in the current project and organization-level super user roles to the current user account.
+* `rake revoke_super_powers` removes the owner role in the current project and organization-level super user roles from the current user account.
 
-  * `USER=<developer_user> rake grant_owner_role`
-  * `USER=<developer_user> rake revoke_owner_role`
+Or if you working with other developer's dev project:
+
+* `USER=<developer_user> rake grant_super_powers`
+* `USER=<developer_user> rake revoke_super_powers`

--- a/gcp/PERMISSIONS.md
+++ b/gcp/PERMISSIONS.md
@@ -24,7 +24,7 @@ Accounts and permissions
 
 ### [DEV_USER]@raisingthefloor.org
 
-  The developers can have their own development cluster managed by this account. This account only exists in the _dev_ projects, where a particular user is the owner of the whole project. In the case of the STG and PRD projects there is not a particular owner.
+  Developers can have their own development cluster managed by this account. This account only exists in their dev projects, where a particular user is the owner of the whole project. There is no particular owner in staging or production projects.
 
   1. Owner
 
@@ -83,10 +83,12 @@ If you are an operator and you need to assign new permissions to your user in or
 
 This can be done with the following rake commands:
 
-* `rake grant_super_powers` attaches the owner role in the current project and organization-level super user roles to the current user account.
-* `rake revoke_super_powers` removes the owner role in the current project and organization-level super user roles from the current user account.
+* `rake grant_owner_role` attaches the owner role in the current project to the current user account.
+* `rake revoke_owner_role` removes the owner role in the current project from the current user account.
+* `rake grant_super_powers` attaches organization-level super user roles to the current user account.
+* `rake revoke_super_powers` removes organization-level super user roles from the current user account.
 
 Or if you working with other developer's dev project:
 
-* `USER=<developer_user> rake grant_super_powers`
-* `USER=<developer_user> rake revoke_super_powers`
+* `USER=<developer_user> rake grant_owner_role`
+* `USER=<developer_user> rake revoke_owner_role`

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -338,28 +338,28 @@ task :destroy_module, [:module] => [:set_vars, :check_destroy_allowed, :fetch_he
 end
 
 desc "[ADMIN ONLY] Grant owner role in the current project to the current user"
-task :grant_owner_role => [:set_vars] do
-  sh "#{@exekube_cmd} rake grant_owner_role"
+task :grant_project_admin => [:set_vars] do
+  sh "#{@exekube_cmd} rake grant_project_admin"
 end
 
 desc "[ADMIN ONLY] Revoke owner role in the current project from the current user"
-task :revoke_owner_role, [:force] => [:set_vars] do |taskname, args|
+task :revoke_project_admin, [:force] => [:set_vars] do |taskname, args|
   if !args[:force] and ENV['TF_VAR_project_id'].match("dev-#{ENV['USER']}")
-    puts "  ERROR: You can not revoke owner role from yourself in your own dev project!"
-    puts "         Run `rake revoke_owner_role[true]` to do this anyway."
+    puts "  ERROR: You can not revoke project admin role from yourself in your own dev project!"
+    puts "         Run `rake revoke_project_admin[true]` to do this anyway."
     exit 1
   end
-  sh "#{@exekube_cmd} rake revoke_owner_role"
+  sh "#{@exekube_cmd} rake revoke_project_admin"
 end
 
-desc "[ADMIN ONLY] Grant org-level super powers to the current user"
-task :grant_super_powers => [:set_vars] do
-  sh "#{@exekube_cmd} rake grant_super_powers"
+desc "[ADMIN ONLY] Grant org-level admin roles to the current user"
+task :grant_org_admin => [:set_vars] do
+  sh "#{@exekube_cmd} rake grant_org_admin"
 end
 
-desc "[ADMIN ONLY] Revoke org-level super powers from the current user"
-task :revoke_super_powers => [:set_vars] do
-  sh "#{@exekube_cmd} rake revoke_super_powers"
+desc "[ADMIN ONLY] Revoke org-level admin roles from the current user"
+task :revoke_org_admin => [:set_vars] do
+  sh "#{@exekube_cmd} rake revoke_org_admin"
 end
 
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -337,14 +337,14 @@ task :destroy_module, [:module] => [:set_vars, :check_destroy_allowed, :fetch_he
   sh "#{@exekube_cmd} rake xk['destroy live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
-desc "[ADMIN ONLY] Grant owner role to the current user"
-task :grant_owner_role => [:set_vars] do
-  sh "#{@exekube_cmd} rake grant_owner_role"
+desc "[ADMIN ONLY] Grant super powers to the current user"
+task :grant_super_powers => [:set_vars] do
+  sh "#{@exekube_cmd} rake grant_super_powers"
 end
 
-desc "[ADMIN ONLY] Revoke owner role to the current user"
-task :revoke_owner_role => [:set_vars] do
-  sh "#{@exekube_cmd} rake revoke_owner_role"
+desc "[ADMIN ONLY] Revoke super powers from the current user"
+task :revoke_super_powers => [:set_vars] do
+  sh "#{@exekube_cmd} rake revoke_super_powers"
 end
 
 

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -337,15 +337,29 @@ task :destroy_module, [:module] => [:set_vars, :check_destroy_allowed, :fetch_he
   sh "#{@exekube_cmd} rake xk['destroy live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
 end
 
-desc "[ADMIN ONLY] Grant super powers to the current user"
+desc "[ADMIN ONLY] Grant owner role in the current project to the current user"
+task :grant_owner_role => [:set_vars] do
+  sh "#{@exekube_cmd} rake grant_owner_role"
+end
+
+desc "[ADMIN ONLY] Revoke owner role in the current project from the current user"
+task :revoke_owner_role, [:force] => [:set_vars] do |taskname, args|
+  if !args[:force] and ENV['TF_VAR_project_id'].match("dev-#{ENV['USER']}")
+    puts "  ERROR: You can not revoke owner role from yourself in your own dev project!"
+    puts "         Run `rake revoke_owner_role[true]` to do this anyway."
+    exit 1
+  end
+  sh "#{@exekube_cmd} rake revoke_owner_role"
+end
+
+desc "[ADMIN ONLY] Grant org-level super powers to the current user"
 task :grant_super_powers => [:set_vars] do
   sh "#{@exekube_cmd} rake grant_super_powers"
 end
 
-desc "[ADMIN ONLY] Revoke super powers from the current user"
+desc "[ADMIN ONLY] Revoke org-level super powers from the current user"
 task :revoke_super_powers => [:set_vars] do
   sh "#{@exekube_cmd} rake revoke_super_powers"
 end
-
 
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -1,6 +1,6 @@
-organization_super_user_roles = [
+org_admin_roles = [
   "roles/iam.serviceAccountAdmin",
-  "roles/securitycenter.admin"
+  "roles/securitycenter.admin",
 ]
 
 # This task rotates target args[:secret].
@@ -185,7 +185,7 @@ task :display_universal_image_info => [:configure] do
 end
 
 # This task grants the owner role in the current project to the current user
-task :grant_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
+task :grant_project_admin => [@gcp_creds_file, :configure_extra_tf_vars] do
   sh "
     gcloud projects add-iam-policy-binding \"$TF_VAR_project_id\" \
       --member user:\"$TF_VAR_auth_user_email\" \
@@ -194,7 +194,7 @@ task :grant_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
 end
 
 # This task revokes the owner role in the current project from the current user
-task :revoke_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
+task :revoke_project_admin => [@gcp_creds_file, :configure_extra_tf_vars] do
   sh "
     gcloud projects remove-iam-policy-binding \"$TF_VAR_project_id\" \
       --member user:\"$TF_VAR_auth_user_email\" \
@@ -202,18 +202,18 @@ task :revoke_owner_role => [@gcp_creds_file, :configure_extra_tf_vars] do
   "
 end
 
-# This task grants organization roles declared in organization_super_user_roles to the current user
-task :grant_super_powers => [@gcp_creds_file, :configure_extra_tf_vars] do
-  organization_super_user_roles.each do |role|
+# This task grants organization roles declared in org_admin_roles to the current user
+task :grant_org_admin => [@gcp_creds_file, :configure_extra_tf_vars] do
+  org_admin_roles.each do |role|
     sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
       --member user:\"$TF_VAR_auth_user_email\" \
       --role #{role}"
   end
 end
 
-# This task revokes organization roles declared in organization_super_user_roles from the current user
-task :revoke_super_powers => [@gcp_creds_file, :configure_extra_tf_vars] do
-  organization_super_user_roles.each do |role|
+# This task revokes organization roles declared in org_admin_roles from the current user
+task :revoke_org_admin => [@gcp_creds_file, :configure_extra_tf_vars] do
+  org_admin_roles.each do |role|
     sh "#{@exekube_cmd} gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
       --member user:\"$TF_VAR_auth_user_email\" \
       --role #{role}"


### PR DESCRIPTION
This PR changes `:grant_owner_role`, `:revoke_owner_role` tasks into tasks that along with owner role in current project grant / revoke org-level super permissions (which are required for SCC administration operations).

The downside of current implementation is that now there is no way to automatically revoke org-level permissions, since we do not enforce org-level IAM policy. I'll think what can be done to improve this.