### PR TITLE
GPII-3940: Exekube upgrade

### DIFF
--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.5.1-google_gpii.0
+    image: gpii/exekube:0.6.0-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.5.1-google_gpii.0
+    image: gpii/exekube:0.6.0-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/shared/charts/gpii-preferences/Chart.yaml
+++ b/shared/charts/gpii-preferences/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-preferences
-version: 1.1.1
+version: 1.1.2
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Preferences Service.

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- if .Values.resources }}
         resources:
-        {{ toYaml .Values.resources | indent 8 | trim }}
+          {{ toYaml .Values.resources | indent 10 | trim }}
         {{- end }}
         livenessProbe:
           exec:


### PR DESCRIPTION
This PR upgrades exekube image to `gpii/exekube:0.6.0-google_gpii.0`. This upgrades Terraform, Terraform providers and other components, see https://github.com/gpii-ops/exekube/pull/56 for details.

This mainly fixes node_pool recreation due to metadata config ([GPII-3940](https://issues.gpii.net/browse/GPII-3940)) - see GoogleCloudPlatform/magic-modules#1507 for details.

Also included is a small formatting fix for preferences chart which was causing wrong yaml indentation and deployment spec validation fail with new helm.