### PR TITLE
GPII-3901: Grant editor role for testing organization istead of owner role

### DIFF
--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -189,18 +189,20 @@ end
 # This task grants the owner role in the current project to the current user
 task :grant_project_admin => [@gcp_creds_file, :configure_extra_tf_vars] do
   if ENV["TF_VAR_organization_name"] == "gpii"
-    role = "roles/owner"
+    roles = ["roles/owner"]
   else
     # The owner role can not be granted using other method than the console for
     # external users to a particular organization.
     # https://cloud.google.com/iam/docs/understanding-roles#invitation_flow
-    role = "roles/editor"
+    roles = ["roles/editor", "roles/resourcemanager.projectIamAdmin"]
   end
-  sh "
-    gcloud projects add-iam-policy-binding \"$TF_VAR_project_id\" \
-      --member user:\"$TF_VAR_auth_user_email\" \
-      --role #{role}
-  "
+  roles.each do |role|
+    sh "
+      gcloud projects add-iam-policy-binding \"$TF_VAR_project_id\" \
+        --member user:\"$TF_VAR_auth_user_email\" \
+        --role #{role}
+    "
+  end
 end
 
 # This task revokes the owner role in the current project from the current user


### PR DESCRIPTION
[GPII-3901](https://issues.gpii.net/browse/GPII-3901)

**Description of the fix**

It is not possible attach the owner role to an user of a different organization using the API:

https://cloud.google.com/iam/docs/understanding-roles#invitation_flow

It must be set using the console, and the user must accept the invitation.

A workaround could be to create manually a group with owner permissions and add the people to that group but it has two downsides from my point of view:
 - hard to maintain the users of such group.
 - it is not consistent along the rest of the projects of the organization.

Other option is to make the test org recognize the raisingthefloor.org users as organization users. But I don't know if that it is possible.

The editor role is almost the same as the owner but without:
 - Manage roles and permissions for a project and all resources within the project.
 - Set up billing for a project.

So I guess that for most of our actions it should work. As we already have the permissions for managing the roles and permissions given for the common group.

**Impact**

This changes only affects to the way that an admin can grant privileges with the CLI. This PR doesn't affect to the living projects, it can be merged safely.