### PR TITLE
GPII-3968: Updated to new enough version to pick up payload validation checks.

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -70,7 +70,7 @@ couchdb:
 dataloader:
   upstream:
     repository: gpii/universal
-    tag: 20190529130130-a3fea39
+    tag: 20190530151536-8203d4b
   generated:
     repository: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076
@@ -78,7 +78,7 @@ dataloader:
 flowmanager:
   upstream:
     repository: gpii/universal
-    tag: 20190529130130-a3fea39
+    tag: 20190530151536-8203d4b
   generated:
     repository: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076
@@ -110,7 +110,7 @@ nginx_ingress:
 preferences:
   upstream:
     repository: gpii/universal
-    tag: 20190529130130-a3fea39
+    tag: 20190530151536-8203d4b
   generated:
     repository: gcr.io/gpii-common-prd/gpii/universal
     sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076


### PR DESCRIPTION
This is the second pull to add validation checks to various endpoints provided by the universal repository. 
 This is the second pull, [the previous pull](https://github.com/gpii-ops/gpii-infra/pull/416) did not use a new enough version of the universal docker container.

This deployment does not require any special handling, there are no changes to data stored in CouchDB that would require a migration.  There are  no new containers, i.e. this is. just an update to the three containers provisioned from the universal container.

@cindyli can easily verify the change by:

1. Logging in to get auth credentials.
2. Using those credentials to attempt to submit an invalid payload to one of the secured endpoints, (settings GET, etc.).