### PR TITLE
GPII-3641: Handle tags that look like floats (or integers)

### DIFF
--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -74,7 +74,11 @@ class Vars
                    values["generated"]["tag"])
       ENV["TF_VAR_#{component}_repository"] = values["generated"]["repository"]
       ENV["TF_VAR_#{component}_checksum"] = values["generated"]["sha"]
-      ENV["TF_VAR_#{component}_tag"] = values["generated"]["tag"]
+      # Usually, the yaml library can deduce that a tag is a string. However, if
+      # the tag is a valid float it is imported as such. Then,
+      # ENV[component_tag]= raises "TypeError: no implicit conversion of Float
+      # into String".
+      ENV["TF_VAR_#{component}_tag"] = values["generated"]["tag"].to_s
     end
   end
 end


### PR DESCRIPTION
This was part of #370 but I ran into it while deploying #368, so I've extracted it into its own PR to merge separately.