### PR TITLE
Minor fixes & cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -301,8 +301,8 @@ gcp-stg:
     - rake display_cluster_state
     - rake display_universal_image_info || true
     # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust/istio] || true
     - rake destroy_module[locust/swarm] || true
+    - rake destroy_module[locust/istio] || true
     - rake destroy_tfstate[locust] || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
@@ -404,8 +404,8 @@ gcp-prd:
     - rake display_cluster_state
     - rake display_universal_image_info || true
     # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust/istio] RAKE_REALLY_DESTROY_IN_PRD=true || true
     - rake destroy_module[locust/swarm] RAKE_REALLY_DESTROY_IN_PRD=true || true
+    - rake destroy_module[locust/istio] RAKE_REALLY_DESTROY_IN_PRD=true || true
     - rake destroy_tfstate[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys RAKE_REALLY_DESTROY_IN_PRD=true || true

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -17,36 +17,6 @@ task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr] => [:configure, :configure
 
   Rake::Task["set_secrets"].invoke
 
-  # This is temporary task to handle updates of existing clusters to Istio (GPII-3671)
-  sh_filter "sh -c '
-    # if there is no kubernetes_namespace resource in TF state
-    terragrunt state pull --terragrunt-working-dir \"live/#{@env}/k8s/gpii/istio\" | jq -er \".modules[].resources[\\\"kubernetes_namespace.gpii\\\"]\" >/dev/null
-    if [ \"$?\" -ne 0 ]; then
-
-      # and if gpii namespace exists
-      kubectl get ns gpii --request-timeout=\"5s\"
-      if [ \"$?\" -eq 0 ]; then
-
-        # import it to TF state
-        terragrunt import kubernetes_namespace.gpii gpii --terragrunt-working-dir \"live/#{@env}/k8s/gpii/istio\"
-      fi
-    fi'"
-
-  # This is temporary task to handle updates of existing clusters to Istio - for locust namespace
-  sh_filter "sh -c '
-    # if there is no kubernetes_namespace resource in TF state
-    terragrunt state pull --terragrunt-working-dir \"live/#{@env}/locust/istio\" | jq -er \".modules[].resources[\\\"kubernetes_namespace.locust\\\"]\" >/dev/null
-    if [ \"$?\" -ne 0 ]; then
-
-      # and if locust namespace exists
-      kubectl get ns locust --request-timeout=\"5s\"
-      if [ \"$?\" -eq 0 ]; then
-
-        # import it to TF state
-        terragrunt import kubernetes_namespace.locust locust --terragrunt-working-dir \"live/#{@env}/locust/istio\"
-      fi
-    fi'"
-
   sh_filter "#{@exekube_cmd} #{args[:cmd]}", !args[:preserve_stderr].nil? if args[:cmd]
 end
 


### PR DESCRIPTION
This PR fixes [GPII-3910 - Investigate and fix "Error loading state" - "The provided encryption key is incorrect" errors](https://issues.gpii.net/browse/GPII-3910) and removes temporary Istio migration scripts.

The issue was caused by a combination of the `terragrunt state pull` which would create the state-file if it didn't exist and running `rake rotate_tfstate_key` in stg/prd environments, which would rotate keys, but only for components under `k8s/` directory and not `locust/`. While there are other possible fixes, removing the unnecessary migration scripts is imho best course fo action.

This might cause issues to devs who still haven't upgraded, but both Istio and locust/Istio have been around for a while.

PR also fixes order of locust modules destroy - `locust/istio` module deletes whole Kubernetes namespace, therefore it makes more sense to first delete the `locust/swarm` deployment and only
after that destroy the actual namespace.
