### PR TITLE
GPII-3970: Try to fix failing flowmanager tests

### DIFF
--- a/shared/charts/locust/Chart.yaml
+++ b/shared/charts/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.7.5
 maintainers:
   - name: so0k

--- a/shared/charts/locust/templates/egress-virtual-service.yaml
+++ b/shared/charts/locust/templates/egress-virtual-service.yaml
@@ -1,0 +1,16 @@
+{{ if not (index .Values.master.config "target-host" | regexMatch ".cluster.local")  }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: locust-target
+spec:
+  hosts:
+  - {{ include "locust.host" . }}
+  tls:
+  - match:
+    - sniHosts:
+      - {{ include "locust.host" . }}
+    route:
+    - destination:
+        host: {{ include "locust.host" . }}
+{{ end }}


### PR DESCRIPTION
Work on static Istio ip (#444, #445, #447) seems to have made existing Issue with failing flowmanager tests (ie. https://gitlab.com/gpii-ops/gpii-infra/-/jobs/249398218) significantly more frequent - now it happens almost on every run on ephemeral clusters.

I was unable to reproduce this reliably locally and also unable to reproduce on existing CI cluster - `rake test_flowmanager` on an existing cluster works fine (one left behind by failed CI run - ig. `dev-gitlab-runner` env). This is furthermore difficult since we don't keep the locust containers around anymore after the failed tests (after https://github.com/gpii-ops/gpii-infra/pull/437) so I was not able to verify if this is the very same underlying issue we used to see or a slightly different one.

Investigating issues @natarajaya observed (details in https://github.com/gpii-ops/gpii-infra/pull/429 PR and https://issues.gpii.net/browse/GPII-4015) and fact that always only flowmanager tests are failing, while preferences seem to work fine, seem to point to issue with Istio egress traffic. Also the previous behavior and observed behavior after #445 and #447 points to some form of race condition (which is also the case of issues in #429).

This PR is a try to workaround the existing routing issue with pre-1.1 Istio by adding an additional SNI based rule for locust target.

Relevant (more or less) Istio issues:
- https://github.com/istio/istio/issues/5498
- https://github.com/istio/istio/issues/12882
- https://github.com/istio/istio/issues/8833
- https://github.com/istio/istio/issues/8572
- https://github.com/istio/istio/issues/7659