### PR TITLE
GPII-3970: Add dependency on parent Istio - wait for external IP

### DIFF
--- a/gcp/live/dev/k8s/gpii/istio/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/istio/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../../cluster",
+      "../../istio",
     ]
   }
 

--- a/gcp/live/prd/k8s/gpii/istio/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/istio/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../../cluster",
+      "../../istio",
     ]
   }
 

--- a/gcp/live/stg/k8s/gpii/istio/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/istio/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../../cluster",
+      "../../istio",
     ]
   }
 


### PR DESCRIPTION
This is a small dependency fix I've missed in #444, after moving the "wait for Istio IP" logic to a `istio` module.

Fixes following CI error by extending the dependency chain - `k8s/gpii/flowmanager` -> `k8s/gpii/istio` ->  `k8s/istio`:
```
Error: Error applying plan:

1 error occurred:
    * google_dns_record_set.flowmanager-dns: Resource 'data.kubernetes_service.istio-ingressgateway' does not have attribute 'load_balancer_ingress.0.ip' for variable 'data.kubernetes_service.istio-ingressgateway.load_balancer_ingress.0.ip'
```