### PR TITLE
Deploy plans should include a rollback plan.

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -192,6 +192,7 @@ See [CI-CD.md#running-in-non-dev-environments](../CI-CD.md#running-manually-in-n
    * When is a good time for you and the Ops team to deploy this change?
    * Does the deployment require any special handling?
    * How will you verify that your change is working correctly in production?
+   * What is the rollback plan if things don't go well?
 
 ### I need to interact with Helm directly, e.g. because a Helm deployment was orphaned due to an error while running `rake`
 


### PR DESCRIPTION
I added this note during a meeting and now I'm committing it.

Please feel free to merge this whenever; I am confident it will not break anything :) but I didn't want to trigger a pipeline before going offline for a week.