### PR TITLE
[GPII-2862]: Add log-based metrics and alert policies to notify on critical security events

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,7 @@ common-stg-test-gcp-dev:
     ORGANIZATION_ID: "327626828918"
     TF_VAR_organization_name: "gpii2test"
     TF_VAR_organization_domain: "test1.gpii.net"
+    TF_VAR_common_project_id: "gpii2test-common-stg"
     TF_VAR_aws_zone_id: "Z1T3NF8J9WVBSP"
     # We override default infra region for dev environments
     # due to GCP resource exhaustion issues:

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -4,7 +4,17 @@ terraform {
 
 variable "nonce" {}
 variable "project_id" {}
+variable "organization_id" {}
 variable "serviceaccount_key" {}
+
+resource "template_dir" "resources" {
+  source_dir      = "${path.cwd}/resources"
+  destination_dir = "${path.cwd}/resources_rendered"
+
+  vars {
+    organization_id = "${var.organization_id}"
+  }
+}
 
 # Enables debug mode when TF_VAR_stackdriver_debug is not empty
 
@@ -30,7 +40,7 @@ resource "null_resource" "apply_stackdriver_lbm" {
         echo "[Try $RETRY_COUNT of $RETRIES] Applying Stackdriver resources..."
         ruby -e '
           require "/rakefiles/stackdriver.rb"
-          resources = read_resources("${path.module}/resources")
+          resources = read_resources("${path.module}/resources_rendered")
           apply_resources(resources)
         '
         STACKDRIVER_EXIT_STATUS="$?"

--- a/gcp/modules/gcp-stackdriver-lbm/main.tf
+++ b/gcp/modules/gcp-stackdriver-lbm/main.tf
@@ -6,6 +6,7 @@ variable "nonce" {}
 variable "project_id" {}
 variable "organization_id" {}
 variable "serviceaccount_key" {}
+variable "common_project_id" {}
 
 resource "template_dir" "resources" {
   source_dir      = "${path.cwd}/resources"
@@ -13,6 +14,7 @@ resource "template_dir" "resources" {
 
   vars {
     organization_id = "${var.organization_id}"
+    common_sa       = "projectowner@${var.common_project_id}.iam.gserviceaccount.com"
   }
 }
 

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls.json
@@ -1,4 +1,0 @@
-{
-  "name": "compute.firewalls",
-  "filter": "resource.type=\"gce_firewall_rule\" AND (jsonPayload.event_subtype=\"compute.firewalls.insert\" OR jsonPayload.event_subtype=\"compute.firewalls.patch\")"
-}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls_modify.json
@@ -1,4 +1,4 @@
 {
-  "name": "compute.firewalls",
+  "name": "compute.firewalls.modify",
   "filter": "resource.type=\"gce_firewall_rule\" AND (protoPayload.methodName:\"compute.firewalls.insert\" OR protoPayload.methodName:\"compute.firewalls.patch\" OR protoPayload.methodName:\"compute.firewalls.update\" OR protoPayload.methodName:\"compute.firewalls.delete\")"
 }

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_firewalls_modify.json
@@ -1,0 +1,4 @@
+{
+  "name": "compute.firewalls",
+  "filter": "resource.type=\"gce_firewall_rule\" AND (protoPayload.methodName:\"compute.firewalls.insert\" OR protoPayload.methodName:\"compute.firewalls.patch\" OR protoPayload.methodName:\"compute.firewalls.update\" OR protoPayload.methodName:\"compute.firewalls.delete\")"
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_instances_insert.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_instances_insert.json
@@ -1,4 +1,4 @@
 {
   "name": "compute.instances.insert",
-  "filter": "resource.type=\"gce_instance\" AND jsonPayload.event_subtype=\"compute.instances.insert\""
+  "filter": "resource.type=\"gce_instance\" AND (protoPayload.methodName=\"beta.compute.instances.insert\" OR protoPayload.methodName=\"compute.instances.insert\") AND protoPayload.authenticationInfo.principalEmail!=\"${organization_id}@cloudservices.gserviceaccount.com\""
 }

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_instances_insert.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/compute_instances_insert.json
@@ -1,0 +1,4 @@
+{
+  "name": "compute.instances.insert",
+  "filter": "resource.type=\"gce_instance\" AND jsonPayload.event_subtype=\"compute.instances.insert\""
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/dns_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/dns_modify.json
@@ -1,0 +1,4 @@
+{
+  "name": "dns.modify",
+  "filter": "resource.type=\"dns_managed_zone\" AND (protoPayload.methodName=\"dns.changes.create\" OR protoPayload.methodName=\"dns.managedZones.delete\" OR protoPayload.methodName=\"dns.managedZones.patch\" OR protoPayload.methodName=\"dns.managedZones.update\")"
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/gke_cluster_create.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/gke_cluster_create.json
@@ -1,0 +1,4 @@
+{
+  "name": "gke_cluster.create",
+  "filter": "resource.type=\"gke_cluster\" AND protoPayload.methodName=\"google.container.v1beta1.ClusterManager.CreateCluster\""
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/gke_cluster_create.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/gke_cluster_create.json
@@ -1,4 +1,4 @@
 {
   "name": "gke_cluster.create",
-  "filter": "resource.type=\"gke_cluster\" AND protoPayload.methodName=\"google.container.v1beta1.ClusterManager.CreateCluster\""
+  "filter": "resource.type=\"gke_cluster\" AND protoPayload.methodName:\"ClusterManager.CreateCluster\""
 }

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/iam_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/iam_modify.json
@@ -1,4 +1,4 @@
 {
   "name": "iam.modify",
-  "filter": "(resource.type=\"project\" AND protoPayload.methodName=\"SetIamPolicy\") OR (resource.type=\"service_account\" AND protoPayload.methodName:\"SetIAMPolicy\") AND protoPayload.authenticationInfo.principalEmail!=\"${common_sa}\""
+  "filter": "((resource.type=\"project\" AND protoPayload.methodName=\"SetIamPolicy\") OR (resource.type=\"service_account\" AND protoPayload.methodName:\"SetIAMPolicy\")) AND protoPayload.authenticationInfo.principalEmail!=\"${common_sa}\""
 }

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/iam_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/iam_modify.json
@@ -1,0 +1,4 @@
+{
+  "name": "iam.modify",
+  "filter": "(resource.type=\"project\" AND protoPayload.methodName=\"SetIamPolicy\") OR (resource.type=\"service_account\" AND protoPayload.methodName:\"SetIAMPolicy\") AND protoPayload.authenticationInfo.principalEmail!=\"${common_sa}\""
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/servicemanagement_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/servicemanagement_modify.json
@@ -1,0 +1,4 @@
+{
+  "name": "servicemanagement.modify",
+  "filter": "resource.type=\"audited_resource\" AND protoPayload.serviceName=\"servicemanagement.googleapis.com\" AND (protoPayload.methodName=\"google.api.servicemanagement.v1.ServiceManager.DeactivateServices\" OR protoPayload.methodName=\"google.api.servicemanagement.v1.ServiceManager.ActivateServices\" OR protoPayload.methodName=\"google.api.servicemanagement.v1.ServiceManager.EnableService\" OR protoPayload.methodName=\"google.api.servicemanagement.v1.ServiceManager.DisableService\")"
+}

--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/stackdriver_alertpolicy_modify.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/stackdriver_alertpolicy_modify.json
@@ -1,0 +1,4 @@
+{
+  "name": "stackdriver.alertpolicy.modify",
+  "filter": "protoPayload.serviceName=\"monitoring.googleapis.com\" AND (protoPayload.methodName:\"AlertPolicyService.DeleteAlertPolicy\" OR protoPayload.methodName:\"AlertPolicyService.UpdateAlertPolicy\")"
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -9,6 +9,7 @@ provider "google-beta" {
 
 variable "nonce" {}
 variable "domain_name" {}
+variable "organization_id" {}
 variable "project_id" {}
 variable "serviceaccount_key" {}
 variable "auth_user_email" {}
@@ -33,6 +34,7 @@ resource "template_dir" "resources" {
 
   vars {
     project_id         = "${var.project_id}"
+    organization_id    = "${var.organization_id}"
     domain_name        = "${var.domain_name}"
     notification_email = "${(var.use_auth_user_email && var.auth_user_email != "") ? var.auth_user_email : var.notification_email}"
   }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_firewalls_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_firewalls_modify.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Firewalls Activity Check",
+  "display_name": "GCE audit log does not contain firewall modification events",
   "combiner": "OR",
   "conditions": [
     {
@@ -29,11 +29,11 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log-based compute.firewalls activity check"
+      "display_name": "Firewall modification event found in GCE audit log"
     }
   ],
   "documentation": {
-    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=jsonPayload.event_subtype%3D%22compute.firewalls.insert%22%20OR%20jsonPayload.event_subtype%3D%22compute.firewalls.patch%22)",
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22gce_firewall_rule%22%20AND%20(protoPayload.methodName:%22compute.firewalls.insert%22%20OR%20protoPayload.methodName:%22compute.firewalls.patch%22%20OR%20protoPayload.methodName:%22compute.firewalls.update%22%20OR%20protoPayload.methodName:%22compute.firewalls.delete%22)",
     "mime_type": "text/markdown"
   },
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_firewalls_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_firewalls_modify.json
@@ -4,7 +4,7 @@
   "conditions": [
     {
       "condition_threshold": {
-        "filter": "metric.type=\"logging.googleapis.com/user/compute.firewalls\" resource.type=\"global\"",
+        "filter": "metric.type=\"logging.googleapis.com/user/compute.firewalls.modify\" resource.type=\"global\"",
         "comparison": "COMPARISON_GT",
         "threshold_value": 0.0,
         "duration": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
@@ -33,7 +33,7 @@
     }
   ],
   "documentation": {
-    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=jsonPayload.event_subtype%3D%22compute.instances.insert%22)",
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=(protoPayload.methodName%3D%22beta.compute.instances.insert%22%20OR%20protoPayload.methodName%3D%22compute.instances.insert%22)%20AND%20protoPayload.authenticationInfo.principalEmail!%3D%${organization_id}@cloudservices.gserviceaccount.com%22)",
     "mime_type": "text/markdown"
   },
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "Compute Instances Creation Check",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/compute.instances.insert\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Log-based compute instances creation check"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=jsonPayload.event_subtype%3D%22compute.instances.insert%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/compute_instances_insert.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Compute Instances Creation Check",
+  "display_name": "GCE audit log does not contain non-GKE instance creation events",
   "combiner": "OR",
   "conditions": [
     {
@@ -29,7 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log-based compute instances creation check"
+      "display_name": "Non-GKE instance creation event found in GCE audit log"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "couchdb_prometheus_exporter exports a metric",
+  "display_name": "CouchDB Prometheus Metric Exporter Check",
   "combiner": "OR",
   "conditions": [
     {
@@ -27,7 +27,7 @@
           }
         ]
       },
-      "display_name": "custom/couchdb/httpd_node_up"
+      "display_name": "Check for absense of custom/couchdb/httpd_node_up metric"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_prometheus_exporter_exports_metric.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "CouchDB Prometheus Metric Exporter Check",
+  "display_name": "couchdb_prometheus_exporter exports a metric",
   "combiner": "OR",
   "conditions": [
     {
@@ -27,7 +27,7 @@
           }
         ]
       },
-      "display_name": "Check for absense of custom/couchdb/httpd_node_up metric"
+      "display_name": "custom/couchdb/httpd_node_up"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/dns_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/dns_modify.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "CloudDNS audit log does not contain zone modification events",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/servicemanagement.modify\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Zone modification modification event found in CloudDNS audit log"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22dns_managed_zone%22%20AND%20(protoPayload.methodName%3D%22dns.changes.create%22%20OR%20protoPayload.methodName%3D%22dns.managedZones.delete%22%20OR%20protoPayload.methodName%3D%22dns.managedZones.patch%22%20OR%20protoPayload.methodName%3D%22dns.managedZones.update%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
@@ -29,7 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log-based compute firewalls creation / modification check"
+      "display_name": "Log-based compute.firewalls activity check"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/firewalls_activity.json
@@ -29,7 +29,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log-based compute.firewalls activity check"
+      "display_name": "Log-based compute firewalls creation / modification check"
     }
   ],
   "documentation": {

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/gke_cluster_create.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/gke_cluster_create.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "GKE audit log does not contain cluster creation events",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/gke_cluster.create\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "GKE cluster creation event found in the audit log"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22gke_cluster%22%20AND%20protoPayload.methodName%3D%22google.container.v1beta1.ClusterManager.CreateCluster%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/iam_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/iam_modify.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "IAM audit logs does not contain policy modification events",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/iam.modify\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "IAM policy modification event found in audit logs"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=(resource.type%3D%22project%22%20AND%20protoPayload.methodName%3D%22SetIamPolicy%22)%20OR%20(resource.type%3D%22service_account%22%20AND%20protoPayload.methodName:%22SetIAMPolicy%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/servicemanagement_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/servicemanagement_modify.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "Service management log does not contain API enabling / disabling events",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/servicemanagement.modify\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "API enabling / disabling event found in the service management log"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22audited_resource%22%20AND%20protoPayload.serviceName%3D%22servicemanagement.googleapis.com%22%20AND%20(protoPayload.methodName%3D%22google.api.servicemanagement.v1.ServiceManager.DeactivateServices%22%20OR%20protoPayload.methodName%3D%22google.api.servicemanagement.v1.ServiceManager.ActivateServices%22%20OR%20protoPayload.methodName%3D%22google.api.servicemanagement.v1.ServiceManager.EnableService%22%20OR%20protoPayload.methodName%3D%22google.api.servicemanagement.v1.ServiceManager.DisableService%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/stackdriver_alertpolicy_modify.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/stackdriver_alertpolicy_modify.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "Stackdriver audit log does not contain alert policy modification events",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/servicemanagement.modify\" resource.type=\"global\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Alert policy modification event found in Stackdriver audit log"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=protoPayload.serviceName%3D%22monitoring.googleapis.com%22%20AND%20(protoPayload.methodName:%22AlertPolicyService.DeleteAlertPolicy%22%20OR%20protoPayload.methodName:%22AlertPolicyService.UpdateAlertPolicy%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -104,6 +104,7 @@ describe Vars do
     expect(ENV).to have_received(:[]=).with("BILLING_ID", "01A0E1-B0B31F-349F4F")
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_name", "gpii")
     expect(ENV).to have_received(:[]=).with("TF_VAR_organization_domain", "gpii.net")
+    expect(ENV).to have_received(:[]=).with("TF_VAR_common_project_id", "gpii-common-prd")
     expect(ENV).to have_received(:[]=).with("TF_VAR_infra_region", "us-central1")
   end
 
@@ -127,6 +128,7 @@ describe Vars do
     allow(ENV).to receive(:[]).with("BILLING_ID").and_return("fake-billing-id")
     allow(ENV).to receive(:[]).with("TF_VAR_organization_name").and_return("fakecorp")
     allow(ENV).to receive(:[]).with("TF_VAR_organization_domain").and_return("fake.org")
+    allow(ENV).to receive(:[]).with("TF_VAR_common_project_id").and_return("fakecorp-common-stg")
     allow(ENV).to receive(:[]).with("TF_VAR_infra_region").and_return("fake-region1")
     env = "stg"
     project_type = "fake-project-type"
@@ -137,6 +139,7 @@ describe Vars do
     expect(ENV).not_to have_received(:[]=).with("BILLING_ID", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_organization_name", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_organization_domain", any_args)
+    expect(ENV).not_to have_received(:[]=).with("TF_VAR_common_project_id", any_args)
     expect(ENV).not_to have_received(:[]=).with("TF_VAR_infra_region", any_args)
   end
 

--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -19,6 +19,8 @@ class Vars
 
     ENV["TF_VAR_organization_domain"] = "gpii.net" if ENV["TF_VAR_organization_domain"].nil?
 
+    ENV["TF_VAR_common_project_id"] = "gpii-common-prd" if ENV["TF_VAR_common_project_id"].nil?
+
     ENV["ORGANIZATION_ID"] = "247149361674" if ENV["ORGANIZATION_ID"].nil? # RtF Organization
     ENV["TF_VAR_organization_id"] = ENV["ORGANIZATION_ID"]
 


### PR DESCRIPTION
As it turned out after all my experiments with Forseti scanners – this is the most straightforward way to address the issue.
Since it is impossible to reliably distinguish between TF-managed and "rogue" instances, log-based metric and policy is configured to alert on all `compute.instances.insert` events. I don't think it is going to be a trouble for long-lived clusters (stg / prd), but it can potentially add some more alert noise for ephemeral clusters.