### PR TITLE
[GPII-4003]: Fix :test task to properly destroy locust resources

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,10 +230,6 @@ gcp-stg:
     - cd gcp/live/stg
     - rake display_cluster_state
     - rake display_universal_image_info || true
-    # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust/swarm] || true
-    - rake destroy_module[locust/istio] || true
-    - rake destroy_tfstate[locust] || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys || true
   only:
@@ -303,10 +299,6 @@ gcp-prd:
     - cd gcp/live/prd
     - rake display_cluster_state
     - rake display_universal_image_info || true
-    # Destroy Locust module (used for smoke tests) and its TF state
-    - rake destroy_module[locust/swarm] RAKE_REALLY_DESTROY_IN_PRD=true || true
-    - rake destroy_module[locust/istio] RAKE_REALLY_DESTROY_IN_PRD=true || true
-    - rake destroy_tfstate[locust] RAKE_REALLY_DESTROY_IN_PRD=true || true
     # Remove all SA keys except current one to prevent hitting 10 keys per SA limit (GPII-3299)
     - rake destroy_sa_keys RAKE_REALLY_DESTROY_IN_PRD=true || true
   only:

--- a/gcp/modules/locust/swarm.tf
+++ b/gcp/modules/locust/swarm.tf
@@ -103,7 +103,7 @@ resource "null_resource" "locust_swarm_session" {
         fi
         RETRY_COUNT=$((RETRY_COUNT+1))
       done
-      [ "$EXIT_STATUS" != "0" ] && echo "Failed to post resutls to Stackdriver, retry limit reached, giving up."
+      [ "$EXIT_STATUS" != "0" ] && echo "Failed to post results to Stackdriver, retry limit reached, giving up."
 
       if [ "$total_rps" -lt "${var.locust_desired_total_rps}" ]; then
         echo


### PR DESCRIPTION
Existing implementation of `:test` task was a little backwards, destroying locust resources before instead of after the test, which caused various CI issues in case module and TF state was not destroyed separately.