### PR TITLE
Istio PDBs

### DIFF
--- a/gcp/live/dev/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/dev/k8s/istio-gke-helper/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio-gke-helper"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/dev/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/dev/k8s/istio-gke-helper/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer"
     ]
   }
 

--- a/gcp/live/prd/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/prd/k8s/istio-gke-helper/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio-gke-helper"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/prd/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/prd/k8s/istio-gke-helper/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer"
     ]
   }
 

--- a/gcp/live/stg/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/stg/k8s/istio-gke-helper/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//istio-gke-helper"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/stg/k8s/istio-gke-helper/terraform.tfvars
+++ b/gcp/live/stg/k8s/istio-gke-helper/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer"
     ]
   }
 

--- a/gcp/modules/istio-gke-helper/main.tf
+++ b/gcp/modules/istio-gke-helper/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "secrets_dir" {}
+variable "charts_dir" {}
+
+module "istio-gke-helper" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name      = "istio-gke-helper"
+  release_namespace = "istio-system"
+  release_values    = ""
+
+  chart_name = "${var.charts_dir}/istio-gke-helper"
+}

--- a/gcp/modules/istio-gke-helper/main.tf
+++ b/gcp/modules/istio-gke-helper/main.tf
@@ -1,3 +1,9 @@
+# This functionality cannot co-exist in istio module due to Terraform's
+# inability to handle dynamic provider configuration for import command (even
+# though the provider is not used for the actual resource import, helm_release
+# & helm provider use data source dependent config). See
+# hashicorp/terraform#17847 for details.
+
 terraform {
   backend "gcs" {}
 }

--- a/shared/charts/istio-gke-helper/.helmignore
+++ b/shared/charts/istio-gke-helper/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/shared/charts/istio-gke-helper/Chart.yaml
+++ b/shared/charts/istio-gke-helper/Chart.yaml
@@ -1,0 +1,10 @@
+name: istio-gke-helper
+version: v0.1.0
+description: A Helm chart for GKE Istio support resources
+home: https://github.com/istio/istio
+keywords:
+  - gcp
+  - gke
+  - istio
+sources:
+  - https://github.com/istio/istio

--- a/shared/charts/istio-gke-helper/README.md
+++ b/shared/charts/istio-gke-helper/README.md
@@ -1,0 +1,38 @@
+# istio-gke-helper chart
+
+This chart is to configure additional properties (like Pod Disruption Budgets) for
+GKE's deployment of Istio.
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their
+default values.
+
+| Parameter         | Description                                        | Default                                                   |
+|-------------------|----------------------------------------------------|-----------------------------------------------------------|
+| `components`      | List of Istio components and their metadata labels | `egressgateway, ingressgateway, pilot, policy, telemetry` |
+| `maxUnavailable`  | `maxUnavailable` value for PodDisruptionBudgets    | `1`                                                       |
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```sh
+$ helm install --name my-release
+path_to_chart/istio-gke-helper
+```
+
+The command deploys istio-gke-helper on the Kubernetes cluster in the
+default configuration. The [configuration](#configuration) section lists the
+parameters that can be configured during installation.
+
+## Un-installing the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```sh
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.

--- a/shared/charts/istio-gke-helper/templates/_helpers.tpl
+++ b/shared/charts/istio-gke-helper/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "istio-gke-helper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "istio-gke-helper.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "istio-gke-helper.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "helm-toolkit.utils.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/shared/charts/istio-gke-helper/templates/pod_disruption_budget.yaml
+++ b/shared/charts/istio-gke-helper/templates/pod_disruption_budget.yaml
@@ -1,0 +1,18 @@
+{{- range $key, $val := .Values.components }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "{{ include "istio-gke-helper.fullname" $ }}-{{ $key }}"
+  labels:
+    app: {{ include "istio-gke-helper.name" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+spec:
+  maxUnavailable: {{ $.Values.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ .app | quote }}
+      istio: {{ .istio | quote }}
+{{- end }}

--- a/shared/charts/istio-gke-helper/values.yaml
+++ b/shared/charts/istio-gke-helper/values.yaml
@@ -1,0 +1,19 @@
+# List of components to create Pod Disruption Budgets for and their labels
+components:
+  egressgateway:
+    app: istio-egressgateway
+    istio: egressgateway
+  ingressgateway:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  pilot:
+    app: pilot
+    istio: pilot
+  policy:
+    app: policy
+    istio: mixer
+  telemetry:
+    app: telemetry
+    istio: mixer
+
+maxUnavailable: 1


### PR DESCRIPTION
This PR introduces Pod Disruption Budget (PDBs) for Istio components. This should increase HA and help in situations like node pool upgrades by ensuring that no more than 1 instance of the critical Istio control plane components is down at a time.

Initially, I wanted to implement this via native TF provider, but it does not support PDBs at this moment, and therefore the new Helm chart and necessity of a separate module.  This cannot co-exist in istio module due to Terraform's inability to handle dynamic provider configuration for `import` command (even though the provider is not used for the actual resource import, helm_release & helm provider use data source dependent config). See hashicorp/terraform#17847 for details.