### PR TITLE
Istio phase 3 - try #2

### DIFF
--- a/gcp/modules/gpii-flowmanager/dns.tf
+++ b/gcp/modules/gpii-flowmanager/dns.tf
@@ -1,11 +1,7 @@
-data "terraform_remote_state" "network" {
-  backend = "gcs"
-
-  config {
-    credentials    = "${var.serviceaccount_key}"
-    bucket         = "${var.project_id}-tfstate"
-    prefix         = "${var.env}/infra/network"
-    encryption_key = "/dev/null"
+data "kubernetes_service" "istio-ingressgateway" {
+  metadata {
+    name      = "istio-ingressgateway"
+    namespace = "istio-system"
   }
 }
 
@@ -16,5 +12,5 @@ resource "google_dns_record_set" "flowmanager-dns" {
 
   type    = "A"
   ttl     = 300
-  rrdatas = ["${data.terraform_remote_state.network.static_ip_address}"]
+  rrdatas = ["${data.kubernetes_service.istio-ingressgateway.load_balancer_ingress.0.ip}"]
 }


### PR DESCRIPTION
This is another try on reverted https://github.com/gpii-ops/gpii-infra/pull/324 after resolving the missing ingress-gateway certs/Kube garbage collector issue (GPII-3903) by upgrading to 1.12.

This PR is part of Istio rollout series described in #322 (and should be merged only after #322 and #323).

**This PR** changes external DNS records to IngressGateway.

Included changes:
- Creates individual DNS records for services and points those to Istio IngressGateway (e76578d)

After deployment, verify that:
1. [ ] Flowmanager still works
2. [ ] DNS record points to Istio IngressGateway