### PR TITLE
Istio HPA state sync fix

### DIFF
--- a/gcp/modules/gke-cluster/istio-sync.tf
+++ b/gcp/modules/gke-cluster/istio-sync.tf
@@ -1,0 +1,15 @@
+# GKE Istio state needs to be synced right after the cluster is created
+# for the firs time and before istio module runs
+
+resource "null_resource" "sync_gke_istio_state" {
+  depends_on = ["module.gke_cluster"]
+
+  provisioner "local-exec" {
+    command     = "/rakefiles/scripts/sync_gke_istio_state.sh"
+    working_dir = "/project"
+
+    environment = {
+      ENV = "${var.env}"
+    }
+  }
+}

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -14,6 +14,7 @@ provider "google-beta" {
 
 variable "project_id" {}
 variable "serviceaccount_key" {}
+variable "env" {}
 
 # Terragrunt variables
 variable "node_type" {}

--- a/shared/rakefiles/scripts/sync_gke_istio_state.sh
+++ b/shared/rakefiles/scripts/sync_gke_istio_state.sh
@@ -37,8 +37,9 @@ for BIN in ${REQUIRED_BINARIES}; do
   fi
 done
 
-# retrieve TF state
-if ! RESOURCES="$(terragrunt state pull --terragrunt-working-dir "${ISTIO_MODULE_DIR}" | jq -ers '.[].modules[].resources')"
+# retrieve TF state, remove "o:" which is weird artifact added to output when
+# running terraform in terraform
+if ! RESOURCES="$(terragrunt state pull --terragrunt-working-dir "${ISTIO_MODULE_DIR}" | sed 's/^o://g' | jq -ers '.[].modules[].resources')"
 then
   echo "${THIS_SCRIPT}: Failed to retrieve or parse Terraform state"
   exit 1


### PR DESCRIPTION
This PR fixes issue we see in CI on ephemeral clusters:
```yaml
Error: Error applying plan:

5 errors occurred:
	* kubernetes_horizontal_pod_autoscaler.istio-policy: 1 error occurred:
	* kubernetes_horizontal_pod_autoscaler.istio-policy: horizontalpodautoscalers.autoscaling "istio-policy" already exists
...
```
(see https://gitlab.com/gpii-ops/gpii-infra/-/jobs/236134449).

This is caused by Istio HPAs state not being synced between the initial cluster creation and the first run of `istio` module.

Not sure why I didn't catch this initially when testing the cluster creation scenario, but I was able to reproduce this in the local dev env and test the fix.