### PR TITLE
GPII-3959: Fix for CouchDB prometheus exporter not starting

### DIFF
--- a/shared/charts/couchdb-prometheus-exporter/Chart.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb-prometheus-exporter
-version: 0.0.1
+version: 0.0.2
 appVersion: 77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2
 home: https://github.com/gesellix/couchdb-prometheus-exporter
 description: CouchDB Prometheus Exporter


### PR DESCRIPTION
This PR bumps version of CouchDB Prometheus exporter Chart to force redeployment with new labels (disabling istio sidecar) on non-ephemeral clusters.

This fixes issue of Prometheus exporter not starting.