### PR TITLE
GPII-3909: Upgrade Kubernetes to 1.12

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -68,7 +68,9 @@ module "gke_cluster" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
 
-  kubernetes_version = "${data.external.gke_version_assert.result.version}"
+  # TODO once 1.12 is default, this should be changed back
+  # kubernetes_version = "${data.external.gke_version_assert.result.version}"
+  kubernetes_version = "1.12.7-gke.10"
 
   region = "${var.infra_region}"
 


### PR DESCRIPTION
This PR upgrades Kubernetes to 1.12. Main driver for this is garbage collector issue (see https://issues.gpii.net/browse/GPII-3903 for details). The current (follow K8s default version) logic is disabled, and should be re-enabled once 1.12 is available as default.

I have tested:
- Creating new cluster with 1.12
- Upgrading from current master (1.11) to 1.12
- Downgrade by manually deleting the cluster

Q&A:
- **Any changes to support on 1.12?**
 During my testing (mainly running `rake test_preferences` and `test_flowmanager`, checking Stackdriver alerts), I did not observe any issues nor changes that would require any further action.
- **What does a rollback look like?**
  Unfortunately downgrading a minor version is not supported GKE operation (https://cloud.google.com/kubernetes-engine/docs/how-to/upgrading-a-cluster#upgrading_the_master). Therefore the rollback would be reverting current PR, destroying the cluster manually (`gcloud container clusters delete k8s-cluster --region us-central1`) and recreating by pipeline (I've tested this, the whole process from deletion up to the point when services started correctly responding took cca 28m on my dev cluster).
- **Zero downtime? Small downtime? Communicate to outage@?**
  Running a simple query on Flowmanager's `/health` endpoint, as well as Stackdriver uptime metrics, did not show any downtime during upgrade operation (I did see some higher latencies at one moment, up to ~ cca 10s, but the perf test was running on my laptop so that might be the cause of it, simultaneously running curl loop from gcp also didn't show any dropped requests). So this would be zero-downtime, no comms. upgrade (while I've considered sending a preventive notice in case things go wrong, I would reserve this for real planned downtime upgrades, also upgrading master is standard GKE operation and as such, I would consider it relatively low-risk).
- **Will we lose any support by using 1.12?**
  No, GKE 1.12.X versions are fully supported and generally available, no implications on support from Google.

Notes on upgrade:
- Master upgrade itself consistently took around 16-19 minutes:
  ```
   operation-1557841006824-4f09f8a7  UPGRADE_MASTER    us-central1  k8s-cluster                                           DONE    2019-05-14T13:36:46.824343114Z  2019-05-14T13:54:15.971994714Z
  ```

- Nodes are not upgraded as part of this process (I expect that to happen as node-auto-upgrade in the maintenance window, although latest GKE release notes state that: *Node auto-upgrade is currently disabled. You can continue to upgrade node pools manually. Node auto-upgrade will be re-enabled in the coming weeks.* - https://cloud.google.com/kubernetes-engine/docs/release-notes).