### PR TITLE
[GPII-3865]: Improve the way we set organization-level permissions

### DIFF
--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -8,11 +8,11 @@ task :apply_common_infra => [:set_vars, :configure_aws_restore] do
 end
 
 desc "[ONLY ADMIN] Set permissions for admin accounts in the organization"
-task :set_organization_permissions => [:set_vars] do
+task :set_org_perms => [:set_vars] do
   # This task sets the permissions in the organization for creating the
   # projects and for setting the IAMs needed to manage such projects.
   #
   # Due to the needed permissions for setting such permissions, only an
   # administrator of the organization must run this task.
-  sh "#{@exekube_cmd} rake set_organization_permissions"
+  sh "#{@exekube_cmd} rake set_org_perms"
 end

--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -7,12 +7,12 @@ task :apply_common_infra => [:set_vars, :configure_aws_restore] do
   sh "#{@exekube_cmd} rake apply_common_infra"
 end
 
-desc "[ONLY ADMIN] Fix the permissions for admin accounts in the organization"
-task :fix_organization_permissions => [:set_vars] do
+desc "[ONLY ADMIN] Set permissions for admin accounts in the organization"
+task :set_organization_permissions => [:set_vars] do
   # This task sets the permissions in the organization for creating the
   # projects and for setting the IAMs needed to manage such projects.
   #
   # Due to the needed permissions for setting such permissions, only an
   # administrator of the organization must run this task.
-  sh "#{@exekube_cmd} rake fix_organization_permissions"
+  sh "#{@exekube_cmd} rake set_organization_permissions"
 end

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -19,6 +19,17 @@ cloud_admin_org_roles = [
   "roles/viewer",
 ]
 
+project_services = [
+  "cloudresourcemanager.googleapis.com",
+  "cloudbilling.googleapis.com",
+  "containeranalysis.googleapis.com",
+  "containerregistry.googleapis.com",
+  "iam.googleapis.com",
+  "dns.googleapis.com",
+  "compute.googleapis.com",
+  "securitycenter.googleapis.com",
+]
+
 task :refresh_common_infra, [:project_type] => [@gcp_creds_file, @app_default_creds_file, :configure_extra_tf_vars] do | taskname, args|
 
   next if args[:project_type] == "common"
@@ -92,14 +103,7 @@ task :apply_common_infra => [@gcp_creds_file] do
   }
   services_list = JSON.parse(services_list)
 
