### PR TITLE
GPII-3860: Plumbing, 0.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
+# https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
+default_docker: &default_docker
+  docker:
+  - image: gpii/exekube:0.5.1-google_gpii.0
+
 version: 2
 jobs:
   terraform-fmt-check:
-    docker:
-      - image: gpii/exekube:0.4.0-google
+    <<: *default_docker
     working_directory: /workspace
     steps:
       - checkout
@@ -13,8 +17,7 @@ jobs:
             terraform fmt --check=true /workspace
 
   gcp-unit-tests:
-    docker:
-      - image: gpii/exekube:0.4.0-google
+    <<: *default_docker
     working_directory: /workspace
     steps:
       - checkout
@@ -29,8 +32,7 @@ jobs:
             rake
 
   aws-unit-tests:
-    docker:
-      - image: gpii/exekube:0.4.0-google
+    <<: *default_docker
     working_directory: /workspace
     steps:
       - checkout

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.4.0-google -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.5.1-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ common-setup:
     - aws --version
     - docker version
     - docker-compose version
-    - pushd gcp/live/dev/ && rake update_exekube && popd
     - docker images | grep exekube
     - ruby --version
     - bundle version
@@ -57,7 +56,6 @@ gcp-setup:
   script:
     - docker version
     - docker-compose version
-    - pushd gcp/live/dev/ && rake update_exekube && popd
     - docker images | grep exekube
     - ruby --version
     - bundle version

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.4.0-google
+    image: gpii/exekube:0.5.1-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -52,6 +52,7 @@ variable "ci_dev_project_regex" {
 variable "service_apis" {
   default = [
     "bigquery-json.googleapis.com",
+    "binaryauthorization.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudbuild.googleapis.com",
     "cloudkms.googleapis.com",

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -53,7 +53,6 @@ Users who already had an RtF email address/Google account usually have performed
 
 1. Clone this repo (or update to the tip of gpii-ops/master).
 1. `cd gpii-infra/gcp/live/dev`
-1. `rake update_exekube`
 1. `rake`
    * The first time you deploy a GPII Cloud (or after you run `rake clobber`), you will be prompted to authenticate **twice**. Follow the instructions in the prompts.
    * If your browser is configured with multiple Google accounts (e.g. a personal Gmail account as well as an RtF Gmail account), make sure to choose the right one when authenticating.

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.5.0-google_gpii.0
+    image: gpii/exekube:0.5.1-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -32,6 +32,10 @@ variable "prevent_destroy_cluster" {
   default = false
 }
 
+variable "enable_binary_authorization" {
+  default = false
+}
+
 data "google_service_account" "gke_cluster_node" {
   account_id = "gke-cluster-node"
   project    = "${var.project_id}"
@@ -91,6 +95,8 @@ module "gke_cluster" {
   primary_pool_machine_type       = "${var.node_type}"
   primary_pool_oauth_scopes       = ["cloud-platform"]
   primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"
+
+  enable_binary_authorization = "${var.enable_binary_authorization}"
 }
 
 # Workaround from

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -20,11 +20,6 @@ end
 
 @exekube_cmd = "docker-compose run --rm xk"
 
-desc "Pull the current exekube container from the Docker hub"
-task :update_exekube => :set_vars do
-  sh "docker-compose pull"
-end
-
 task :clean_volumes => :set_vars do
   ["helm", "kube", "locust_tasks"].each do |app|
     sh "docker volume rm -f -- #{ENV["TF_VAR_project_id"]}-#{ENV["USER"]}-#{app}"

--- a/shared/rakefiles/tests/Gemfile
+++ b/shared/rakefiles/tests/Gemfile
@@ -10,7 +10,7 @@ source 'https://rubygems.org'
 # gems.
 group :use_gem_installed_in_exekube do
   gem "google-cloud-monitoring", "0.29.2"
-  gem "grpc", "1.17.1"
+  gem "grpc", "1.20.0"
 end
 
 gem "rake"

--- a/shared/rakefiles/tests/Gemfile.lock
+++ b/shared/rakefiles/tests/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
-    grpc (1.17.1)
+    grpc (1.20.0)
       google-protobuf (~> 3.1)
       googleapis-common-protos-types (~> 1.0.0)
     jwt (2.1.0)
@@ -64,7 +64,7 @@ PLATFORMS
 
 DEPENDENCIES
   google-cloud-monitoring (= 0.29.2)
-  grpc (= 1.17.1)
+  grpc (= 1.20.0)
   rake
   rspec
 


### PR DESCRIPTION
More preparatory steps for using Binary Authorization in GKE. There are a few semi-related things in this PR:
* Some plumbing for binary authorization (see also https://github.com/gpii-ops/exekube/pull/53)
* Bump various references to use the new 0.5.1 exekube image
** I should have bumped some of these to 0.5.0 in #390; better late than never ;)
** DRY out image reference in CircleCI config. Tested using my fork -- all tests green there
* Remove `update_exekube`. It shouldn't be needed now that we're using 'immutable' tags
* Enable binary auth API