### PR TITLE
Fix removed projectCreator role

### DIFF
--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -5,6 +5,7 @@ common_sa_org_roles = [
   "roles/iam.serviceAccountAdmin",
   "roles/iam.serviceAccountKeyAdmin",
   "roles/resourcemanager.organizationAdmin",
+  "roles/resourcemanager.projectCreator",
   "roles/serviceusage.serviceUsageAdmin",
   "roles/storage.admin",
   "roles/viewer",


### PR DESCRIPTION
This PR adds back `roles/resourcemanager.projectCreator` which was removed as part of https://github.com/gpii-ops/gpii-infra/pull/380 PR and is causing fail when creating new environments:

```
Error: Error applying plan:

1 error occurred:
    * google_project.project: 1 error occurred:
    * google_project.project: error creating project gpii-gcp-dev-duhrer (gpii-gcp-dev-duhrer): googleapi: Error 403: User is not authorized., forbidden. If you received a 403 error, make sure you have the `roles/resourcemanager.projectCreator` permission
```
(see https://gitlab.com/gpii-ops/gpii-infra/pipelines/67450122 for more).