### PR TITLE
[GPII-3890]: Add missing cloud security scanner roles to cloud-admin account

### DIFF
--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -17,6 +17,7 @@ cloud_admin_org_roles = [
   "roles/resourcemanager.organizationAdmin",
   "roles/securitycenter.viewer",
   "roles/cloudsecurityscanner.runner",
+  "roles/cloudsecurityscanner.viewer",
   "roles/viewer",
 ]
 

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -16,6 +16,7 @@ cloud_admin_org_roles = [
   "roles/orgpolicy.policyAdmin",
   "roles/resourcemanager.organizationAdmin",
   "roles/securitycenter.viewer",
+  "roles/cloudsecurityscanner.runner",
   "roles/viewer",
 ]
 


### PR DESCRIPTION
This [should allow](https://cloud.google.com/iam/docs/understanding-roles) read access to scans and scan runs, plus the ability to start scans without need to grant project admin.