### PR TITLE
GPII-3883: Locust - wait for several successful responses before moving on

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -66,7 +66,7 @@ k8s_snapshots:
     sha: sha256:c787dc6fa1812c97ac96f46b4ff6dc1485e06c458839d4aa129aaf62201309e9
     tag: v2.0
 locust:
-  upstream_image: gpii/locust:0.9.0-gpii.4
+  upstream_image: gpii/locust:0.9.0-gpii.5
   generated:
     image: gcr.io/gpii-common-prd/gpii/locust
     sha: sha256:6fc15400ca231ac2636879d45fa3aa89a86bf1a9cf50c5285d2bb4faf248e482


### PR DESCRIPTION
This PR bumps locust image from gpii-ops/docker-image-locust/pull/6

This is an attempt to solve the issue with a high number of failing CI builds, due to the slow max_response_time after moving to the DNS challenge, by waiting for multiple consecutive good replies from the service before starting the test.

Depends on gpii-ops/docker-image-locust/pull/6