### PR TITLE
[GPII-3868]: Gracefully rotate deployment credentials

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,6 +223,8 @@ gcp-stg:
     - rake rotate_tfstate_key
     - rake rotate_secrets_key
     - rake
+    - rake rotate_deployment_credentials['preferences']
+    - rake rotate_deployment_credentials['flowmanager']
     - rake test_preferences
     - rake test_flowmanager
   after_script:
@@ -296,6 +298,8 @@ gcp-prd:
     - rake rotate_tfstate_key RAKE_REALLY_DESTROY_IN_PRD=true
     - rake rotate_secrets_key RAKE_REALLY_DESTROY_IN_PRD=true
     - rake
+    - rake rotate_deployment_credentials['preferences'] RAKE_REALLY_DESTROY_IN_PRD=true
+    - rake rotate_deployment_credentials['flowmanager'] RAKE_REALLY_DESTROY_IN_PRD=true
     - rake test_preferences RAKE_REALLY_DESTROY_IN_PRD=true
     - rake test_flowmanager RAKE_REALLY_DESTROY_IN_PRD=true
   after_script:

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.7.0-google_gpii.0
+    image: gpii/exekube:0.7.1-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -247,6 +247,11 @@ task :rotate_secrets_key, [:kms_key] => [:set_vars, :check_destroy_allowed] do |
   sh "#{@exekube_cmd} rake rotate_secrets_key['#{kms_key}']"
 end
 
+desc "[ADVANCED] Gracefully rotate SA credentials used by target K8s deployment"
+task :rotate_deployment_credentials, [:deployment, :namespace] => [:set_vars, :check_destroy_allowed] do |taskname, args|
+  sh "#{@exekube_cmd} rake rotate_deployment_credentials['#{args[:deployment]}','#{args[:namespace]}']"
+end
+
 desc "[EXPERIMENTAL] [ADVANCED] Import an existing KMS keyring, e.g when moving an environment to a new (but previously-used) region"
 task :import_keyring => [:set_vars, :check_destroy_allowed] do
   sh "#{@exekube_cmd} rake import_keyring"

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -196,9 +196,9 @@ task :plain_sh, [:cmd] => [:set_vars] do |taskname, args|
   sh "#{@exekube_cmd} #{cmd}"
 end
 
-desc "[ADVANCED] Destroy all SA keys except current one"
-task :destroy_sa_keys => [:set_vars, :check_destroy_allowed] do
-  sh "#{@exekube_cmd} rake destroy_sa_keys"
+desc "[ADVANCED] Destroy keys for target SA"
+task :destroy_sa_keys, [:sa_name, :destroy_current_key] => [:set_vars, :check_destroy_allowed] do |taskname, args|
+  sh "#{@exekube_cmd} rake destroy_sa_keys['#{args[:sa_name]}','#{args[:destroy_current_key]}']"
 end
 
 desc "[ADVANCED] Destroy secrets file stored in GS bucket for encryption key, passed as argument -- rake destroy_secrets['default']"


### PR DESCRIPTION
This is a proof-of-concept solution that gracefully rotates SA credentials managed in TF (https://github.com/gpii-ops/gpii-infra/pull/429).
It needs new `kubectl` that is capable of doing rolling restarts (https://github.com/gpii-ops/exekube/pull/59).