### PR TITLE
[GPII-3868]: Fix Stackdriver Trace by reverting legacy metadata endpoints

### DIFF
--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: flowmanager
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "169.254.169.254/32"
     spec:
       containers:
       - name: flowmanager

--- a/shared/charts/gpii-flowmanager/templates/service_entry_cloudtrace.yaml
+++ b/shared/charts/gpii-flowmanager/templates/service_entry_cloudtrace.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "flowmanager.name" . }}-cloudtrace
+spec:
+  hosts:
+  - cloudtrace.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+{{- end }}

--- a/shared/charts/gpii-flowmanager/templates/service_entry_googleapis.yaml
+++ b/shared/charts/gpii-flowmanager/templates/service_entry_googleapis.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "flowmanager.name" . }}-googleapis
+spec:
+  hosts:
+  - www.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+{{- end }}

--- a/shared/charts/gpii-flowmanager/templates/virtual_service_cloudtrace.yaml
+++ b/shared/charts/gpii-flowmanager/templates/virtual_service_cloudtrace.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "flowmanager.name" . }}-cloudtrace
+spec:
+  hosts:
+  - cloudtrace.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - cloudtrace.googleapis.com
+    route:
+    - destination:
+        host: cloudtrace.googleapis.com
+        port:
+          number: 443
+      weight: 100
+{{- end }}

--- a/shared/charts/gpii-flowmanager/templates/virtual_service_googleapis.yaml
+++ b/shared/charts/gpii-flowmanager/templates/virtual_service_googleapis.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "flowmanager.name" . }}-googleapis
+spec:
+  hosts:
+  - www.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - www.googleapis.com
+    route:
+    - destination:
+        host: www.googleapis.com
+        port:
+          number: 443
+      weight: 100
+{{- end }}

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -9,7 +9,6 @@ spec:
     rollingUpdate:
       maxSurge: {{ .Values.rollingUpdate.maxSurge }}
       maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}
-    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: preferences
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "169.254.169.254/32"
     spec:
       containers:
       - name: preferences

--- a/shared/charts/gpii-preferences/templates/service_entry_cloudtrace.yaml
+++ b/shared/charts/gpii-preferences/templates/service_entry_cloudtrace.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "preferences.name" . }}-cloudtrace
+spec:
+  hosts:
+  - cloudtrace.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+{{- end }}

--- a/shared/charts/gpii-preferences/templates/service_entry_googleapis.yaml
+++ b/shared/charts/gpii-preferences/templates/service_entry_googleapis.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "preferences.name" . }}-googleapis
+spec:
+  hosts:
+  - www.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+{{- end }}

--- a/shared/charts/gpii-preferences/templates/virtual_service_cloudtrace.yaml
+++ b/shared/charts/gpii-preferences/templates/virtual_service_cloudtrace.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "preferences.name" . }}-cloudtrace
+spec:
+  hosts:
+  - cloudtrace.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - cloudtrace.googleapis.com
+    route:
+    - destination:
+        host: cloudtrace.googleapis.com
+        port:
+          number: 443
+      weight: 100
+{{- end }}

--- a/shared/charts/gpii-preferences/templates/virtual_service_googleapis.yaml
+++ b/shared/charts/gpii-preferences/templates/virtual_service_googleapis.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enableStackdriverTrace }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "preferences.name" . }}-googleapis
+spec:
+  hosts:
+  - www.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - www.googleapis.com
+    route:
+    - destination:
+        host: www.googleapis.com
+        port:
+          number: 443
+      weight: 100
+{{- end }}


### PR DESCRIPTION
This is the alternative to https://github.com/gpii-ops/gpii-infra/pull/429 that requires legacy metadata endpoints (https://github.com/gpii-ops/exekube/pull/58) and solves metadata egress problem by adding `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to preferences and flowmanager deployments (per @stepanstipl suggestion) that is picked up by Istio's sidecar injector and enables off-mesh metadata traffic.

It affected by the same issue with Istio egress primitives duplication.