### PR TITLE
[GPII-3865]: Add missing billing user role to common SA

### DIFF
--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -1,4 +1,5 @@
 common_sa_org_roles = [
+  "roles/billing.user",
   "roles/dns.admin",
   "roles/iam.organizationRoleViewer",
   "roles/iam.serviceAccountAdmin",


### PR DESCRIPTION
This role is required to [link projects to billing account](https://github.com/gpii-ops/gpii-infra/blob/master/shared/rakefiles/xk_infra.rake#L85-L86). 