### PR TITLE
GPII-3846: Upgrade to couchdb 2.3

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -31,8 +31,8 @@ couchdb_helper:
     tag: 1.1.0
 couchdb_init:
   upstream:
-    repository: busybox
-    tag: latest
+    repository: alpine
+    tag: 3.9
   generated:
     repository: gcr.io/gpii-common-prd/busybox
     sha: sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -24,7 +24,7 @@ certmerge_operator:
 couchdb_helper:
   upstream:
     repository: kocolosk/couchdb-statefulset-assembler
-    tag: 1.1.0
+    tag: 1.2.0
   generated:
     repository: gcr.io/gpii-common-prd/kocolosk/couchdb-statefulset-assembler
     sha: sha256:a689a5cde2c19b7767c79fc2d265844bbc5913f10f5516480d7e06e2292f234e

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -56,7 +56,7 @@ prometheus_to_sd:
 couchdb:
   upstream:
     repository: couchdb
-    tag: 2.2.0
+    tag: 2.3.0
   generated:
     repository: gcr.io/gpii-common-prd/couchdb
     sha: sha256:d1535416e14602ad6f061500fdfb4c3a862cf0a552961fb37a4325d65470e7af


### PR DESCRIPTION
Separated from https://github.com/gpii-ops/gpii-infra/pull/373.