### PR TITLE
GPII-3641 GPII-3861 GPII-3871 GPII-3856 GPII-3857 Various fixes

### DIFF
--- a/CI-CD.md
+++ b/CI-CD.md
@@ -55,6 +55,7 @@ Examples of things that get credentials this way include: CouchDB, Alertmanager.
    * Add the contents of the Key file to `vault.yml`.
    * Apply the ansible role [ansible-gpii-version-updater](https://github.com/idi-ops/ansible-gpii-version-updater) to the build node.
       * The [internal ansible repo](https://github.com/inclusive-design/ops) has a playbook to do this: `config_host_gpii_version_updater.yml`.
+      * You'll need the ssh key you [configured with Github](#configure-github).
 
 ### Configure AWS (DEPRECATED)
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -167,25 +167,15 @@ See [CI-CD.md#running-in-non-dev-environments](../CI-CD.md#running-manually-in-n
 
 ### I want to test my local changes to GPII components in my cluster
 
-*NOTE:* This workflow is outdated until https://issues.gpii.net/browse/GPII-3861 is completed.
-
 1. Build a local Docker image containing your changes.
-1. Push your image to Docker Hub under your user account.
-1. Clone https://github.com/gpii-ops/gpii-version-updater/.
-1. Edit `components.conf`. Find your component and edit the `image` field to point to your Docker Hub user account.
+1. Push your image to Docker Hub under your user account (e.g. `docker build -t mrtyler/universal . && docker push mrtyler/universal`).
+1. Edit `gpii-infra/shared/versions.yml`. Find your component and edit the `upstream.repository` field to point to your Docker Hub user account.
    * E.g., `gpii/universal -> mrtyler/universal`
-1. Run `./update-version versions.yml`. It will generate a `versions.yml` in the current directory.
-1. `cp versions.yml ../gpii-infra/shared`
-1. `cd ../gpii-infra/gcp/live/dev && rake`
-
-#### Can't I just edit `versions.yml` by hand?
-
-gpii-infra uses explicit SHAs to refer to specific Docker images for GPII components. This has a number of advantages (repeatability, auditability) but the main thing you care about is that changing the SHA forces Kubernetes to re-deploy a component.
-
-If you don't want to deal with gpii-version-updater, you can instead:
-1. Edit `shared/versions.yml`. Find your component and replace the entire image value (path and SHA) with your Docker Hub user account.
-   * E.g., `flowmanager: "gpii/universal@sha256:4b3...64f" -> flowmanager: "mrtyler/universal"`
-1. Manually delete the component via Kubernetes Dashboard or with `kubectl delete`.
+1. Clone https://github.com/gpii-ops/gpii-version-updater/ in the same directory as your gpii-infra clone.
+   * The `gpii-version-updater` clone and the `gpii-infra` clone should be siblings in the same directory (there are some references to `../gpii-infra`).
+1. `cd gpii-version-updater`
+1. Follow the steps at [gpii-version-updater: Installing on host](https://github.com/gpii-ops/gpii-version-updater/#installing-on-host) (or [gpii-version-updater: Running in a container](https://github.com/gpii-ops/gpii-version-updater/#running-in-a-container).
+1. `rake sync`
 1. `cd ../gpii-infra/gcp/live/dev && rake`
 
 ### I need to interact with Helm directly, e.g. because a Helm deployment was orphaned due to an error while running `rake`

--- a/gcp/modules/couchdb-prometheus-exporter/main.tf
+++ b/gcp/modules/couchdb-prometheus-exporter/main.tf
@@ -25,7 +25,7 @@ data "template_file" "couchdb_prometheus_exporter_values" {
     couchdb_admin_username                      = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password                      = "${var.secret_couchdb_admin_password}"
     couchdb_prometheus_exporter_repository      = "${var.couchdb_prometheus_exporter_repository}"
-    couchdb_prometheus_exporter_tag        = "${var.couchdb_prometheus_exporter_tag}"
+    couchdb_prometheus_exporter_tag             = "${var.couchdb_prometheus_exporter_tag}"
     couchdb_prometheus_exporter_p2sd_repository = "${var.couchdb_prometheus_exporter_p2sd_repository}"
     couchdb_prometheus_exporter_p2sd_tag        = "${var.couchdb_prometheus_exporter_p2sd_tag}"
     replica_count                               = "${var.replica_count}"

--- a/gcp/modules/couchdb-prometheus-exporter/main.tf
+++ b/gcp/modules/couchdb-prometheus-exporter/main.tf
@@ -5,7 +5,7 @@ terraform {
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "couchdb_prometheus_exporter_repository" {}
-variable "couchdb_prometheus_exporter_checksum" {}
+variable "couchdb_prometheus_exporter_tag" {}
 variable "couchdb_prometheus_exporter_p2sd_repository" {}
 variable "couchdb_prometheus_exporter_p2sd_tag" {}
 
@@ -25,7 +25,7 @@ data "template_file" "couchdb_prometheus_exporter_values" {
     couchdb_admin_username                      = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password                      = "${var.secret_couchdb_admin_password}"
     couchdb_prometheus_exporter_repository      = "${var.couchdb_prometheus_exporter_repository}"
-    couchdb_prometheus_exporter_checksum        = "${var.couchdb_prometheus_exporter_checksum}"
+    couchdb_prometheus_exporter_tag        = "${var.couchdb_prometheus_exporter_tag}"
     couchdb_prometheus_exporter_p2sd_repository = "${var.couchdb_prometheus_exporter_p2sd_repository}"
     couchdb_prometheus_exporter_p2sd_tag        = "${var.couchdb_prometheus_exporter_p2sd_tag}"
     replica_count                               = "${var.replica_count}"

--- a/gcp/modules/couchdb-prometheus-exporter/values.yaml
+++ b/gcp/modules/couchdb-prometheus-exporter/values.yaml
@@ -6,7 +6,7 @@ couchdbPassword: ${couchdb_admin_password}
 
 image:
   repository: ${couchdb_prometheus_exporter_repository}
-  checksum: ${couchdb_prometheus_exporter_checksum}
+  tag: ${couchdb_prometheus_exporter_tag}
   prometheusToSdExporter:
     repository: ${couchdb_prometheus_exporter_p2sd_repository}
     tag: ${couchdb_prometheus_exporter_p2sd_tag}

--- a/shared/charts/couchdb-prometheus-exporter/README.md
+++ b/shared/charts/couchdb-prometheus-exporter/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `couchdbPassword` | password for couchdb uri | `password`
 `couchdbDatabases` | list of specific databases to monitor | `_all_dbs`
 `image.repository` | container image repository | `gesellix/couchdb-prometheus-exporter`
-`image.checksum` | container image checksum | `sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2`
+`image.tag` | container image checksum | `22`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`
 `image.prometheusToSdExporter.repository` | prometheus-to-sd container image repository | `gcr.io/google-containers/prometheus-to-sd`
 `image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.5.1`

--- a/shared/charts/couchdb-prometheus-exporter/README.md
+++ b/shared/charts/couchdb-prometheus-exporter/README.md
@@ -56,6 +56,6 @@ Parameter | Description | Default
 `image.checksum` | container image checksum | `sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`
 `image.prometheusToSdExporter.repository` | prometheus-to-sd container image repository | `gcr.io/google-containers/prometheus-to-sd`
-`image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.3.2`
+`image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.5.1`
 `image.pullPolicy` | prometheus-to-sd container image pullPolicy | `IfNotPresent`
 `resources` | optional resource requests and limits for deployment | `requests:`<br/>&nbsp;&nbsp;`cpu: 10m`<br/>&nbsp;&nbsp;`memory: 60Mi`<br/>`limits:`<br/>&nbsp;&nbsp;`cpu: 10m`<br/>&nbsp;&nbsp;`memory: 60Mi`

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: couchdb-prometheus-exporter
-        image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -logtostderr

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: prometheus-to-sd
-        image: "{{ .Values.prometheusToSdExporter.image.repository }}:{{ .Values.prometheusToSdExporter.image.tag }}"
+        image: "{{ .Values.image.prometheusToSdExporter.repository }}:{{ .Values.image.prometheusToSdExporter.tag }}"
         imagePullPolicy: {{ .Values.prometheusToSdExporter.image.pullPolicy }}
         command:
           - /monitor

--- a/shared/charts/couchdb-prometheus-exporter/values.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/values.yaml
@@ -12,7 +12,7 @@ couchdbDatabases: _all_dbs
 
 image:
   repository: gesellix/couchdb-prometheus-exporter
-  checksum: sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2
+  tag: 22
   pullPolicy: IfNotPresent
 
 prometheusToSdExporter:

--- a/shared/charts/couchdb-prometheus-exporter/values.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/values.yaml
@@ -18,7 +18,7 @@ image:
 prometheusToSdExporter:
   image:
     repository: gcr.io/google-containers/prometheus-to-sd
-    tag: v0.3.2
+    tag: v0.5.1
     pullPolicy: IfNotPresent
 
 ## Optional resource requests and limits for deployment

--- a/shared/charts/nginx-ingress/Chart.yaml
+++ b/shared/charts/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: nginx-ingress
-version: 0.22.1
-appVersion: 0.15.0
+version: 1.6.0
+appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -14,6 +14,4 @@ maintainers:
     email: jack.zampolin@gmail.com
   - name: mgoodness
     email: mgoodness@gmail.com
-  - name: chancez
-    email: chance.zibolski@coreos.com
 engine: gotpl

--- a/shared/charts/nginx-ingress/OWNERS
+++ b/shared/charts/nginx-ingress/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jackzampolin
+- mgoodness
+reviewers:
+- jackzampolin
+- mgoodness

--- a/shared/charts/nginx-ingress/README.md
+++ b/shared/charts/nginx-ingress/README.md
@@ -47,11 +47,13 @@ Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.15.0`
+`controller.image.tag` | controller container image tag | `0.24.1`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
+`controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses debian one. | `33`
 `controller.config` | nginx ConfigMap entries | none
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.dnsPolicy` | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`. See [pod's dns policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details | `ClusterFirst`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
 `controller.extraContainers` | Sidecar containers to add to the controller pod. See [LemonLDAP::NG controller](https://github.com/lemonldap-ng-controller/lemonldap-ng-controller) as example | `{}`
@@ -66,14 +68,17 @@ Parameter | Description | Default
 `controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
+`controller.daemonset.hostPorts.stats` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"18080"`
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
+`controller.podLabels` | labels to add to the pod container metadata | `{}`
 `controller.replicaCount` | desired number of controller pods | `1`
 `controller.minAvailable` | minimum number of available controller pods for PodDisruptionBudget | `1`
 `controller.resources` | controller pod resource requests & limits | `{}`
+`controller.priorityClassName` | controller priorityClassName | `nil`
 `controller.lifecycle` | controller pod lifecycle hooks | `{}`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
@@ -115,27 +120,34 @@ Parameter | Description | Default
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
 `controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
 `controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
+`controller.metrics.service.labels` | labels for metrics service | `{}`
 `controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
-`controller.metrics.service.targetPort` | Prometheus metrics target port | `10254`
 `controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
+`controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
+`defaultBackend.enabled` | If false, controller.defaultBackendService must be provided | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend`
-`defaultBackend.image.tag` | default backend container image tag | `1.3`
+`defaultBackend.image.tag` | default backend container image tag | `1.4`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
+`defaultBackend.port` | Http port number | `8080`
 `defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
 `defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
+`defaultBackend.podLabels` | labels to add to the pod container metadata | `{}`
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
 `defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
+`defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
@@ -144,6 +156,7 @@ Parameter | Description | Default
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
 `imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
 `rbac.create` | if `true`, create & use RBAC resources | `true`
+`podSecurityPolicy.enabled` | if `true`, create & use Pod Security Policy resources | `false`
 `serviceAccount.create` | if `true`, create a service account | ``
 `serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
@@ -167,6 +180,11 @@ as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs
 ```console
 $ helm install stable/nginx-ingress --set controller.extraArgs.v=2
 ```
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## PodDisruptionBudget
+Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
+else it would make it impossible to evacuate a node. See [gh issue #7127](https://github.com/helm/charts/issues/7127) for more info.
 
 ## Prometheus Metrics
 
@@ -178,27 +196,7 @@ $ helm install stable/nginx-ingress --name my-release \
     --set controller.metrics.enabled=true
 ```
 
-You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you need to create a ServiceMonitor as follows:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: nginx-ingress-service-monitor
-spec:
-  jobLabel: nginx-ingress
-  selector:
-    matchLabels:
-      app: nginx-ingress
-      release: <RELEASE>
-  namespaceSelector:
-    matchNames:
-      - <RELEASE_NAMESPACE>
-  endpoints:
-    - port: metrics
-      interval: 30s
-```
-> **Tip**: You can use the default [values.yaml](values.yaml)
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
 
 ## ExternalDNS Service configuration
 

--- a/shared/charts/nginx-ingress/ci/psp-values.yaml
+++ b/shared/charts/nginx-ingress/ci/psp-values.yaml
@@ -1,0 +1,2 @@
+podSecurityPolicy:
+  enabled: true

--- a/shared/charts/nginx-ingress/templates/_helpers.tpl
+++ b/shared/charts/nginx-ingress/templates/_helpers.tpl
@@ -11,11 +11,15 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -24,12 +28,7 @@ Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.controller.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -52,12 +51,7 @@ Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.defaultBackend.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/shared/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -17,10 +17,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
-    {{- if .Values.controller.podAnnotations }}
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
-    {{- end }}
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"
@@ -34,6 +33,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -75,6 +77,15 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -114,6 +125,9 @@ spec:
             - name: stats
               containerPort: 18080
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.stats }}
+              {{- end }}
             {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254
@@ -149,7 +163,7 @@ spec:
               readOnly: true
 {{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
-{{ toYaml .Values.controller.extraVolumeMounts | indent 10}}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
 {{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
@@ -187,6 +201,6 @@ spec:
               path: nginx.tmpl
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
-{{ toYaml .Values.controller.extraVolumes | indent 6}}
+{{ toYaml .Values.controller.extraVolumes | indent 8}}
 {{- end }}
 {{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -19,7 +19,9 @@ spec:
     metadata:
       {{- if .Values.controller.podAnnotations }}
       annotations:
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
@@ -34,6 +36,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -74,6 +79,15 @@ spec:
             {{- else }}
             - --{{ $key }}
             {{- end }}
+          {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/shared/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -4,9 +4,14 @@ kind: Service
 metadata:
 {{- if .Values.controller.metrics.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.metrics.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
+{{- if .Values.controller.metrics.service.labels }}
+{{ toYaml .Values.controller.metrics.service.labels | indent 4 }}
+{{- end }}
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"

--- a/shared/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.controller.replicaCount 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.controller.name }}"
   minAvailable: {{ .Values.controller.minAvailable }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-service.yaml
@@ -3,7 +3,9 @@ kind: Service
 metadata:
 {{- if .Values.controller.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
 {{- if .Values.controller.service.labels }}

--- a/shared/charts/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+  {{- if .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
 {{- if .Values.controller.stats.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.stats.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}

--- a/shared/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -16,7 +16,9 @@ spec:
     metadata:
     {{- if .Values.defaultBackend.podAnnotations }}
       annotations:
-{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
+      {{- range $key, $value := .Values.defaultBackend.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
@@ -30,6 +32,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.defaultBackend.priorityClassName }}
+      priorityClassName: "{{ .Values.defaultBackend.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
@@ -45,16 +50,17 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: {{ .Values.defaultBackend.port }}
               scheme: HTTP
             initialDelaySeconds: 30
             timeoutSeconds: 5
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.defaultBackend.port }}
               protocol: TCP
           resources:
 {{ toYaml .Values.defaultBackend.resources | indent 12 }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
     {{- if .Values.defaultBackend.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}

--- a/shared/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.defaultBackend.replicaCount 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
 {{- if .Values.defaultBackend.service.annotations }}
   annotations:
-{{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.defaultBackend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}

--- a/shared/charts/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/shared/charts/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.podSecurityPolicy.enabled}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "nginx-ingress.fullname" . }} 
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  privileged: false
+  allowPrivilegeEscalation: true
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    #- 'emptyDir'
+    #- 'projected'
+    - 'secret'
+    #- 'downwardAPI'
+  hostNetwork: {{ .Values.controller.hostNetwork }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  seLinux:
+    rule: 'RunAsAny'
+  hostPorts:
+    - max: 65535
+      min: 1
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/role.yaml
+++ b/shared/charts/nginx-ingress/templates/role.yaml
@@ -79,4 +79,11 @@ rules:
     verbs:
       - create
       - patch
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "nginx-ingress.fullname" . }}]
+{{- end }}
+
 {{- end -}}

--- a/shared/charts/nginx-ingress/templates/scoped-clusterrole.yaml
+++ b/shared/charts/nginx-ingress/templates/scoped-clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.controller.scope.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/shared/charts/nginx-ingress/templates/scoped-clusterrolebinding.yaml
+++ b/shared/charts/nginx-ingress/templates/scoped-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create .Values.controller.scope.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/shared/charts/nginx-ingress/values.yaml
+++ b/shared/charts/nginx-ingress/values.yaml
@@ -5,8 +5,10 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.15.0"
+    tag: "0.24.1"
     pullPolicy: IfNotPresent
+    # www-data -> uid 33
+    runAsUser: 33
 
   config: {}
   # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
@@ -29,6 +31,8 @@ controller:
     hostPorts:
       http: 80
       https: 443
+      ## healthz endpoint
+      stats: 18080
 
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
@@ -145,10 +149,10 @@ controller:
 
   autoscaling:
     enabled: false
-  #  minReplicas: 1
-  #  maxReplicas: 11
-  #  targetCPUUtilizationPercentage: 50
-  #  targetMemoryUtilizationPercentage: 50
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
   ## Override NGINX template
   customTemplate:
@@ -192,7 +196,7 @@ controller:
       http: ""
       https: ""
 
-  extraContainers: {}
+  extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   #  - name: my-sidecar
@@ -216,12 +220,12 @@ controller:
   #    - name: copy-portal-skins
   #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
 
-  extraVolumeMounts: {}
+  extraVolumeMounts: []
   ## Additional volumeMounts to the controller main container.
   #  - name: copy-portal-skins
   #   mountPath: /var/lib/lemonldap-ng/portal/skins
 
-  extraVolumes: {}
+  extraVolumes: []
   ## Additional volumes to the controller pod.
   #  - name: copy-portal-skins
   #    emptyDir: {}
@@ -272,7 +276,14 @@ controller:
       servicePort: 9913
       type: ClusterIP
 
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+
   lifecycle: {}
+
+  priorityClassName: ""
 
 ## Rollback limit
 ##
@@ -289,10 +300,12 @@ defaultBackend:
   name: default-backend
   image:
     repository: k8s.gcr.io/defaultbackend
-    tag: "1.3"
+    tag: "1.4"
     pullPolicy: IfNotPresent
 
   extraArgs: {}
+
+  port: 8080
 
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -344,9 +357,16 @@ defaultBackend:
     servicePort: 80
     type: ClusterIP
 
+  priorityClassName: ""
+
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: true
+
+# If true, create & use Pod Security Policy resources
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
 
 serviceAccount:
   create: true

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -148,34 +148,44 @@ describe Vars do
   it "set_versions sets TF_VAR_<component>_(repository|checksum|tag)" do
     fake_versions = {
       "flowmanager" => {
-        "upstream_image" => "fake_image:fake_tag",
+        "upstream" => {
+          "repository" => "fake_repository:fake_tag",
+        },
         "generated" => {
-          "image" => "gcr.io/some-project/fake_image",
+          "repository" => "gcr.io/some-project/fake_repository",
           "sha" => "sha256:c0ffee",
           "tag" => "fake_tag",
         },
       },
       "component_without_generated" => {
-        "upstream_image" => "another_fake_image",
+        "upstream" => {
+          "repository" => "another_fake_repository",
+        },
       },
-      "component_without_image" => {
-        "upstream_image" => "another_fake_image",
+      "component_without_repository" => {
+        "upstream" => {
+          "repository" => "another_fake_repository",
+        },
         "generated" => {
           "sha" => "sha256:50da",
           "tag" => "fake_tag",
         },
       },
       "component_without_sha" => {
-        "upstream_image" => "another_fake_image",
+        "upstream" => {
+          "repository" => "another_fake_repository",
+        },
         "generated" => {
-          "image" => "gcr.io/some-project/another_fake_image",
+          "repository" => "gcr.io/some-project/another_fake_repository",
           "tag" => "fake_tag",
         },
       },
       "component_without_tag" => {
-        "upstream_image" => "another_fake_image",
+        "upstream" => {
+          "repository" => "another_fake_repository",
+        },
         "generated" => {
-          "image" => "gcr.io/some-project/another_fake_image",
+          "repository" => "gcr.io/some-project/another_fake_repository",
           "sha" => "sha256:50da",
         },
       },
@@ -183,10 +193,10 @@ describe Vars do
     allow(File).to receive(:read)
     allow(YAML).to receive(:load).and_return(fake_versions)
     Vars.set_versions()
-    expect(ENV).to have_received(:[]=).with("TF_VAR_flowmanager_repository", "gcr.io/some-project/fake_image")
+    expect(ENV).to have_received(:[]=).with("TF_VAR_flowmanager_repository", "gcr.io/some-project/fake_repository")
     expect(ENV).to have_received(:[]=).with("TF_VAR_flowmanager_checksum", "sha256:c0ffee")
     expect(ENV).to have_received(:[]=).with("TF_VAR_flowmanager_tag", "fake_tag")
-    expect(ENV).not_to have_received(:[]=).with("TF_VAR_component_without_image_repository", any_args)
+    expect(ENV).not_to have_received(:[]=).with("TF_VAR_component_without_repository_repository", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_component_without_sha_repository", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_component_without_tag_repository", any_args)
   end

--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -74,7 +74,11 @@ class Vars
                    values["generated"]["tag"])
       ENV["TF_VAR_#{component}_repository"] = values["generated"]["repository"]
       ENV["TF_VAR_#{component}_checksum"] = values["generated"]["sha"]
-      ENV["TF_VAR_#{component}_tag"] = values["generated"]["tag"]
+      # Usually, the yaml library can deduce that a tag is a string. However, if
+      # the tag is a valid float it is imported as such. Then,
+      # ENV[component_tag]= raises "TypeError: no implicit conversion of Float
+      # into String".
+      ENV["TF_VAR_#{component}_tag"] = values["generated"]["tag"].to_s
     end
   end
 end

--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -69,10 +69,10 @@ class Vars
     versions = YAML.load(File.read(Vars::VERSIONS_FILE))
     versions.each do |component, values|
       next unless (values["generated"] and
-                   values["generated"]["image"] and
+                   values["generated"]["repository"] and
                    values["generated"]["sha"] and
                    values["generated"]["tag"])
-      ENV["TF_VAR_#{component}_repository"] = values["generated"]["image"]
+      ENV["TF_VAR_#{component}_repository"] = values["generated"]["repository"]
       ENV["TF_VAR_#{component}_checksum"] = values["generated"]["sha"]
       ENV["TF_VAR_#{component}_tag"] = values["generated"]["tag"]
     end

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -27,8 +27,8 @@ couchdb_helper:
     tag: 1.2.0
   generated:
     repository: gcr.io/gpii2test-common-stg/kocolosk/couchdb-statefulset-assembler
-    sha: sha256:a689a5cde2c19b7767c79fc2d265844bbc5913f10f5516480d7e06e2292f234e
-    tag: 1.1.0
+    sha: sha256:6effb982154ed2d480a8ea49f9aad0cd5fded721d024012165638991c71b1f97
+    tag: 1.2.0
 couchdb_init:
   upstream:
     repository: alpine
@@ -67,7 +67,7 @@ dataloader:
     tag: latest
   generated:
     repository: gcr.io/gpii2test-common-stg/gpii/universal
-    sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
+    sha: sha256:39804331bf843374b653973e4d8e44d8d712e3b4aa6774b43b82c4ea934240ff
     tag: latest
 flowmanager:
   upstream:
@@ -75,7 +75,7 @@ flowmanager:
     tag: latest
   generated:
     repository: gcr.io/gpii2test-common-stg/gpii/universal
-    sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
+    sha: sha256:39804331bf843374b653973e4d8e44d8d712e3b4aa6774b43b82c4ea934240ff
     tag: latest
 k8s_snapshots:
   upstream:
@@ -107,7 +107,7 @@ preferences:
     tag: latest
   generated:
     repository: gcr.io/gpii2test-common-stg/gpii/universal
-    sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
+    sha: sha256:39804331bf843374b653973e4d8e44d8d712e3b4aa6774b43b82c4ea934240ff
     tag: latest
 service_account_assigner:
   upstream:

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -96,7 +96,7 @@ locust:
 nginx_ingress:
   upstream:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.15.0
+    tag: 0.24.1
   generated:
     image: gcr.io/gpii-common-prd/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     sha: sha256:0489cd1c6f0755f532d4b8204d5dabea038d4b2be8ec6efc2da584ff3f5aba61

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -24,7 +24,7 @@ certmerge_operator:
 couchdb_helper:
   upstream:
     repository: kocolosk/couchdb-statefulset-assembler
-    tag: 1.1.0
+    tag: 1.2.0
   generated:
     repository: gcr.io/gpii2test-common-stg/kocolosk/couchdb-statefulset-assembler
     sha: sha256:a689a5cde2c19b7767c79fc2d265844bbc5913f10f5516480d7e06e2292f234e

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -88,7 +88,7 @@ k8s_snapshots:
 locust:
   upstream:
     repository: gpii/locust
-    tag: 0.9.0-gpii.2
+    tag: 0.9.0-gpii.4
   generated:
     image: gcr.io/gpii-common-prd/gpii/locust
     sha: sha256:6fc15400ca231ac2636879d45fa3aa89a86bf1a9cf50c5285d2bb4faf248e482

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -6,85 +6,113 @@
 # components.
 ---
 cert_manager:
-  upstream_image: quay.io/jetstack/cert-manager-controller:v0.6.1
+  upstream:
+    repository: quay.io/jetstack/cert-manager-controller
+    tag: v0.6.1
   generated:
     image: gcr.io/gpii-common-prd/quay.io/jetstack/cert-manager-controller
     sha: sha256:e995152afc1f609e91343122aff8af56b192eee102ffbe5a8350bb37b68fde7f
     tag: v0.6.1
 certmerge_operator:
-  upstream_image: gpii/certmerge-operator:0.0.3-gpii.0
+  upstream:
+    repository: gpii/certmerge-operator
+    tag: 0.0.3-gpii.0
   generated:
     image: gcr.io/gpii-common-prd/gpii/certmerge-operator
     sha: sha256:96c435ee42bae821210e91430c18c0fd1cbe8cd33216175a77fbdc7622f5d535
     tag: 0.0.3-gpii.0
 couchdb_helper:
-  upstream_image: kocolosk/couchdb-statefulset-assembler:1.1.0
+  upstream:
+    repository: kocolosk/couchdb-statefulset-assembler
+    tag: 1.1.0
   generated:
     image: gcr.io/gpii-common-prd/kocolosk/couchdb-statefulset-assembler
     sha: sha256:a689a5cde2c19b7767c79fc2d265844bbc5913f10f5516480d7e06e2292f234e
     tag: 1.1.0
 couchdb_init:
-  upstream_image: busybox:latest
+  upstream:
+    repository: busybox
+    tag: latest
   generated:
     image: gcr.io/gpii-common-prd/busybox
     sha: sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4
     tag: latest
 couchdb_prometheus_exporter:
-  upstream_image: gesellix/couchdb-prometheus-exporter:22
+  upstream:
+    repository: gesellix/couchdb-prometheus-exporter
+    tag: 22
   generated:
     image: gcr.io/gpii-common-prd/gesellix/couchdb-prometheus-exporter
     sha: sha256:8184086713d28fc19f3d2ecd5eabd0cce23c21bd0daa9f8921fa0ce4acb912f6
     tag: '22'
 couchdb_prometheus_exporter_p2sd:
-  upstream_image: gcr.io/google-containers/prometheus-to-sd:v0.3.2
+  upstream:
+    repository: gcr.io/google-containers/prometheus-to-sd
+    tag: v0.3.2
   generated:
     image: gcr.io/gpii-common-prd/gcr.io/google-containers/prometheus-to-sd
     sha: sha256:7f7e424211b64a77b5ee2e8a3085048b54c1676217ee8830dc4112df6111b8a2
     tag: v0.3.2
 couchdb:
-  upstream_image: couchdb:2.2.0
+  upstream:
+    repository: couchdb
+    tag: 2.2.0
   generated:
     image: gcr.io/gpii-common-prd/couchdb
     sha: sha256:d1535416e14602ad6f061500fdfb4c3a862cf0a552961fb37a4325d65470e7af
     tag: 2.2.0
 dataloader:
-  upstream_image: gpii/universal:latest
+  upstream:
+    repository: gpii/universal
+    tag: latest
   generated:
     image: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 flowmanager:
-  upstream_image: gpii/universal:latest
+  upstream:
+    repository: gpii/universal
+    tag: latest
   generated:
     image: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 k8s_snapshots:
-  upstream_image: elsdoerfer/k8s-snapshots:v2.0
+  upstream:
+    repository: elsdoerfer/k8s-snapshots
+    tag: v2.0
   generated:
     image: gcr.io/gpii-common-prd/elsdoerfer/k8s-snapshots
     sha: sha256:c787dc6fa1812c97ac96f46b4ff6dc1485e06c458839d4aa129aaf62201309e9
     tag: v2.0
 locust:
-  upstream_image: gpii/locust:0.9.0-gpii.4
+  upstream:
+    repository: gpii/locust
+    tag: 0.9.0-gpii.2
   generated:
     image: gcr.io/gpii-common-prd/gpii/locust
     sha: sha256:6fc15400ca231ac2636879d45fa3aa89a86bf1a9cf50c5285d2bb4faf248e482
     tag: 0.9.0-gpii.4
 nginx_ingress:
-  upstream_image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.15.0
+  upstream:
+    repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    tag: 0.15.0
   generated:
     image: gcr.io/gpii-common-prd/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     sha: sha256:0489cd1c6f0755f532d4b8204d5dabea038d4b2be8ec6efc2da584ff3f5aba61
     tag: 0.15.0
 preferences:
-  upstream_image: gpii/universal:latest
+  upstream:
+    repository: gpii/universal
+    tag: latest
   generated:
     image: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 service_account_assigner:
-  upstream_image: gpii/service-account-assigner:0.0.2-gpii.0
+  upstream:
+    repository: gpii/service-account-assigner
+    tag: 0.0.2-gpii.0
   generated:
     image: gcr.io/gpii-common-prd/gpii/service-account-assigner
     sha: sha256:c464aceecdb83363ee8d339cfdcc6877210b881be1e8fa020ffaddf25a3c83bd

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -31,8 +31,8 @@ couchdb_helper:
     tag: 1.1.0
 couchdb_init:
   upstream:
-    repository: busybox
-    tag: latest
+    repository: alpine
+    tag: 3.9
   generated:
     image: gcr.io/gpii-common-prd/busybox
     sha: sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -35,7 +35,7 @@ couchdb_init:
     tag: 3.9
   generated:
     repository: gcr.io/gpii2test-common-stg/alpine
-    sha: sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
+    sha: sha256:5c40b3c27b9f13c873fefb2139765c56ce97fd50230f1f2d5c91e55dec171907
     tag: 3.9
 couchdb_prometheus_exporter:
   upstream:
@@ -99,7 +99,7 @@ nginx_ingress:
     tag: 0.24.1
   generated:
     repository: gcr.io/gpii2test-common-stg/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    sha: sha256:76861d167e4e3db18f2672fd3435396aaa898ddf4d1128375d7c93b91c59f87f
+    sha: sha256:a805454d5fdc799d28011752b7da5bfa52a4b12dccef735f09c4b18f8598c488
     tag: 0.24.1
 preferences:
   upstream:

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -48,7 +48,7 @@ couchdb_prometheus_exporter:
 couchdb_prometheus_exporter_p2sd:
   upstream:
     repository: gcr.io/google-containers/prometheus-to-sd
-    tag: v0.3.2
+    tag: v0.5.1
   generated:
     image: gcr.io/gpii-common-prd/gcr.io/google-containers/prometheus-to-sd
     sha: sha256:7f7e424211b64a77b5ee2e8a3085048b54c1676217ee8830dc4112df6111b8a2

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -56,11 +56,11 @@ couchdb_prometheus_exporter_p2sd:
 couchdb:
   upstream:
     repository: couchdb
-    tag: 2.2.0
+    tag: 2.3.0
   generated:
     repository: gcr.io/gpii2test-common-stg/couchdb
-    sha: sha256:d1535416e14602ad6f061500fdfb4c3a862cf0a552961fb37a4325d65470e7af
-    tag: 2.2.0
+    sha: sha256:d1bf43a8484a1728a897f20d9d223f71076a91cd9f73e6f5070ce2f3e22b37fe
+    tag: 2.3.0
 dataloader:
   upstream:
     repository: gpii/universal

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -10,7 +10,7 @@ cert_manager:
     repository: quay.io/jetstack/cert-manager-controller
     tag: v0.6.1
   generated:
-    image: gcr.io/gpii-common-prd/quay.io/jetstack/cert-manager-controller
+    repository: gcr.io/gpii2test-common-stg/quay.io/jetstack/cert-manager-controller
     sha: sha256:e995152afc1f609e91343122aff8af56b192eee102ffbe5a8350bb37b68fde7f
     tag: v0.6.1
 certmerge_operator:
@@ -18,7 +18,7 @@ certmerge_operator:
     repository: gpii/certmerge-operator
     tag: 0.0.3-gpii.0
   generated:
-    image: gcr.io/gpii-common-prd/gpii/certmerge-operator
+    repository: gcr.io/gpii2test-common-stg/gpii/certmerge-operator
     sha: sha256:96c435ee42bae821210e91430c18c0fd1cbe8cd33216175a77fbdc7622f5d535
     tag: 0.0.3-gpii.0
 couchdb_helper:
@@ -26,7 +26,7 @@ couchdb_helper:
     repository: kocolosk/couchdb-statefulset-assembler
     tag: 1.1.0
   generated:
-    image: gcr.io/gpii-common-prd/kocolosk/couchdb-statefulset-assembler
+    repository: gcr.io/gpii2test-common-stg/kocolosk/couchdb-statefulset-assembler
     sha: sha256:a689a5cde2c19b7767c79fc2d265844bbc5913f10f5516480d7e06e2292f234e
     tag: 1.1.0
 couchdb_init:
@@ -34,31 +34,31 @@ couchdb_init:
     repository: alpine
     tag: 3.9
   generated:
-    image: gcr.io/gpii-common-prd/busybox
-    sha: sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4
-    tag: latest
+    repository: gcr.io/gpii2test-common-stg/alpine
+    sha: sha256:28ef97b8686a0b5399129e9b763d5b7e5ff03576aa5580d6f4182a49c5fe1913
+    tag: 3.9
 couchdb_prometheus_exporter:
   upstream:
     repository: gesellix/couchdb-prometheus-exporter
     tag: 22
   generated:
-    image: gcr.io/gpii-common-prd/gesellix/couchdb-prometheus-exporter
+    repository: gcr.io/gpii2test-common-stg/gesellix/couchdb-prometheus-exporter
     sha: sha256:8184086713d28fc19f3d2ecd5eabd0cce23c21bd0daa9f8921fa0ce4acb912f6
-    tag: '22'
+    tag: 22
 couchdb_prometheus_exporter_p2sd:
   upstream:
     repository: gcr.io/google-containers/prometheus-to-sd
     tag: v0.5.1
   generated:
-    image: gcr.io/gpii-common-prd/gcr.io/google-containers/prometheus-to-sd
-    sha: sha256:7f7e424211b64a77b5ee2e8a3085048b54c1676217ee8830dc4112df6111b8a2
-    tag: v0.3.2
+    repository: gcr.io/gpii2test-common-stg/gcr.io/google-containers/prometheus-to-sd
+    sha: sha256:8e3679a6e059d1806daae335ab08b304fd1d8d35cdff457baded7306b5af9ba5
+    tag: v0.5.1
 couchdb:
   upstream:
     repository: couchdb
     tag: 2.2.0
   generated:
-    image: gcr.io/gpii-common-prd/couchdb
+    repository: gcr.io/gpii2test-common-stg/couchdb
     sha: sha256:d1535416e14602ad6f061500fdfb4c3a862cf0a552961fb37a4325d65470e7af
     tag: 2.2.0
 dataloader:
@@ -66,7 +66,7 @@ dataloader:
     repository: gpii/universal
     tag: latest
   generated:
-    image: gcr.io/gpii-common-prd/gpii/universal
+    repository: gcr.io/gpii2test-common-stg/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 flowmanager:
@@ -74,7 +74,7 @@ flowmanager:
     repository: gpii/universal
     tag: latest
   generated:
-    image: gcr.io/gpii-common-prd/gpii/universal
+    repository: gcr.io/gpii2test-common-stg/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 k8s_snapshots:
@@ -82,7 +82,7 @@ k8s_snapshots:
     repository: elsdoerfer/k8s-snapshots
     tag: v2.0
   generated:
-    image: gcr.io/gpii-common-prd/elsdoerfer/k8s-snapshots
+    repository: gcr.io/gpii2test-common-stg/elsdoerfer/k8s-snapshots
     sha: sha256:c787dc6fa1812c97ac96f46b4ff6dc1485e06c458839d4aa129aaf62201309e9
     tag: v2.0
 locust:
@@ -90,7 +90,7 @@ locust:
     repository: gpii/locust
     tag: 0.9.0-gpii.4
   generated:
-    image: gcr.io/gpii-common-prd/gpii/locust
+    repository: gcr.io/gpii2test-common-stg/gpii/locust
     sha: sha256:6fc15400ca231ac2636879d45fa3aa89a86bf1a9cf50c5285d2bb4faf248e482
     tag: 0.9.0-gpii.4
 nginx_ingress:
@@ -98,15 +98,15 @@ nginx_ingress:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     tag: 0.24.1
   generated:
-    image: gcr.io/gpii-common-prd/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    sha: sha256:0489cd1c6f0755f532d4b8204d5dabea038d4b2be8ec6efc2da584ff3f5aba61
-    tag: 0.15.0
+    repository: gcr.io/gpii2test-common-stg/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    sha: sha256:76861d167e4e3db18f2672fd3435396aaa898ddf4d1128375d7c93b91c59f87f
+    tag: 0.24.1
 preferences:
   upstream:
     repository: gpii/universal
     tag: latest
   generated:
-    image: gcr.io/gpii-common-prd/gpii/universal
+    repository: gcr.io/gpii2test-common-stg/gpii/universal
     sha: sha256:eab9307f4b1549077c97646848e54b49fc6ceed42d98185882e2258b409f0770
     tag: latest
 service_account_assigner:
@@ -114,6 +114,6 @@ service_account_assigner:
     repository: gpii/service-account-assigner
     tag: 0.0.2-gpii.0
   generated:
-    image: gcr.io/gpii-common-prd/gpii/service-account-assigner
+    repository: gcr.io/gpii2test-common-stg/gpii/service-account-assigner
     sha: sha256:c464aceecdb83363ee8d339cfdcc6877210b881be1e8fa020ffaddf25a3c83bd
     tag: 0.0.2-gpii.0


### PR DESCRIPTION
This PR is on top of #368. First new commit is 057e2e4. Note that hashes don't line up (but commit messages do) because I rebased this branch because Github didn't like the merge I did as my first try.

This needs a little more testing and ticket-related bookkeeping, but so far these changes all seem to work.

* Replace busybox with alpine for couchdb init container
* Update couchdb-prometheus-exporter's prometheus-to-sd to the latest, 0.5.1
* Update nginx-ingress to the latest, 0.21.1 (I plan to update the chart as well while I'm doing this)
* Re-run port-forward each time when checking membership for couchdb.finish_cluster