### PR TITLE
GPII-3745: Bump to 0.5.0-google_gpii.0.

### DIFF
--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.4.0-google
+    image: gpii/exekube:0.5.0-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}


### PR DESCRIPTION
This requires https://github.com/gpii-ops/exekube/pull/52