### PR TITLE
[GPII-4003]: Clean up :destroy_hard, reenable :destroy_tfstate in :test

### DIFF
--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -135,8 +135,7 @@ task :destroy_hard => [:set_vars] do
     Rake::Task["destroy"].invoke
     Rake::Task["destroy_secrets"].reenable
     Rake::Task["destroy_secrets"].invoke
-    # If destroy and destroy_secrets both succeed, we want to run all of these
-    # destroy_tfstate commands (regardless if any one destroy_tfstate fails).
+    # If destroy and destroy_secrets both succeed, we want to destroy_tfstate as well.
     begin
       Rake::Task["destroy_tfstate"].reenable
       Rake::Task["destroy_tfstate"].invoke("k8s")

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -135,19 +135,11 @@ task :destroy_hard => [:set_vars] do
     Rake::Task["destroy"].invoke
     Rake::Task["destroy_secrets"].reenable
     Rake::Task["destroy_secrets"].invoke
-    # Iff destroy and destroy_secrets both succeed, we want to run all of these
+    # If destroy and destroy_secrets both succeed, we want to run all of these
     # destroy_tfstate commands (regardless if any one destroy_tfstate fails).
     begin
       Rake::Task["destroy_tfstate"].reenable
       Rake::Task["destroy_tfstate"].invoke("k8s")
-    rescue RuntimeError => err
-      puts "destroy_tfstate step failed:"
-      puts err
-      puts "Continuing."
-    end
-    begin
-      Rake::Task["destroy_tfstate"].reenable
-      Rake::Task["destroy_tfstate"].invoke("locust")
     rescue RuntimeError => err
       puts "destroy_tfstate step failed:"
       puts err

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -5,6 +5,7 @@ task :test do
   end
   # We want to clean up after Locust even if test failed
   sh "#{@exekube_cmd} rake xk['down live/#{@env}/locust',skip_secret_mgmt]"
+  Rake::Task[:destroy_tfstate].reenable
   Rake::Task[:destroy_tfstate].invoke('locust')
   # Exit only if something went wrong to fail the pipeline
   exit locust_status unless locust_status == 0


### PR DESCRIPTION
CI skips `:destroy_tfstate` in `:test` for ephemeral clusters:
https://gitlab.com/gpii-ops/gpii-infra/-/jobs/248496212

And here is the reason:
* `:test` tasks [are part of](https://github.com/gpii-ops/gpii-infra/blob/master/shared/rakefiles/ci.rake#L67-L68) `:destroy_hard_and_deploy_ci`
* `:destroy_tfstate` already being executed [as part of](https://github.com/gpii-ops/gpii-infra/blob/master/shared/rakefiles/entrypoint.rake#L141-L150) `:destroy_hard`
* So it needs to be reenabled again before invocation in `:test`

Also, there is no need to destroy locust state in `:destroy_hard` anymore.