### PR TITLE
GPII-3941: Fully-specified version vs floating patch version; init_registry uses alpine:3.9; add commands to display_cluster_state

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -31,3 +31,9 @@ This document describes various high-level prinicples, goals, and rules of thumb
 We should be well-aware of Docker images we use in our infrastructrue, as deploying an untrusted, potentially malicious, image poses a significant security threat.
 
 As a rule of thumb: official Docker curated images (https://docs.docker.com/docker-hub/official_images/) or images directly published by trusted OSS projects are acceptable, otherwise we should build the images ourselves.
+
+#### Fully-specified version vs "floating" patch version
+
+* In general, and especially for critical components (e.g. couchdb), prefer to use a fully specified version (e.g. 2.3.0) for maximum predictability.
+   * We have observed that even a so-called "fully-specified" version (e.g. couchdb:2.3.0) can change (Docker tags are mutable).
+* For stable utility components (e.g. alpine), prefer using a "floating" patch version (e.g. 3.9, not 3.9.4). This allows us to quickly take advantage of security updates with little risk (it is unlikely that alpine:3.9.5 breaks something that worked in alpine:3.9.4).

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -257,11 +257,11 @@ end
 # the Registry, which creates the Registry if it does not exist (or does
 # basically nothing if it already exists).
 task :init_registry => [:set_vars] do
-  # I've chosen the current exekube base image (alpine:3.8) because it is small
+  # I've chosen the current exekube base image (alpine:3.9) because it is small
   # and because it will end up in the Registry anyway. Note that this
   # duplicates information in exekube/dockerfiles, i.e. there is coupling
   # without cohesion.
-  image = "alpine:3.8"
+  image = "alpine:3.9"
   registry_url_base = "gcr.io"
   registry_url = "#{registry_url_base}/#{ENV["TF_VAR_project_id"]}"
 

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -113,6 +113,8 @@ task :display_cluster_state => [:configure, :configure_secrets, :set_secrets] do
     "kubectl -n gpii get events -o wide",
     "kubectl -n locust get all -o wide",
     "kubectl -n locust get events -o wide",
+    "kubectl -n istio-system get svc",
+    "kubectl -n istio-system get secrets",
     # The 'terraform' disks are root partitions. Filter those out to reduce
     # some clutter.
     "gcloud compute disks list --filter 'NOT name:gke-k8s-cluster-terraform' --format json",


### PR DESCRIPTION
```
[tyler@toaster:~/rtf/gpii-infra/gcp/live/stg]$ rake display_cluster_state

...

timeout -t 30 kubectl -n istio-system get svc
NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                                                                                   AGE
istio-citadel            ClusterIP      10.18.24.50     <none>          8060/TCP,9093/TCP                                                                                                         65d
istio-egressgateway      ClusterIP      10.18.104.250   <none>          80/TCP,443/TCP                                                                                                            65d
istio-galley             ClusterIP      10.18.182.171   <none>          443/TCP,9093/TCP                                                                                                          65d
istio-ingressgateway     LoadBalancer   10.18.186.48    35.238.136.95   80:31180/TCP,443:30824/TCP,31400:31935/TCP,15011:32720/TCP,8060:31898/TCP,853:31169/TCP,15030:31070/TCP,15031:30982/TCP   65d
istio-pilot              ClusterIP      10.18.193.33    <none>          15010/TCP,15011/TCP,8080/TCP,9093/TCP                                                                                     65d
istio-policy             ClusterIP      10.18.46.56     <none>          9091/TCP,15004/TCP,9093/TCP                                                                                               65d
istio-sidecar-injector   ClusterIP      10.18.115.239   <none>          443/TCP                                                                                                                   65d
istio-telemetry          ClusterIP      10.18.250.40    <none>          9091/TCP,15004/TCP,9093/TCP,42422/TCP                                                                                     65d
promsd                   ClusterIP      10.18.156.249   <none>          9090/TCP                                                                                                                  63d
timeout -t 30 kubectl -n istio-system get secrets
NAME                                                 TYPE                                  DATA   AGE
default-token-7g4rk                                  kubernetes.io/service-account-token   3      65d                                                                                                       istio-ca-secret                                      istio.io/ca-root                      2      65d
istio-citadel-service-account-token-xp494            kubernetes.io/service-account-token   3      65d
istio-cleanup-secrets-service-account-token-f58bl    kubernetes.io/service-account-token   3      65d
istio-egressgateway-service-account-token-zm2h4      kubernetes.io/service-account-token   3      65d
istio-galley-service-account-token-t5rzl             kubernetes.io/service-account-token   3      65d
istio-ingressgateway-service-account-token-d7szb     kubernetes.io/service-account-token   3      65d
istio-mixer-service-account-token-pwllz              kubernetes.io/service-account-token   3      65d
istio-pilot-service-account-token-br7c5              kubernetes.io/service-account-token   3      65d
istio-security-post-install-account-token-qpg9h      kubernetes.io/service-account-token   3      65d
istio-sidecar-injector-service-account-token-nzr8v   kubernetes.io/service-account-token   3      65d
istio.default                                        istio.io/key-and-cert                 3      65d
istio.istio-citadel-service-account                  istio.io/key-and-cert                 3      65d
istio.istio-cleanup-secrets-service-account          istio.io/key-and-cert                 3      65d
istio.istio-egressgateway-service-account            istio.io/key-and-cert                 3      65d
istio.istio-galley-service-account                   istio.io/key-and-cert                 3      65d
istio.istio-ingressgateway-service-account           istio.io/key-and-cert                 3      65d
istio.istio-mixer-service-account                    istio.io/key-and-cert                 3      65d
istio.istio-pilot-service-account                    istio.io/key-and-cert                 3      65d
istio.istio-security-post-install-account            istio.io/key-and-cert                 3      65d
istio.istio-sidecar-injector-service-account         istio.io/key-and-cert                 3      65d                                                                                                       istio.prometheus                                     istio.io/key-and-cert                 3      65d
istio.promsd                                         istio.io/key-and-cert                 3      63d
prometheus-token-nwwm7                               kubernetes.io/service-account-token   3      65d
promsd-token-nflc8                                   kubernetes.io/service-account-token   3      63d
```