### PR TITLE
locust/ is no longer a module, so we must delete the 'sub'modules dir…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -303,7 +303,8 @@ gcp-stg:
     - rake display_cluster_state
     - rake display_universal_image_info || true
     # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust] || true
+    - rake destroy_module[locust/istio] || true
+    - rake destroy_module[locust/swarm] || true
     - rake destroy_tfstate[locust] || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
@@ -405,7 +406,8 @@ gcp-prd:
     - rake display_cluster_state
     - rake display_universal_image_info || true
     # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
+    - rake destroy_module[locust/istio] RAKE_REALLY_DESTROY_IN_PRD=true || true
+    - rake destroy_module[locust/swarm] RAKE_REALLY_DESTROY_IN_PRD=true || true
     - rake destroy_tfstate[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys RAKE_REALLY_DESTROY_IN_PRD=true || true


### PR DESCRIPTION
…ectly.

https://raisingthefloor.slack.com/archives/C9PCPPUF8/p1557279409282700

I would prefer a nicer solution (human locust users will have to remember these special destroy_module steps) but this should unblock the pipeline.