### PR TITLE
GPII-3591 - Delete the DNS AWS zones of the deprecated GPII AWS

### DIFF
--- a/common/modules/aws-gcp-dns/main.tf
+++ b/common/modules/aws-gcp-dns/main.tf
@@ -35,13 +35,6 @@ provider "aws" {
   region  = "us-east-2"
 }
 
-module "aws_zone" {
-  source              = "./aws-dns-zone"
-  record_name         = "aws"
-  aws_zone_id         = "${var.aws_zone_id}"
-  organization_domain = "${var.organization_domain}"
-}
-
 module "gcp_zone" {
   source              = "./gcp-dns-zone"
   record_name         = "gcp"


### PR DESCRIPTION
This PR is part of [GPII-3591](https://issues.gpii.net/browse/GPII-3591). This PR deletes the aws.gpii.net and aws.test1.gpii.net zones and their NS records in the parent domains.

Changes for common-stg
```
[...]
Refreshing Terraform state in-memory prior to plan...                                                                                                                                 
The refreshed state will be used to calculate this plan, but will not be                                                                                                              
persisted to local or remote state storage.                                                                                                                                           
                                                                                                                                                                                      
google_dns_managed_zone.main: Refreshing state... (ID: gcp-test1-gpii-net)                                                                                                            
aws_route53_zone.main: Refreshing state... (ID: Z3CZ4X01NHJQ3U)                            
aws_route53_zone.main: Refreshing state... (ID: Z5PA0UC6SKSF1)                             
aws_route53_record.main_ns: Refreshing state... (ID: Z1T3NF8J9WVBSP_gcp.test1.gpii.net_NS)                                                                                            
aws_route53_record.main_ns: Refreshing state... (ID: Z1T3NF8J9WVBSP_aws.test1.gpii.net_NS)                                                                                            
                                                                                                                                                                                      
------------------------------------------------------------------------                                                                                                              
                                                                                                                                                                                      
An execution plan has been generated and is shown below.                                                                                                                              
Resource actions are indicated with the following symbols:                                                                                                                            
  - destroy                                                                                                                                                                           
                                                                                                                                                                                      
Terraform will perform the following actions:                                              
                                                                                                                                                                                      
  - module.aws_zone.aws_route53_record.main_ns

  - module.aws_zone.aws_route53_zone.main

Plan: 0 to add, 0 to change, 2 to destroy.

------------------------------------------------------------------------
# terragrunt state show module.aws_zone.aws_route53_record.main_ns                                                                                                            
[...]
id                 = Z1T3NF8J9WVBSP_aws.test1.gpii.net_NS
allow_overwrite    = true
fqdn               = aws.test1.gpii.net
health_check_id    = 
name               = aws.test1.gpii.net
records.#          = 4
records.1108397575 = ns-505.awsdns-63.com
records.2118373385 = ns-589.awsdns-09.net
records.255805746  = ns-1707.awsdns-21.co.uk
records.2990341214 = ns-1168.awsdns-18.org
set_identifier     = 
ttl                = 60
type               = NS
zone_id            = Z1T3NF8J9WVBSP


# terragrunt state show module.aws_zone.aws_route53_zone.main
[...]
module.aws_zone.aws_route53_zone.main
id                = Z3CZ4X01NHJQ3U
comment           = Managed by Terraform
delegation_set_id = 
force_destroy     = false
name              = aws.test1.gpii.net.
name_servers.#    = 4
name_servers.0    = ns-1168.awsdns-18.org
name_servers.1    = ns-1707.awsdns-21.co.uk
name_servers.2    = ns-505.awsdns-63.com
name_servers.3    = ns-589.awsdns-09.net
tags.%            = 1
tags.Terraform    = 1
vpc.#             = 0
vpc_id            = 
vpc_region        = 
zone_id           = Z3CZ4X01NHJQ3U

```

Changes for common-prd
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

google_dns_managed_zone.main: Refreshing state... (ID: gcp-gpii-net)
aws_route53_zone.main: Refreshing state... (ID: Z26VOXVJXXG9QQ)
aws_route53_zone.main: Refreshing state... (ID: Z29SXC5CAHOH1D)
aws_route53_record.main_ns: Refreshing state... (ID: Z26C1YEN96KOGI_aws.gpii.net_NS)
aws_route53_record.main_ns: Refreshing state... (ID: Z26C1YEN96KOGI_gcp.gpii.net_NS)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions: 

  - module.aws_zone.aws_route53_record.main_ns

  - module.aws_zone.aws_route53_zone.main

Plan: 0 to add, 0 to change, 2 to destroy.

------------------------------------------------------------------------
# terragrunt state show module.aws_zone.aws_route53_record.main_ns
[...]
id                 = Z26C1YEN96KOGI_aws.gpii.net_NS
allow_overwrite    = true
fqdn               = aws.gpii.net
health_check_id    = 
name               = aws.gpii.net
records.#          = 4
records.1401333002 = ns-1627.awsdns-11.co.uk
records.2368443323 = ns-497.awsdns-62.com
records.3487276393 = ns-690.awsdns-22.net
records.3936386861 = ns-1503.awsdns-59.org
set_identifier     = 
ttl                = 60
type               = NS
zone_id            = Z26C1YEN96KOGI
bash-4.4# terragrunt state show module.aws_zone.aws_route53_zone.main
[...]
id                = Z26VOXVJXXG9QQ
comment           = Managed by Terraform
delegation_set_id = 
force_destroy     = false
name              = aws.gpii.net.
name_servers.#    = 4
name_servers.0    = ns-1503.awsdns-59.org
name_servers.1    = ns-1627.awsdns-11.co.uk
name_servers.2    = ns-497.awsdns-62.com
name_servers.3    = ns-690.awsdns-22.net
tags.%            = 1
tags.Terraform    = 1
vpc.#             = 0
vpc_id            = 
vpc_region        = 
zone_id           = Z26VOXVJXXG9QQ
```