### PR TITLE
GPII-3903: Fix garbage-collector cross-namespace issue

### DIFF
--- a/gcp/modules/certmerge-operator-crd/main.tf
+++ b/gcp/modules/certmerge-operator-crd/main.tf
@@ -11,7 +11,7 @@ module "certmerge-operator-crd" {
   client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
   release_name      = "certmerge-operator-crd"
-  release_namespace = "certmerge"
+  release_namespace = "istio-system"
 
   chart_name = "${var.charts_dir}/certmerge-operator-crd"
 }

--- a/gcp/modules/certmerge-operator-crd/main.tf
+++ b/gcp/modules/certmerge-operator-crd/main.tf
@@ -10,7 +10,10 @@ module "certmerge-operator-crd" {
   tiller_namespace = "kube-system"
   client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
-  release_name      = "certmerge-operator-crd"
+  release_name = "certmerge-operator-crd"
+
+  # This is to fix issue with K8s garbage collector (GPII-3903), which does not support
+  # cross-namespace garbage collection correctly
   release_namespace = "istio-system"
 
   chart_name = "${var.charts_dir}/certmerge-operator-crd"


### PR DESCRIPTION
This is a bit of a long-shot to try to fix the Istio ingress-gateway-certs/garbage collector issue.

Due to the difficulty of reproducing this, I'm not able to confirm if it will fix the issue, but certainly shouldn't make anything worse. The cross-namespace GC seems to be un-intentional (although it's deleting the certs in our case) as per official docs - https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/, and there are a couple of issues related to this, mainly:
- https://github.com/kubernetes/kubernetes/pull/63386
- https://github.com/kubernetes/kubernetes/issues/65200

I originally didn't think this might be the cause, but after going through the issues above & some others opened against Kubernetes, I think it's worth a shot.

This PR moves the parent resource (certmerge) to the same namespace as the child - istio-system.