### PR TITLE
Istio HA - HPAs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,6 +233,8 @@ gcp-plan-all-stg:
     - rake fetch_helm_certs
     # Infra requires special treatment because of secrets configuration
     - rake plain_sh['rake plan_infra'] || true
+    # Sync GKE Istio state so that the plan reflects real changes
+    - rake plain_sh['rake sync_gke_istio_state'] || true
     - rake sh['xk plan-all live/stg/k8s 2> /dev/null'] || true
   only:
     - master@gpii-ops/gpii-infra
@@ -344,6 +346,8 @@ gcp-plan-all-prd:
     - rake fetch_helm_certs
     # Infra requires special treatment because of secrets configuration
     - rake plain_sh['rake plan_infra'] || true
+    # Sync GKE Istio state so that the plan reflects real changes
+    - rake plain_sh['rake sync_gke_istio_state'] || true
     - rake sh['xk plan-all live/prd/k8s 2> /dev/null'] || true
   only:
     - master@gpii-ops/gpii-infra

--- a/gcp/live/dev/k8s/istio/terraform.tfvars
+++ b/gcp/live/dev/k8s/istio/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/prd/k8s/istio/terraform.tfvars
+++ b/gcp/live/prd/k8s/istio/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/stg/k8s/istio/terraform.tfvars
+++ b/gcp/live/stg/k8s/istio/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/modules/istio/hpa.tf
+++ b/gcp/modules/istio/hpa.tf
@@ -1,0 +1,119 @@
+resource "kubernetes_horizontal_pod_autoscaler" "istio-egressgateway" {
+  metadata = {
+    name      = "istio-egressgateway"
+    namespace = "istio-system"
+
+    labels = {
+      k8s-app = "istio"
+    }
+  }
+
+  spec {
+    max_replicas = 5
+    min_replicas = 2
+
+    scale_target_ref {
+      kind        = "Deployment"
+      name        = "istio-egressgateway"
+      api_version = "apps/v1beta1"
+    }
+
+    target_cpu_utilization_percentage = 80
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler" "istio-ingressgateway" {
+  metadata = {
+    name      = "istio-ingressgateway"
+    namespace = "istio-system"
+
+    labels = {
+      k8s-app = "istio"
+    }
+  }
+
+  spec {
+    max_replicas = 5
+    min_replicas = 3
+
+    scale_target_ref {
+      kind        = "Deployment"
+      name        = "istio-ingressgateway"
+      api_version = "apps/v1beta1"
+    }
+
+    target_cpu_utilization_percentage = 80
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler" "istio-pilot" {
+  metadata = {
+    name      = "istio-pilot"
+    namespace = "istio-system"
+
+    labels = {
+      k8s-app = "istio"
+    }
+  }
+
+  spec {
+    max_replicas = 5
+    min_replicas = 2
+
+    scale_target_ref {
+      kind        = "Deployment"
+      name        = "istio-pilot"
+      api_version = "apps/v1beta1"
+    }
+
+    target_cpu_utilization_percentage = 80
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler" "istio-policy" {
+  metadata = {
+    name      = "istio-policy"
+    namespace = "istio-system"
+
+    labels = {
+      k8s-app = "istio"
+    }
+  }
+
+  spec {
+    max_replicas = 5
+    min_replicas = 2
+
+    scale_target_ref {
+      kind        = "Deployment"
+      name        = "istio-policy"
+      api_version = "apps/v1beta1"
+    }
+
+    target_cpu_utilization_percentage = 80
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler" "istio-telemetry" {
+  metadata = {
+    name      = "istio-telemetry"
+    namespace = "istio-system"
+
+    labels = {
+      k8s-app = "istio"
+    }
+  }
+
+  spec {
+    max_replicas = 5
+    min_replicas = 2
+
+    scale_target_ref {
+      kind        = "Deployment"
+      name        = "istio-telemetry"
+      api_version = "apps/v1beta1"
+    }
+
+    target_cpu_utilization_percentage = 80
+  }
+}

--- a/gcp/modules/istio/hpa.tf
+++ b/gcp/modules/istio/hpa.tf
@@ -1,3 +1,7 @@
+# Most of the values in this module (such as max_replicas or target_cpu_utilization_percentage)
+# come from the default Istio deployment by GKE.
+# min_replicas has been increased, compared to the GKE defaults, to provide HA.
+
 resource "kubernetes_horizontal_pod_autoscaler" "istio-egressgateway" {
   metadata = {
     name      = "istio-egressgateway"

--- a/gcp/modules/istio/main.tf
+++ b/gcp/modules/istio/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "gcs" {}
+}

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -69,7 +69,7 @@ end
 
 desc "Create cluster and deploy GPII components to it"
 task :deploy => [:set_vars, :apply_infra] do
-  sh "#{@exekube_cmd} rake xk[up]"
+  sh "#{@exekube_cmd} rake xk[up,false,false,true]"
   Rake::Task["display_cluster_info"].invoke
 end
 
@@ -314,7 +314,7 @@ task :deploy_module, [:module] => [:set_vars, :fetch_helm_certs] do |taskname, a
     puts "  ERROR: args[:module] must point to Terragrunt directory!"
     raise
   end
-  sh "#{@exekube_cmd} rake xk['apply live/#{@env}/#{args[:module]}',skip_secret_mgmt]"
+  sh "#{@exekube_cmd} rake xk['apply live/#{@env}/#{args[:module]}',true,false,true]"
 end
 
 desc "[ADVANCED] Destroy provided module in the cluster -- rake destroy_module['k8s/kube-system/cert-manager']"

--- a/shared/rakefiles/scripts/sync_gke_istio_state.sh
+++ b/shared/rakefiles/scripts/sync_gke_istio_state.sh
@@ -24,7 +24,7 @@ REQUIRED_BINARIES=${REQUIRED_BINARIES:="kubectl terragrunt jq"}
 # check the module does exist, otherwise silently exit
 if [ ! -d "${ISTIO_MODULE_DIR}" ]
 then
-  echo "${THIS_SCRIPT}: Istio module not found (${ISTIO_MODULE_DIR})"
+  echo "${THIS_SCRIPT}: Skipping Istio HPA state synchronization, Istio module not found (${ISTIO_MODULE_DIR})"
   exit 0
 fi
 

--- a/shared/rakefiles/scripts/sync_gke_istio_state.sh
+++ b/shared/rakefiles/scripts/sync_gke_istio_state.sh
@@ -50,7 +50,7 @@ for HPA in ${ISTIO_HPAS}; do
   if ! echo "${RESOURCES}" | jq -ers ".[].\"kubernetes_horizontal_pod_autoscaler.${HPA}\"" >/dev/null
   then
     # and if hpa exists
-    if kubectl get hpa "${HPA}" -n istio-system --request-timeout='5s'
+    if kubectl get hpa "${HPA}" -n istio-system --request-timeout='5s' >/dev/null
     then
       echo "${THIS_SCRIPT}: Trying to import GKE Istio HPA - ${HPA}"
       # import it to TF state

--- a/shared/rakefiles/scripts/sync_gke_istio_state.sh
+++ b/shared/rakefiles/scripts/sync_gke_istio_state.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+
+# This script goes through a list of Istio HPAs ($ISTIO_HPAS) and tries to
+# import them into Terraform state in given Terragrunt module
+# ($ISTIO_MODULE_DIR). This is intended to sync Terraform state with actual
+# state, as istio components on GKE are managed by Google.
+
+set -eou pipefail
+
+# enable debug output if $DEBUG is set to true
+[ "${DEBUG:=false}" = 'true' ] && set -x
+
+# get script name
+THIS_SCRIPT="$(basename "${0}")"
+
+# list of env variables - interface
+# required
+ENV=${ENV:?"Environment variable must be set"}
+# optional
+ISTIO_MODULE_DIR=${ISTIO_MODULE_DIR:="live/${ENV}/k8s/istio"}
+ISTIO_HPAS=${ISTIO_HPAS:="istio-egressgateway istio-ingressgateway istio-pilot istio-policy istio-telemetry"}
+REQUIRED_BINARIES=${REQUIRED_BINARIES:="kubectl terragrunt jq"}
+
+# check the module does exist, otherwise silently exit
+if [ ! -d "${ISTIO_MODULE_DIR}" ]
+then
+  echo "${THIS_SCRIPT}: Istio module not found (${ISTIO_MODULE_DIR})"
+  exit 0
+fi
+
+# check if we have all the dependencies
+for BIN in ${REQUIRED_BINARIES}; do
+  if [ ! -x "$(command -v "${BIN}")" ]
+  then
+    echo "${THIS_SCRIPT}: Required dependency ${BIN} not found in path"
+    exit 1
+  fi
+done
+
+# retrieve TF state
+if ! RESOURCES="$(terragrunt state pull --terragrunt-working-dir "${ISTIO_MODULE_DIR}" | jq -ers '.[].modules[].resources')"
+then
+  echo "${THIS_SCRIPT}: Failed to retrieve or parse Terraform state"
+  exit 1
+fi
+
+# iterate through the list of HPAs
+for HPA in ${ISTIO_HPAS}; do
+  # if hpa is not in state already
+  if ! echo "${RESOURCES}" | jq -ers ".[].\"kubernetes_horizontal_pod_autoscaler.${HPA}\"" >/dev/null
+  then
+    # and if hpa exists
+    if kubectl get hpa "${HPA}" -n istio-system --request-timeout='5s'
+    then
+      echo "${THIS_SCRIPT}: Trying to import GKE Istio HPA - ${HPA}"
+      # import it to TF state
+      terragrunt import "kubernetes_horizontal_pod_autoscaler.${HPA}" "istio-system/${HPA}" --terragrunt-working-dir "${ISTIO_MODULE_DIR}"
+    fi
+  fi
+done
+
+echo "${THIS_SCRIPT}: Done"

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -12,7 +12,7 @@ require_relative "./sh_filter.rb"
 # This task is being called from entrypoint.rake and runs inside exekube container.
 # It applies secret-mgmt, sets secrets, and then executes arbitrary command from args[:cmd].
 # You should not invoke this task directly!
-task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr] => [:configure, :configure_secrets] do |taskname, args|
+task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr, :sync_gke_istio_state] => [:configure, :configure_secrets] do |taskname, args|
   sh "#{@exekube_cmd} up live/#{@env}/secret-mgmt" unless args[:skip_secret_mgmt]
 
   Rake::Task["set_secrets"].invoke

--- a/shared/rakefiles/xk.rake
+++ b/shared/rakefiles/xk.rake
@@ -17,22 +17,7 @@ task :xk, [:cmd, :skip_secret_mgmt, :preserve_stderr] => [:configure, :configure
 
   Rake::Task["set_secrets"].invoke
 
-  sh_filter "sh -c '
-    # retrieve TF state
-    RESOURCES=\"$(terragrunt state pull --terragrunt-working-dir \"live/#{@env}/k8s/istio\" | jq -er \".modules[].resources\")\"
-    [ \"$?\" -ne 0 ] && exit 1
-
-    for HPA in istio-egressgateway istio-ingressgateway istio-pilot istio-policy istio-telemetry; do
-      echo \"${RESOURCES}\" | jq -er \".[\\\"kubernetes_horizontal_pod_autoscaler.${HPA}\\\"]\" >/dev/null
-      if [ \"$?\" -ne 0 ]; then
-        # and if hpa exists
-        kubectl get hpa istio-egressgateway -n istio-system --request-timeout=\"5s\"
-        if [ \"$?\" -eq 0 ]; then
-          # import it to TF state
-          terragrunt import \"kubernetes_horizontal_pod_autoscaler.${HPA}\" \"istio-system/${HPA}\" --terragrunt-working-dir \"live/#{@env}/k8s/istio\"
-        fi
-      fi
-    done'"
+  Rake::Task["sync_gke_istio_state"].invoke if args[:sync_gke_istio_state]
 
   sh_filter "#{@exekube_cmd} #{args[:cmd]}", !args[:preserve_stderr].nil? if args[:cmd]
 end

--- a/shared/rakefiles/xk_config.rake
+++ b/shared/rakefiles/xk_config.rake
@@ -125,5 +125,12 @@ task :configure => [@gcp_creds_file, @app_default_creds_file, @kubectl_creds_fil
   # It does nothing, but it has all dependencies that required for standard rake workflow.
 end
 
+task :sync_gke_istio_state => [:configure, :configure_secrets, :set_secrets] do
+  #  This task syncs Terrafrom state to actual state of Istio components.
+  #  As Istio components are created and managed by Google (via Kubernetes add-on manager),
+  #  they have to be imported to Terraform state first, before being modified via Terraform,
+  #  and repeatedly synced as the state can change independently on this code.
+  sh "/rakefiles/scripts/sync_gke_istio_state.sh"
+end
 
 # vim: et ts=2 sw=2:


### PR DESCRIPTION
This PR adds management of Istio HPAs to make Istio deployment Highly Available. All the components are set to min 2 instances (while still allowing them to autoscale up to 5 - GKE's default), except for `istio-ingressgateway` which is set to 3 instances as this is component in the critical path accessed externally via the load-balancer and more instances give the gcp load-balancer health checks a bit more time to settle in situations like node auto-upgrade.

Unfortunately, as Istio components are created and managed by Google (via Kubernetes add-on manager), they have to be imported to Terraform state first, before being modified via Terraform.