### PR TITLE
GPII-3970: Fix gpii namespace creation race condition

### DIFF
--- a/gcp/live/dev/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../couchdb",
+      "../istio",
     ]
   }
 

--- a/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
@@ -7,7 +7,8 @@ terragrunt = {
   dependencies {
     paths = [
       "../../kube-system/helm-initializer",
-      "../../kube-system/cert-manager"
+      "../../kube-system/cert-manager",
+      "../istio",
     ]
   }
 

--- a/gcp/live/prd/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../couchdb",
+      "../istio",
     ]
   }
 

--- a/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
     paths = [
       "../../kube-system/helm-initializer",
       "../../kube-system/cert-manager",
+      "../istio",
     ]
   }
 

--- a/gcp/live/stg/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/couchdb-prometheus-exporter/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../couchdb",
+      "../istio",
     ]
   }
 

--- a/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
@@ -8,6 +8,7 @@ terragrunt = {
     paths = [
       "../../kube-system/helm-initializer",
       "../../kube-system/cert-manager",
+      "../istio",
     ]
   }
 


### PR DESCRIPTION
Work on static istio ip (#444, #445) surfaced existing race condition between Terraform and Helm when creating `gpii` namespace. When Helm gets there first, following error happens:

```
Error: Error applying plan:

1 error occurred:
    * kubernetes_namespace.gpii: 1 error occurred:
    * kubernetes_namespace.gpii: namespaces "gpii" already exists
```

This PR fixes this by making all the remaining modules (`couchdb` and `couchdb-prometheus-exporter`) depend on `gpii/istio` module, which creates the namespace.