### PR TITLE
GPII-3641 GPII-3856 GPII-3857 Image updates

### DIFF
--- a/gcp/modules/couchdb-prometheus-exporter/main.tf
+++ b/gcp/modules/couchdb-prometheus-exporter/main.tf
@@ -5,7 +5,7 @@ terraform {
 variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "couchdb_prometheus_exporter_repository" {}
-variable "couchdb_prometheus_exporter_checksum" {}
+variable "couchdb_prometheus_exporter_tag" {}
 variable "prometheus_to_sd_repository" {}
 variable "prometheus_to_sd_tag" {}
 
@@ -25,7 +25,7 @@ data "template_file" "couchdb_prometheus_exporter_values" {
     couchdb_admin_username                 = "${var.secret_couchdb_admin_username}"
     couchdb_admin_password                 = "${var.secret_couchdb_admin_password}"
     couchdb_prometheus_exporter_repository = "${var.couchdb_prometheus_exporter_repository}"
-    couchdb_prometheus_exporter_checksum   = "${var.couchdb_prometheus_exporter_checksum}"
+    couchdb_prometheus_exporter_tag        = "${var.couchdb_prometheus_exporter_tag}"
     prometheus_to_sd_repository            = "${var.prometheus_to_sd_repository}"
     prometheus_to_sd_tag                   = "${var.prometheus_to_sd_tag}"
     replica_count                          = "${var.replica_count}"

--- a/gcp/modules/couchdb-prometheus-exporter/values.yaml
+++ b/gcp/modules/couchdb-prometheus-exporter/values.yaml
@@ -6,7 +6,7 @@ couchdbPassword: ${couchdb_admin_password}
 
 image:
   repository: ${couchdb_prometheus_exporter_repository}
-  checksum: ${couchdb_prometheus_exporter_checksum}
+  tag: ${couchdb_prometheus_exporter_tag}
   prometheusToSdExporter:
     repository: ${prometheus_to_sd_repository}
     tag: ${prometheus_to_sd_tag}

--- a/shared/charts/couchdb-prometheus-exporter/README.md
+++ b/shared/charts/couchdb-prometheus-exporter/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `couchdbPassword` | password for couchdb uri | `password`
 `couchdbDatabases` | list of specific databases to monitor | `_all_dbs`
 `image.repository` | container image repository | `gesellix/couchdb-prometheus-exporter`
-`image.checksum` | container image checksum | `sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2`
+`image.tag` | container image checksum | `22`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`
 `image.prometheusToSdExporter.repository` | prometheus-to-sd container image repository | `gcr.io/google-containers/prometheus-to-sd`
 `image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.5.1`

--- a/shared/charts/couchdb-prometheus-exporter/README.md
+++ b/shared/charts/couchdb-prometheus-exporter/README.md
@@ -56,6 +56,6 @@ Parameter | Description | Default
 `image.checksum` | container image checksum | `sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`
 `image.prometheusToSdExporter.repository` | prometheus-to-sd container image repository | `gcr.io/google-containers/prometheus-to-sd`
-`image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.3.2`
+`image.prometheusToSdExporter.tag` | prometheus-to-sd container image tag | `v0.5.1`
 `image.pullPolicy` | prometheus-to-sd container image pullPolicy | `IfNotPresent`
 `resources` | optional resource requests and limits for deployment | `requests:`<br/>&nbsp;&nbsp;`cpu: 10m`<br/>&nbsp;&nbsp;`memory: 60Mi`<br/>`limits:`<br/>&nbsp;&nbsp;`cpu: 10m`<br/>&nbsp;&nbsp;`memory: 60Mi`

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: couchdb-prometheus-exporter
-        image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -logtostderr

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: prometheus-to-sd
-        image: "{{ .Values.prometheusToSdExporter.image.repository }}:{{ .Values.prometheusToSdExporter.image.tag }}"
+        image: "{{ .Values.image.prometheusToSdExporter.repository }}:{{ .Values.image.prometheusToSdExporter.tag }}"
         imagePullPolicy: {{ .Values.prometheusToSdExporter.image.pullPolicy }}
         command:
           - /monitor

--- a/shared/charts/couchdb-prometheus-exporter/values.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/values.yaml
@@ -12,7 +12,7 @@ couchdbDatabases: _all_dbs
 
 image:
   repository: gesellix/couchdb-prometheus-exporter
-  checksum: sha256:77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2
+  tag: 22
   pullPolicy: IfNotPresent
 
 prometheusToSdExporter:

--- a/shared/charts/couchdb-prometheus-exporter/values.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/values.yaml
@@ -18,7 +18,7 @@ image:
 prometheusToSdExporter:
   image:
     repository: gcr.io/google-containers/prometheus-to-sd
-    tag: v0.3.2
+    tag: v0.5.1
     pullPolicy: IfNotPresent
 
 ## Optional resource requests and limits for deployment

--- a/shared/charts/nginx-ingress/Chart.yaml
+++ b/shared/charts/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: nginx-ingress
-version: 0.22.1
-appVersion: 0.15.0
+version: 1.6.0
+appVersion: 0.24.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
@@ -14,6 +14,4 @@ maintainers:
     email: jack.zampolin@gmail.com
   - name: mgoodness
     email: mgoodness@gmail.com
-  - name: chancez
-    email: chance.zibolski@coreos.com
 engine: gotpl

--- a/shared/charts/nginx-ingress/OWNERS
+++ b/shared/charts/nginx-ingress/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jackzampolin
+- mgoodness
+reviewers:
+- jackzampolin
+- mgoodness

--- a/shared/charts/nginx-ingress/README.md
+++ b/shared/charts/nginx-ingress/README.md
@@ -47,11 +47,13 @@ Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.15.0`
+`controller.image.tag` | controller container image tag | `0.24.1`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
+`controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses debian one. | `33`
 `controller.config` | nginx ConfigMap entries | none
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.dnsPolicy` | If using `hostNetwork=true`, change to `ClusterFirstWithHostNet`. See [pod's dns policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) for details | `ClusterFirst`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
 `controller.extraContainers` | Sidecar containers to add to the controller pod. See [LemonLDAP::NG controller](https://github.com/lemonldap-ng-controller/lemonldap-ng-controller) as example | `{}`
@@ -66,14 +68,17 @@ Parameter | Description | Default
 `controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
+`controller.daemonset.hostPorts.stats` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"18080"`
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`
 `controller.nodeSelector` | node labels for pod assignment | `{}`
 `controller.podAnnotations` | annotations to be added to pods | `{}`
+`controller.podLabels` | labels to add to the pod container metadata | `{}`
 `controller.replicaCount` | desired number of controller pods | `1`
 `controller.minAvailable` | minimum number of available controller pods for PodDisruptionBudget | `1`
 `controller.resources` | controller pod resource requests & limits | `{}`
+`controller.priorityClassName` | controller priorityClassName | `nil`
 `controller.lifecycle` | controller pod lifecycle hooks | `{}`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
@@ -115,27 +120,34 @@ Parameter | Description | Default
 `controller.metrics.service.annotations` | annotations for Prometheus metrics service | `{}`
 `controller.metrics.service.clusterIP` | cluster IP address to assign to service | `""`
 `controller.metrics.service.externalIPs` | Prometheus metrics service external IP addresses | `[]`
+`controller.metrics.service.labels` | labels for metrics service | `{}`
 `controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
-`controller.metrics.service.targetPort` | Prometheus metrics target port | `10254`
 `controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
+`controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
+`controller.metrics.serviceMonitor.namespace` | namespace where servicemonitor resource should be created | `the same namespace as nginx ingress`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
+`defaultBackend.enabled` | If false, controller.defaultBackendService must be provided | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend`
-`defaultBackend.image.tag` | default backend container image tag | `1.3`
+`defaultBackend.image.tag` | default backend container image tag | `1.4`
 `defaultBackend.image.pullPolicy` | default backend container image pull policy | `IfNotPresent`
 `defaultBackend.extraArgs` | Additional default backend container arguments | `{}`
+`defaultBackend.port` | Http port number | `8080`
 `defaultBackend.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `defaultBackend.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `defaultBackend.nodeSelector` | node labels for pod assignment | `{}`
 `defaultBackend.podAnnotations` | annotations to be added to pods | `{}`
+`defaultBackend.podLabels` | labels to add to the pod container metadata | `{}`
 `defaultBackend.replicaCount` | desired number of default backend pods | `1`
 `defaultBackend.minAvailable` | minimum number of available default backend pods for PodDisruptionBudget | `1`
 `defaultBackend.resources` | default backend pod resource requests & limits | `{}`
+`defaultBackend.priorityClassName` | default backend  priorityClassName | `nil`
 `defaultBackend.service.annotations` | annotations for default backend service | `{}`
 `defaultBackend.service.clusterIP` | internal default backend cluster service IP | `""`
 `defaultBackend.service.externalIPs` | default backend service external IP addresses | `[]`
@@ -144,6 +156,7 @@ Parameter | Description | Default
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
 `imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
 `rbac.create` | if `true`, create & use RBAC resources | `true`
+`podSecurityPolicy.enabled` | if `true`, create & use Pod Security Policy resources | `false`
 `serviceAccount.create` | if `true`, create a service account | ``
 `serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
@@ -167,6 +180,11 @@ as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs
 ```console
 $ helm install stable/nginx-ingress --set controller.extraArgs.v=2
 ```
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## PodDisruptionBudget
+Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
+else it would make it impossible to evacuate a node. See [gh issue #7127](https://github.com/helm/charts/issues/7127) for more info.
 
 ## Prometheus Metrics
 
@@ -178,27 +196,7 @@ $ helm install stable/nginx-ingress --name my-release \
     --set controller.metrics.enabled=true
 ```
 
-You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you need to create a ServiceMonitor as follows:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: nginx-ingress-service-monitor
-spec:
-  jobLabel: nginx-ingress
-  selector:
-    matchLabels:
-      app: nginx-ingress
-      release: <RELEASE>
-  namespaceSelector:
-    matchNames:
-      - <RELEASE_NAMESPACE>
-  endpoints:
-    - port: metrics
-      interval: 30s
-```
-> **Tip**: You can use the default [values.yaml](values.yaml)
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
 
 ## ExternalDNS Service configuration
 

--- a/shared/charts/nginx-ingress/ci/psp-values.yaml
+++ b/shared/charts/nginx-ingress/ci/psp-values.yaml
@@ -1,0 +1,2 @@
+podSecurityPolicy:
+  enabled: true

--- a/shared/charts/nginx-ingress/templates/_helpers.tpl
+++ b/shared/charts/nginx-ingress/templates/_helpers.tpl
@@ -11,11 +11,15 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -24,12 +28,7 @@ Create a default fully qualified controller name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.controller.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.controller.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -52,12 +51,7 @@ Create a default fully qualified default backend name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "nginx-ingress.defaultBackend.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" (include "nginx-ingress.fullname" .) .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/shared/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -17,10 +17,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
-    {{- if .Values.controller.podAnnotations }}
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
-    {{- end }}
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"
@@ -34,6 +33,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -75,6 +77,15 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:
@@ -114,6 +125,9 @@ spec:
             - name: stats
               containerPort: 18080
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPort }}
+              hostPort: {{ .Values.controller.daemonset.hostPorts.stats }}
+              {{- end }}
             {{- if .Values.controller.metrics.enabled }}
             - name: metrics
               containerPort: 10254
@@ -149,7 +163,7 @@ spec:
               readOnly: true
 {{- end }}
 {{- if .Values.controller.extraVolumeMounts }}
-{{ toYaml .Values.controller.extraVolumeMounts | indent 10}}
+{{ toYaml .Values.controller.extraVolumeMounts | indent 12}}
 {{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
@@ -187,6 +201,6 @@ spec:
               path: nginx.tmpl
 {{- end }}
 {{- if .Values.controller.extraVolumes }}
-{{ toYaml .Values.controller.extraVolumes | indent 6}}
+{{ toYaml .Values.controller.extraVolumes | indent 8}}
 {{- end }}
 {{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -19,7 +19,9 @@ spec:
     metadata:
       {{- if .Values.controller.podAnnotations }}
       annotations:
-{{ toYaml .Values.controller.podAnnotations | indent 8}}
+      {{- range $key, $value := .Values.controller.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
@@ -34,6 +36,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.controller.priorityClassName }}
+      priorityClassName: "{{ .Values.controller.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
@@ -74,6 +79,15 @@ spec:
             {{- else }}
             - --{{ $key }}
             {{- end }}
+          {{- end }}
+          {{- if (semverCompare ">=0.16.0" .Values.controller.image.tag) }}
+          securityContext:
+            capabilities:
+                drop:
+                - ALL
+                add:
+                - NET_BIND_SERVICE
+            runAsUser: {{ .Values.controller.image.runAsUser }}
           {{- end }}
           env:
             - name: POD_NAME

--- a/shared/charts/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-metrics-service.yaml
@@ -4,9 +4,14 @@ kind: Service
 metadata:
 {{- if .Values.controller.metrics.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.metrics.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
+{{- if .Values.controller.metrics.service.labels }}
+{{ toYaml .Values.controller.metrics.service.labels | indent 4 }}
+{{- end }}
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"

--- a/shared/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.controller.replicaCount 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.controller.name }}"
   minAvailable: {{ .Values.controller.minAvailable }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-service.yaml
@@ -3,7 +3,9 @@ kind: Service
 metadata:
 {{- if .Values.controller.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
 {{- if .Values.controller.service.labels }}

--- a/shared/charts/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+  {{- if .Values.controller.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.controller.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/controller-stats-service.yaml
+++ b/shared/charts/nginx-ingress/templates/controller-stats-service.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
 {{- if .Values.controller.stats.service.annotations }}
   annotations:
-{{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.controller.stats.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}

--- a/shared/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -16,7 +16,9 @@ spec:
     metadata:
     {{- if .Values.defaultBackend.podAnnotations }}
       annotations:
-{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
+      {{- range $key, $value := .Values.defaultBackend.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
       labels:
         app: {{ template "nginx-ingress.name" . }}
@@ -30,6 +32,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+{{- if .Values.defaultBackend.priorityClassName }}
+      priorityClassName: "{{ .Values.defaultBackend.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
@@ -45,16 +50,17 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: {{ .Values.defaultBackend.port }}
               scheme: HTTP
             initialDelaySeconds: 30
             timeoutSeconds: 5
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.defaultBackend.port }}
               protocol: TCP
           resources:
 {{ toYaml .Values.defaultBackend.resources | indent 12 }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
     {{- if .Values.defaultBackend.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}

--- a/shared/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if gt .Values.defaultBackend.replicaCount 1.0 }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/default-backend-service.yaml
+++ b/shared/charts/nginx-ingress/templates/default-backend-service.yaml
@@ -4,7 +4,9 @@ kind: Service
 metadata:
 {{- if .Values.defaultBackend.service.annotations }}
   annotations:
-{{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
+  {{- range $key, $value := .Values.defaultBackend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{- end }}
   labels:
     app: {{ template "nginx-ingress.name" . }}

--- a/shared/charts/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/shared/charts/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.podSecurityPolicy.enabled}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "nginx-ingress.fullname" . }} 
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  allowedCapabilities:
+    - NET_BIND_SERVICE
+  privileged: false
+  allowPrivilegeEscalation: true
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    #- 'emptyDir'
+    #- 'projected'
+    - 'secret'
+    #- 'downwardAPI'
+  hostNetwork: {{ .Values.controller.hostNetwork }}
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  seLinux:
+    rule: 'RunAsAny'
+  hostPorts:
+    - max: 65535
+      min: 1
+{{- end }}

--- a/shared/charts/nginx-ingress/templates/role.yaml
+++ b/shared/charts/nginx-ingress/templates/role.yaml
@@ -79,4 +79,11 @@ rules:
     verbs:
       - create
       - patch
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "nginx-ingress.fullname" . }}]
+{{- end }}
+
 {{- end -}}

--- a/shared/charts/nginx-ingress/templates/scoped-clusterrole.yaml
+++ b/shared/charts/nginx-ingress/templates/scoped-clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.controller.scope.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/shared/charts/nginx-ingress/templates/scoped-clusterrolebinding.yaml
+++ b/shared/charts/nginx-ingress/templates/scoped-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.rbac.create .Values.controller.scope.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "nginx-ingress.fullname" . }}-scoped
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/shared/charts/nginx-ingress/values.yaml
+++ b/shared/charts/nginx-ingress/values.yaml
@@ -5,8 +5,10 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.15.0"
+    tag: "0.24.1"
     pullPolicy: IfNotPresent
+    # www-data -> uid 33
+    runAsUser: 33
 
   config: {}
   # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
@@ -29,6 +31,8 @@ controller:
     hostPorts:
       http: 80
       https: 443
+      ## healthz endpoint
+      stats: 18080
 
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
@@ -145,10 +149,10 @@ controller:
 
   autoscaling:
     enabled: false
-  #  minReplicas: 1
-  #  maxReplicas: 11
-  #  targetCPUUtilizationPercentage: 50
-  #  targetMemoryUtilizationPercentage: 50
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
   ## Override NGINX template
   customTemplate:
@@ -192,7 +196,7 @@ controller:
       http: ""
       https: ""
 
-  extraContainers: {}
+  extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   #  - name: my-sidecar
@@ -216,12 +220,12 @@ controller:
   #    - name: copy-portal-skins
   #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
 
-  extraVolumeMounts: {}
+  extraVolumeMounts: []
   ## Additional volumeMounts to the controller main container.
   #  - name: copy-portal-skins
   #   mountPath: /var/lib/lemonldap-ng/portal/skins
 
-  extraVolumes: {}
+  extraVolumes: []
   ## Additional volumes to the controller pod.
   #  - name: copy-portal-skins
   #    emptyDir: {}
@@ -272,7 +276,14 @@ controller:
       servicePort: 9913
       type: ClusterIP
 
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+      namespace: ""
+
   lifecycle: {}
+
+  priorityClassName: ""
 
 ## Rollback limit
 ##
@@ -289,10 +300,12 @@ defaultBackend:
   name: default-backend
   image:
     repository: k8s.gcr.io/defaultbackend
-    tag: "1.3"
+    tag: "1.4"
     pullPolicy: IfNotPresent
 
   extraArgs: {}
+
+  port: 8080
 
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -344,9 +357,16 @@ defaultBackend:
     servicePort: 80
     type: ClusterIP
 
+  priorityClassName: ""
+
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: true
+
+# If true, create & use Pod Security Policy resources
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
 
 serviceAccount:
   create: true

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -96,7 +96,7 @@ locust:
 nginx_ingress:
   upstream:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: 0.15.0
+    tag: 0.24.1
   generated:
     repository: gcr.io/gpii-common-prd/quay.io/kubernetes-ingress-controller/nginx-ingress-controller
     sha: sha256:0489cd1c6f0755f532d4b8204d5dabea038d4b2be8ec6efc2da584ff3f5aba61

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -48,7 +48,7 @@ couchdb_prometheus_exporter:
 prometheus_to_sd:
   upstream:
     repository: gcr.io/google-containers/prometheus-to-sd
-    tag: v0.3.2
+    tag: v0.5.1
   generated:
     repository: gcr.io/gpii-common-prd/gcr.io/google-containers/prometheus-to-sd
     sha: sha256:7f7e424211b64a77b5ee2e8a3085048b54c1676217ee8830dc4112df6111b8a2


### PR DESCRIPTION
This PR replaces #370 -- there is nothing new to review. It has the contents of #370, rebased onto master now that #367 and #368 (and version-updater companion PRs) are merged, minus #372 (which was merged separately while merging #367 and #368).

* GPII-3641: Replace busybox with alpine for couchdb init container
* ~GPII-3871: Re-run port-forward each time when checking membership for couchdb.finish_cluster~ --> #377 
* GPII-3856 Update couchdb-prometheus-exporter's prometheus-to-sd to the latest, 0.5.1
* GPII-3857: Update nginx-ingress to the latest 0.21.1 and (for fun) update the chart with latest from upstream.
* ~GPII-3846: Update couchdb to 2.3.0 and (for fun) couchdb-statefulset-assembler to 1.2.0.~ --> #376 


Additional testing info:

- [x] Deploy dev env with current master (un-updated images/charts -- in particular couchdb 2.2.0).
   * This deploy and all deploys happen with `execute_destroy_pvcs = "false"` and `execute_recover_pvcs = "true"`, to simulate a long-lived env
- [x] Add [custom data](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/README.md#hack-adding-data-to-couchdb) to couchdb.
- [x]  Switch to this PR (updated images/charts -- in particular couchdb 2.3.0) and deploy.
- [x] (For fun, run test_flowmanager during deploy)
- [x] Verify custom data still present in couchdb.
- [x] Watch couchdb logs for any indication of trouble related to the new version.
- [x] Switch back to current master and downgrade images (back to couchdb 2.2.0).
- [x] Verify custom data still present in couchdb.
- [x] Watch couchdb logs for any indication of trouble related to the new version.
   * Downgrade appears to fail:
```
[info] 2019-04-25T03:24:53.087604Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.210.0> -------- db _nodes died with reason {invalid_header_size,{db_header,7,2,0,{8460,{2,0,{size_info,90,8}},165},{8625,2,167},{16614,[],455},nil,nil,205,1000,<<"be960de869802d865ff4000153916b13">>,[{'couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local',0}],0,1000}}

[info] 2019-04-25T03:24:53.087839Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.210.0> -------- db _users died with reason {invalid_header_size,{db_header,7,1,0,{2363,{1,0,{size_info,2089,5361}},118},{2481,1,115},{20917,[],817},nil,nil,205,1000,<<"b0c7a7cd244e8285af4e3313c7fd8e05">>,[{'couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local',0}],0,1000}}

[error] 2019-04-25T03:24:53.087946Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.249.0> -------- CRASH REPORT Process  (<0.249.0>) with 2 neighbors crashed with reason: {invalid_header_size,{db_header,7,2,0,{8460,{2,0,{size_info,90,8}},165},{8625,2,167},{16614,[],455},nil,nil,205,1000,<<"be960de869802d865ff4000153916b13">>,[{'couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local',0}],0,1000}} at couch_bt_engine_header:upgrade_tuple/1(line:212) <= lists:foldl/3(line:1263) <= couch_bt_engine:init_state/4(line:684) <= couch_bt_engine:init/2(line:148) <= couch_db_engine:init/3(line:648) <= couch_db_updater:init/1(line:32) <= proc_lib:init_p_do_apply/3(line:247); initial_call: {couch_db_updater,init,['Argument__1']}, ancestors: [<0.248.0>], messages: [], links: [<0.248.0>,<0.252.0>], dictionary: [{idle_limit,61000},{io_priority,{db_update,<<"_nodes">>}}], trap_exit: false, status: running, heap_size: 987, stack_size: 27, reductions: 572

[error] 2019-04-25T03:24:53.088543Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.251.0> -------- CRASH REPORT Process  (<0.251.0>) with 2 neighbors crashed with reason: {invalid_header_size,{db_header,7,1,0,{2363,{1,0,{size_info,2089,5361}},118},{2481,1,115},{20917,[],817},nil,nil,205,1000,<<"b0c7a7cd244e8285af4e3313c7fd8e05">>,[{'couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local',0}],0,1000}} at couch_bt_engine_header:upgrade_tuple/1(line:212) <= lists:foldl/3(line:1263) <= couch_bt_engine:init_state/4(line:684) <= couch_bt_engine:init/2(line:148) <= couch_db_engine:init/3(line:648) <= couch_db_updater:init/1(line:32) <= proc_lib:init_p_do_apply/3(line:247); initial_call: {couch_db_updater,init,['Argument__1']}, ancestors: [<0.250.0>], messages: [], links: [<0.250.0>,<0.253.0>], dictionary: [{idle_limit,61000},{io_priority,{db_update,<<"_users">>}}], trap_exit: false, status: running, heap_size: 987, stack_size: 27, reductions: 543

[error] 2019-04-25T03:24:53.090499Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.255.0> -------- Could not open file ./data/_users.couch: file already exists

[info] 2019-04-25T03:24:53.090569Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.210.0> -------- open_result error file_exists for _users

[error] 2019-04-25T03:24:53.090938Z couchdb@couchdb-couchdb-1.couchdb-couchdb.gpii.svc.cluster.local <0.245.0> -------- CRASH REPORT Process  (<0.245.0>) with 1 neighbors exited with reason: no match of right hand value file_exists at couch_auth_cache:ensure_users_db_exists/2(line:447) <= couch_auth_cache:open_auth_db/0(line:419) <= couch_auth_cache:reinit_cache/1(line:282) <= couch_auth_cache:init/1(line:164) <= gen_server:init_it/6(line:328) <= proc_lib:init_p_do_apply/3(line:247) at gen_server:init_it/6(line:352) <= proc_lib:init_p_do_apply/3(line:247); initial_call: {couch_auth_cache,init,['Argument__1']}, ancestors: [couch_secondary_services,couch_sup,<0.204.0>], messages: [], links: [<0.214.0>,<0.247.0>], dictionary: [], trap_exit: true, status: running, heap_size: 987, stack_size: 27, reductions: 341
```
   * Re-upgrading to 2.3.0 heals the cluster

## Deployment plan - prep phase
- [ ] Merge this PR, #376, and #377
- [ ] version-updater picks up the new versions, syncs the images, and re-writes the generated configs
- [ ] Babysit pipeline to stg. Problems with couchdb or nginx-ingress should be obvious, but monitor the logs
- [ ] Ensure couchdb metrics are still being collected: https://app.google.stackdriver.com/dashboards/11824930462768382974?project=gpii-gcp-stg
- [ ] Review `plan-all-prd` output, ensure changes are as expected (couchdb upgrade good, k8s cluster destruction bad)

## Deployment plan - production phase
- [ ] Wait for planned maintenance time
- [ ] Identify the last set of Snapshots from before the upgrade. Note their IDs, as you will need them in case of couchdb rollback.
- [ ] Promote pipeline to prd. Problems with couchdb or nginx-ingress should be obvious, but monitor the logs
- [ ] Ensure couchdb metrics are still being collected: https://app.google.stackdriver.com/dashboards/5252464485969725191?project=gpii-gcp-prd
- [ ] Email the all clear to outage@

## Rollback plan
- [ ] Revert the bad update (this PR or #376 or both -- hopefully not #377)
- [ ] If reverting nginx-ingress, the environment should recover on its own. If it doesn't, the first serious step is probably `rake redeploy_module`.
- [ ] If reverting couchdb, restore from the Snapshots you identified before: https://github.com/gpii-ops/gpii-infra/blob/master/gcp/README.md#data-corruption-on-all-replicas-of-couchdb-cluster