-  ["cloudresourcemanager.googleapis.com",
-   "cloudbilling.googleapis.com",
-   "containeranalysis.googleapis.com",
-   "containerregistry.googleapis.com",
-   "iam.googleapis.com",
-   "dns.googleapis.com",
-   "compute.googleapis.com",
-   "securitycenter.googleapis.com"].each do |service|
+  project_services.each do |service|
      sh "#{@exekube_cmd} gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
   end
 

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -39,7 +39,7 @@ task :refresh_common_infra, [:project_type] => [@gcp_creds_file, @app_default_cr
   # DNS zone.
 
   dns_zone_found = %x{
-    #{@exekube_cmd} sh -c " \
+    sh -c " \
     terragrunt state show module.gke_network.google_dns_managed_zone.dns_zones \
     --terragrunt-working-dir /project/live/#{@env}/infra/network 2>/dev/null \
   "}
@@ -47,14 +47,14 @@ task :refresh_common_infra, [:project_type] => [@gcp_creds_file, @app_default_cr
   if dns_zone_found.empty?
     # The DNS zone is not in the TF state file, we need to add it
     puts "DNS zone #{ENV["TF_VAR_domain_name"].tr('.','-')} not found in TF state, importing..."
-    sh "#{@exekube_cmd} sh -c ' \
+    sh "sh -c ' \
       terragrunt import module.gke_network.google_dns_managed_zone.dns_zones #{ENV["TF_VAR_domain_name"].tr('.','-')} \
       --terragrunt-working-dir /project/live/#{@env}/infra/network \
     '"
   else
     # The DNS zone is in the TF state file, we will refresh it just in case
     puts "DNS zone #{ENV["TF_VAR_domain_name"].tr('.','-')} found in TF state, refreshing..."
-    sh "#{@exekube_cmd} sh -c ' \
+    sh "sh -c ' \
       terragrunt refresh \
       --terragrunt-working-dir /project/live/#{@env}/infra/network \
     '"
@@ -71,48 +71,48 @@ task :apply_common_infra => [@gcp_creds_file] do
   # administrator of the organization can run this task.
 
   projects_list = %x{
-    #{@exekube_cmd} gcloud projects list --format='json' --filter='name:#{ENV["TF_VAR_project_id"]}'
+    gcloud projects list --format='json' --filter='name:#{ENV["TF_VAR_project_id"]}'
   }
   projects_list = JSON.parse(projects_list)
   if projects_list.empty?
     puts "#{ENV["TF_VAR_project_id"]} not found, I'll create a new one"
-    sh "#{@exekube_cmd} gcloud projects create #{ENV["TF_VAR_project_id"]} \
+    sh "gcloud projects create #{ENV["TF_VAR_project_id"]} \
       --organization #{ENV["ORGANIZATION_ID"]} \
       --set-as-default"
   end
 
   Rake::Task[:configure_current_project].invoke
 
-  sh "#{@exekube_cmd} gcloud beta billing projects link #{ENV["TF_VAR_project_id"]} \
+  sh "gcloud beta billing projects link #{ENV["TF_VAR_project_id"]} \
     --billing-account #{ENV["BILLING_ID"]}"
 
   sa_list = %x{
-    #{@exekube_cmd} gcloud iam service-accounts list --format='json' \
+    gcloud iam service-accounts list --format='json' \
     --filter='email:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com'
   }
   sa_list = JSON.parse(sa_list)
   if sa_list.empty?
-    sh "#{@exekube_cmd} gcloud iam service-accounts create projectowner --display-name 'CI account'"
+    sh "gcloud iam service-accounts create projectowner --display-name 'CI account'"
   end
 
   Rake::Task[:configure_serviceaccount].invoke
   Rake::Task[:set_org_perms].invoke
 
   services_list = %x{
-    #{@exekube_cmd} gcloud services list --format='json'
+    gcloud services list --format='json'
   }
   services_list = JSON.parse(services_list)
 
   project_services.each do |service|
-     sh "#{@exekube_cmd} gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
+     sh "gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
   end
 
   tfstate_bucket = %x{
-    #{@exekube_cmd} gsutil ls | grep 'gs://#{ENV["TF_VAR_project_id"]}-tfstate'
+    gsutil ls | grep 'gs://#{ENV["TF_VAR_project_id"]}-tfstate'
   }
   unless tfstate_bucket
-    sh "#{@exekube_cmd} gsutil mb gs://#{ENV["TF_VAR_project_id"]}-tfstate"
-    sh "#{@exekube_cmd} gsutil versioning set on gs://#{ENV["TF_VAR_project_id"]}-tfstate"
+    sh "gsutil mb gs://#{ENV["TF_VAR_project_id"]}-tfstate"
+    sh "gsutil versioning set on gs://#{ENV["TF_VAR_project_id"]}-tfstate"
   end
 end
 
@@ -120,18 +120,18 @@ task :set_org_perms => [@gcp_creds_file] do
   # Remove org-level roles from individual user accounts if found,
   # to forcefully revoke all org-level permissions granted by :grant_org_admin
   user_roles = %x{
-    #{@exekube_cmd} gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
+    gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
     --filter bindings.members:user:* \
     --flatten="bindings[].members" \
     --format json | jq -r ".[].bindings.members"
   }.split.uniq.each do |user|
     existing_user_roles = %x{
-      #{@exekube_cmd} gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
+      gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
       --filter bindings.members:#{user} \
       --flatten="bindings[].members" \
       --format json | jq -r ".[].bindings.role"
     }.split.each do |role|
-      sh "#{@exekube_cmd} gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
+      sh "gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
         --member #{user} \
         --role #{role}"
     end
@@ -144,7 +144,7 @@ task :set_org_perms => [@gcp_creds_file] do
   }
   members.each do |member, expected_roles|
     existing_roles = %x{
-      #{@exekube_cmd} gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
+      gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
       --filter bindings.members:#{member} \
       --flatten="bindings[].members" \
       --format json | jq -r ".[].bindings.role"
@@ -154,12 +154,12 @@ task :set_org_perms => [@gcp_creds_file] do
     roles_to_remove = existing_roles - expected_roles
 
     roles_to_add.each do |role|
-      sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
+      sh "gcloud organizations add-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
         --member #{member} \
         --role #{role}"
     end
     roles_to_remove.each do |role|
-      sh "#{@exekube_cmd} gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
+      sh "gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
         --member #{member} \
         --role #{role}"
     end
@@ -170,7 +170,7 @@ task :set_org_perms => [@gcp_creds_file] do
   # organization IAM settings.
   # Go to the https://console.cloud.google.com/billing/ to see the permissions
   # granted to which SA for using billing services.
-  sh "#{@exekube_cmd} gcloud organizations add-iam-policy-binding 247149361674 \
+  sh "gcloud organizations add-iam-policy-binding 247149361674 \
     --member serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com \
     --role roles/billing.user"
 end


### PR DESCRIPTION
Summary of changes:
* Every time `:apply_common_infra` runs, it invokes `:set_org_perms` that
  1. Removes all roles from individual user accounts (to revoke perms granted to operators by `:grant_org_admin`).
  1. For common SA, cloud-admin group and Eugene's account: it ensures that only expected set of permissions is present, removes all unexpected roles.
* Refactored `:refresh_common_infra` and related tasks.
  