### PR TITLE
GPII-3937: Wait for Istio ingress IP

### DIFF
--- a/gcp/modules/gpii-flowmanager/dns.tf
+++ b/gcp/modules/gpii-flowmanager/dns.tf
@@ -1,8 +1,34 @@
+resource "null_resource" "ingress_ip_wait" {
+  triggers = {
+    nonce = "${var.nonce}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+      COUNT=1
+      MAX_RETRIES=60
+      SLEEP_SEC=5
+      INGRESS_READY=false
+
+      while [ "$INGRESS_READY" != 'true' ] && [ "$COUNT" -le "$MAX_RETRIES" ]; do
+        echo "Waiting for istio-ingressgateway ip ($COUNT/$MAX_RETRIES)"
+        kubectl -n istio-system get svc istio-ingressgateway -o json | jq -e '.status.loadBalancer.ingress[0].ip'
+        [ "$?" -eq 0 ] && INGRESS_READY=true
+        # Sleep only if we're not ready
+        [ "$INGRESS_READY" != 'true' ] && sleep "$SLEEP_SEC"
+        COUNT=$((COUNT+1))
+      done
+    EOF
+  }
+}
+
 data "kubernetes_service" "istio-ingressgateway" {
   metadata {
     name      = "istio-ingressgateway"
     namespace = "istio-system"
   }
+
+  depends_on = ["null_resource.ingress_ip_wait"]
 }
 
 resource "google_dns_record_set" "flowmanager-dns" {

--- a/gcp/modules/gpii-flowmanager/main.tf
+++ b/gcp/modules/gpii-flowmanager/main.tf
@@ -6,6 +6,7 @@ variable "env" {}
 variable "serviceaccount_key" {}
 variable "project_id" {}
 variable "auth_user_email" {}
+variable "nonce" {}
 
 variable "secrets_dir" {}
 variable "charts_dir" {}


### PR DESCRIPTION
This PR adds a wait for Istio's ingress gateway IP to be allocated (before trying to retrieve it via TF's data source).

This also fixes error when running destroy on empty infrastructure.