### PR TITLE
GPII-3968: Replace telugu with nvda.

### DIFF
--- a/gcp/modules/locust/tasks/flowmanager.py
+++ b/gcp/modules/locust/tasks/flowmanager.py
@@ -3,7 +3,7 @@ import random
 
 class FlowmanagerTasks(TaskSet):
 
-  _keys = ["carla", "vladimir", "wayne", "omar", "telugu"]
+  _keys = ["carla", "vladimir", "wayne", "omar", "nvda"]
 
   @task
   def post_access_token(self):

--- a/gcp/modules/locust/tasks/preferences.py
+++ b/gcp/modules/locust/tasks/preferences.py
@@ -3,7 +3,7 @@ import random
 
 class PreferencesTasks(TaskSet):
 
-  _keys = ["carla", "vladimir", "wayne", "omar", "telugu"]
+  _keys = ["carla", "vladimir", "wayne", "omar", "nvda"]
 
   @task
   def get_pref_by_key(self):


### PR DESCRIPTION
telugu's snapset was invalid under Tony's new validation scheme.

nvda is the largest snapset we currently have (10k).