### PR TITLE
[GPII-3885]: Add :activate_serviceaccount task

### DIFF
--- a/shared/rakefiles/ci.rake
+++ b/shared/rakefiles/ci.rake
@@ -34,12 +34,8 @@ task :configure_serviceaccount_ci_restore => [:set_vars_ci] do
   # service account key file.
   sh "#{@exekube_cmd_with_backups} sh -c '\
     mkdir -p $(dirname #{@serviceaccount_key_file}) && \
-    cp -av #{@serviceaccount_key_file_in_backups} #{@serviceaccount_key_file} \
-  '"
-  sh "#{@exekube_cmd} sh -c '\
-    gcloud auth activate-service-account \
-      --key-file #{@serviceaccount_key_file} \
-      --project $TF_VAR_project_id \
+    cp -av #{@serviceaccount_key_file_in_backups} #{@serviceaccount_key_file} && \
+    rake activate_serviceaccount
   '"
 end
 

--- a/shared/rakefiles/xk_config.rake
+++ b/shared/rakefiles/xk_config.rake
@@ -29,6 +29,18 @@ task :configure_serviceaccount => [@gcp_creds_file] do
         --iam-account projectowner@$TF_VAR_project_id.iam.gserviceaccount.com
     "
   end
+  Rake::Task[:activate_serviceaccount].invoke
+end
+
+# We need separate task to activate service account from key file
+# so we can call it directly after restoring saved
+# @serviceaccount_key_file in :configure_serviceaccount_ci_restore
+task :activate_serviceaccount => [@serviceaccount_key_file] do
+  sh "
+    gcloud auth activate-service-account \
+      --key-file #{@serviceaccount_key_file} \
+      --project $TF_VAR_project_id
+  "
 end
 
 @app_default_creds_file = "/root/.config/gcloud/application_default_credentials.json"


### PR DESCRIPTION
I had to revert #366, because it turned out that I was testing the code with rake `:configure_serviceaccount` auth, but even if you have SA key downloaded, it needs to be activated, otherwise `gcloud` calls will keep using credentials retrieved by `auth login` (therefore changing IAM and set of permissions).