### PR TITLE
GPII-3952: Fix missing provider config block

### DIFF
--- a/gcp/modules/gke-network/main.tf
+++ b/gcp/modules/gke-network/main.tf
@@ -6,6 +6,11 @@ terraform {
   backend "gcs" {}
 }
 
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
 # ------------------------------------------------------------------------------
 # Input variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
I've removed TF provider config block by mistake as part of cleaning up the **_mostly_** commented out `global-ip.tf` file (https://github.com/gpii-ops/gpii-infra/commit/0fa9460eb58128d3302aed618060d63091767204).