### PR TITLE
GPII-2805 - Add backup testing procedure to stg environment

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -138,13 +138,14 @@ Deploying to `stg` verifies that the gpii-infra code that worked to create a `de
 
 Because `stg` emulates production, it will (in the future) allow us to run realistic end-to-end tests before deploying to `prd`.
 
-The `stg` environment is almost the same environment as `prd`, this fact makes `stg` the proper environment to test some recovering procedures that the ops team must perform periodically. Like the restoration of the persistance layer. **The ops team will perform a restoration of the persistance layer every first monday of the month as part of the procedures verification needed for the FERPA compliance, so expect an outage of about 30 min at that time of the services in `stg`**.
+The `stg` environment is almost the same environment as `prd`, this fact makes `stg` the proper environment to test some recovering procedures that the ops team must perform periodically. 
 
 #### Service Level Objective
 
 * No guarantee of service for development environments (stg is a development environment).
 * Ops team receives alerts about problems, and addresses them when convenient for the team (i.e. we won't wake up an on-call engineer, but we will investigate during business hours)
 * Ops team makes an effort to keep stg stable and available for ad-hoc testing, but may disrupt the environment at any time for our own testing.
+* Ops team will perform a restoration of the persistence layer every first monday of the month as part of the procedures verification needed for the FERPA compliance, so expect an outage of about 30 min at that time of the services in `stg`.
 
 ### prd
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -138,6 +138,8 @@ Deploying to `stg` verifies that the gpii-infra code that worked to create a `de
 
 Because `stg` emulates production, it will (in the future) allow us to run realistic end-to-end tests before deploying to `prd`.
 
+The `stg` environment is almost the same environment as `prd`, this fact makes `stg` the proper environment to test some recovering procedures that the ops team must perform periodically. Like the restoration of the persistance layer. **The ops team will perform a restoration of the persistance layer every first monday of the month as part of the procedures verification needed for the FERPA compliance, so expect an outage of about 30 min at that time of the services in `stg`**.
+
 #### Service Level Objective
 
 * No guarantee of service for development environments (stg is a development environment).

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -136,16 +136,14 @@ This is a shared, long-lived environment for staging / pre-production. It aims t
 
 Deploying to `stg` verifies that the gpii-infra code that worked to create a `dev-$USER` environment from scratch also works to update a pre-existing environment. This is important since we generally don't want to destroy and re-create the production environment from scratch.
 
-Because `stg` emulates production, it will (in the future) allow us to run realistic end-to-end tests before deploying to `prd`.
-
-The `stg` environment is almost the same environment as `prd`, this fact makes `stg` the proper environment to test some recovering procedures that the ops team must perform periodically. 
+Because `stg` emulates production, it will (in the future) allow us to run realistic end-to-end tests before deploying to `prd`. This fact also makes `stg` the proper environment to test some recovering procedures that the ops team must perform periodically.
 
 #### Service Level Objective
 
 * No guarantee of service for development environments (stg is a development environment).
 * Ops team receives alerts about problems, and addresses them when convenient for the team (i.e. we won't wake up an on-call engineer, but we will investigate during business hours)
 * Ops team makes an effort to keep stg stable and available for ad-hoc testing, but may disrupt the environment at any time for our own testing.
-* Ops team will perform a restoration of the persistence layer every first monday of the month as part of the procedures verification needed for the FERPA compliance, so expect an outage of about 30 min at that time of the services in `stg`.
+* Ops team will perform a restoration of the persistence layer every first monday of the month at 13:00EDT as part of the backup testing process needed for the FERPA compliance, so expect an outage of about 30 min at that time of the services in `stg`.
 
 ### prd
 
@@ -698,7 +696,7 @@ Prime Minister at that time!"), please let me know immediately.
 ##### Setup.
 
 Create a Terragrunt definition like `gcp/live/prd/k8s/kube-system/backup-exporter/terraform.tfvars` inside the exekube project. This file contains 3 variables:
-   * `destination_bucket` - The destination GCS bucket, i.e "gs://gpii-backup-external-prd". 
+   * `destination_bucket` - The destination GCS bucket, i.e "gs://gpii-backup-external-prd".
    * `replica_count` - the number of CouchDB replicas that the cluster has. This is important for copying all the snapshots of the cluster at the same time.
    * `schedule` - Follows the same format as a Cron Job. i.e: `*/10 * * * *` to execute the task every 10 minutes.
 


### PR DESCRIPTION
Part of [GPII-2805](https://issues.gpii.net/browse/GPII-2805)

This PR adds the description of a periodically procedure applied to the `stg` environment of the infrastructure.

[Rendered version](https://github.com/gpii-ops/gpii-infra/blob/53d5aa9348fd01cea33e66f3203196631ea53be4/gcp/README.md#stg)