### PR TITLE
Istio pilot workaround

### DIFF
--- a/gcp/modules/locust/values.yaml
+++ b/gcp/modules/locust/values.yaml
@@ -10,3 +10,7 @@ worker:
   replicaCount: ${locust_workers}
   config:
     locust-script: /locust-tasks/${locust_script}
+
+service:
+  type: ClusterIP
+  name: http-master-web

--- a/shared/charts/locust/Chart.yaml
+++ b/shared/charts/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.7.5
 maintainers:
   - name: so0k

--- a/shared/charts/locust/templates/_helpers.tpl
+++ b/shared/charts/locust/templates/_helpers.tpl
@@ -11,6 +11,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "master-svc" | trunc 63 -}}
 {{- end -}}
 
+{{- define "locust.worker-svc" -}}
+{{- printf "%s-%s" .Release.Name "worker-svc" | trunc 63 -}}
+{{- end -}}
+
 {{- define "locust.master" -}}
 {{- printf "%s-%s" .Release.Name "master" | trunc 63 -}}
 {{- end -}}

--- a/shared/charts/locust/templates/master-deploy.yaml
+++ b/shared/charts/locust/templates/master-deploy.yaml
@@ -41,6 +41,8 @@ spec:
           value: "master"
         - name: LOCUST_SCRIPT
           value: {{ index .Values.worker.config "locust-script" | quote }}
+        - name: WAIT_FOR_TARGET
+          value: "false"
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: loc-master-web

--- a/shared/charts/locust/templates/worker-svc.yaml
+++ b/shared/charts/locust/templates/worker-svc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "locust.worker-svc" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "locust.fullname" . }}
+    component: "worker"
+    {{- range $key, $value :=  .Values.service.extraLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- range $key, $value :=  .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: {{ template "locust.fullname" . }}
+    component: "worker"
+  sessionAffinity: None


### PR DESCRIPTION
This PR is a try to fix the issue with failing tests, which is caused by Istio (race condition between podIP and adding inbound listener I believe, see https://issues.gpii.net/browse/GPII-3960 for more details). 

One of the "soft" requirements for Istio is that a pod must belong to at least one Kubernetes service even if the pod does NOT expose any port (see https://istio.io/docs/setup/kubernetes/prepare/requirements/ for details). This affects discovery and how & when Istio pushes info to pilot and other proxies, and I believe it might help in our case.

I've tested this, running tests with and without this fix in stg, and it seems to make a difference. But as I can't reproduce the issue reliably, I'm not 100% sure it will fix the issue.

Changes introduced in this PR:
- Change locust master svc to ClusterIP - there's no need to expose locust as NodePort service
- Rename port to istio-friendly name - Istio benefits from port name prefixed by traffic type (see https://istio.io/docs/setup/kubernetes/prepare/requirements/), renaming port to `http-*` allows one to take advantage of Istio’s http metrics (otherwise the traffic is treated as generic tcp)
- Add locust worker service - "soft" requirement for Istio, headless
- Disable wait for target for locust master - no need there, speeds up master start