### PR TITLE
[GPII-3868]: Use gpii/service-account-assigner:0.0.3-gpii.0

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -110,7 +110,7 @@ preferences:
 service_account_assigner:
   upstream:
     repository: gpii/service-account-assigner
-    tag: 0.0.2-gpii.0
+    tag: 0.0.3-gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/gpii/service-account-assigner
     sha: sha256:c464aceecdb83363ee8d339cfdcc6877210b881be1e8fa020ffaddf25a3c83bd


### PR DESCRIPTION
This PR switches `service-account-assigner` to new version with changes from:
https://github.com/gpii-ops/k8s-gke-service-account-assigner/pull/2

Merge after:
https://github.com/gpii-ops/docker-image-service-account-assigner/pull/3