### PR TITLE
Istio phase 2.5 - Locust

### DIFF
--- a/gcp/live/dev/locust/istio/terraform.tfvars
+++ b/gcp/live/dev/locust/istio/terraform.tfvars
@@ -1,8 +1,7 @@
 # ↓ Module metadata
-
 terragrunt = {
   terraform {
-    source = "/project/modules//locust"
+    source = "/project/modules//locust-istio"
   }
 
   include = {
@@ -11,4 +10,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-

--- a/gcp/live/dev/locust/swarm/terraform.tfvars
+++ b/gcp/live/dev/locust/swarm/terraform.tfvars
@@ -1,0 +1,21 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//locust"
+  }
+
+  dependencies {
+    paths = [
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/live/prd/locust/istio/terraform.tfvars
+++ b/gcp/live/prd/locust/istio/terraform.tfvars
@@ -1,8 +1,7 @@
 # ↓ Module metadata
-
 terragrunt = {
   terraform {
-    source = "/project/modules//locust"
+    source = "/project/modules//locust-istio"
   }
 
   include = {
@@ -11,4 +10,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-

--- a/gcp/live/prd/locust/swarm/terraform.tfvars
+++ b/gcp/live/prd/locust/swarm/terraform.tfvars
@@ -1,0 +1,21 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//locust"
+  }
+
+  dependencies {
+    paths = [
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/live/stg/locust/istio/terraform.tfvars
+++ b/gcp/live/stg/locust/istio/terraform.tfvars
@@ -1,8 +1,7 @@
 # ↓ Module metadata
-
 terragrunt = {
   terraform {
-    source = "/project/modules//locust"
+    source = "/project/modules//locust-istio"
   }
 
   include = {
@@ -11,4 +10,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-

--- a/gcp/live/stg/locust/swarm/terraform.tfvars
+++ b/gcp/live/stg/locust/swarm/terraform.tfvars
@@ -1,0 +1,21 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//locust"
+  }
+
+  dependencies {
+    paths = [
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/modules/locust-istio/main.tf
+++ b/gcp/modules/locust-istio/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  backend "gcs" {}
+}
+
+resource "kubernetes_namespace" "locust" {
+  metadata {
+    name = "locust"
+
+    labels {
+      istio-injection = "enabled"
+    }
+  }
+}

--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -28,7 +28,7 @@ resource "null_resource" "locust_swarm_session" {
       WORKERS_READY=0
       while [ "$WORKERS_READY" -lt "${var.locust_workers}" ]; do
         echo "[Try $RETRY_COUNT of $RETRIES] Waiting for all Locust workers to join the master..."
-        WORKERS_READY=$(kubectl -n locust logs deployment/locust-master --tail 1 | grep -oE "Currently \d+ clients" | grep -oE "\d+")
+        WORKERS_READY=$(kubectl -n locust logs deployment/locust-master -c locust --tail 1 | grep -oE "Currently \d+ clients" | grep -oE "\d+")
         if [ "$WORKERS_READY" == "" ]; then
           WORKERS_READY=0
         fi

--- a/shared/charts/locust/Chart.yaml
+++ b/shared/charts/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.7.5
 maintainers:
   - name: so0k

--- a/shared/charts/locust/templates/_helpers.tpl
+++ b/shared/charts/locust/templates/_helpers.tpl
@@ -25,3 +25,11 @@ Create fully qualified configmap name.
 {{- define "locust.worker-configmap" -}}
 {{- printf "%s-%s" .Release.Name "worker" -}}
 {{- end -}}
+
+{{/*
+Get DNS from target-host
+*/}}
+{{- define "locust.host" -}}
+{{- $match := index .Values.master.config "target-host" | toString | regexFind "//.*[^:]" -}}
+{{- $match | trimAll "/" -}}
+{{- end -}}

--- a/shared/charts/locust/templates/egress-service-entry.yaml
+++ b/shared/charts/locust/templates/egress-service-entry.yaml
@@ -1,0 +1,15 @@
+{{ if not (index .Values.master.config "target-host" | regexMatch ".cluster.local")  }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: locust-target
+spec:
+  hosts:
+  - {{ include "locust.host" . }}
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+{{ end }}

--- a/shared/charts/locust/templates/master-deploy.yaml
+++ b/shared/charts/locust/templates/master-deploy.yaml
@@ -55,15 +55,17 @@ spec:
           - name: locust-tasks
             mountPath: /locust-tasks/
         livenessProbe:
-          periodSeconds: 30
-          httpGet:
-            path: /
-            port: {{ .Values.service.internalPort }}
+          exec:
+            command:
+            - '/usr/bin/curl'
+            - '-f'
+            - 'http://localhost:{{ .Values.service.internalPort }}/'
         readinessProbe:
-          periodSeconds: 30
-          httpGet:
-            path: /
-            port: {{ .Values.service.internalPort }}
+          exec:
+            command:
+            - '/usr/bin/curl'
+            - '-f'
+            - 'http://localhost:{{ .Values.service.internalPort }}/'
       volumes:
       - name: "locust-tasks"
         configMap:

--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -14,6 +14,7 @@ service:
   nodePort: 0
   annotations: {}
   extraLabels: {}
+
 master:
   config:
     target-host: https://site.example.com
@@ -24,9 +25,9 @@ master:
     requests:
       cpu: 100m
       memory: 128Mi
+
 worker:
   config:
-
     # all files from tasks folder are mounted under `/locust-tasks`
     locust-script: "/locust-tasks/tasks.py"
   replicaCount: 2


### PR DESCRIPTION
This is additional PR to the Istio series since we moved Preferences endpoint out of internet and the tests now run against the internal endpoint. Since we're moving that to Istio and enforcing mutual TLS auth, Locust wouldn't be able to connect unless running on Istio itself.

This PR moves Locust to Istio and should be merged before/together with https://github.com/gpii-ops/gpii-infra/pull/324.

This PR:
- Adds locust-istio module to create istio-enabled locust namespace
- Moves locust chart to Istio (liveness & readinees, egress service entry)
- Makes locust module work with Istio
- Adds temporary migration code for locust namespace

I have tried to do this without creating a new dedicated module just for the locust namespace, but wasn's successful due to Helm's inability to handle labels on namespaces (see https://github.com/helm/helm/issues/3503 and https://github.com/helm/helm/issues/4178) and Terraform's inability to handle provider configuration depending on resources for `import` command (even though the provider is not used for the actual resource import, `helm_release` & helm provider use data source dependent config). See https://github.com/hashicorp/terraform/issues/17847 for details.

