### PR TITLE
GPII-3901: You must construct additional permissions

### DIFF
--- a/common/live/stg/infra/dev/tyler/terraform.tfvars
+++ b/common/live/stg/infra/dev/tyler/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+
+terragrunt = {
+  terraform {
+    source = "/project/modules//gcp-project"
+  }
+  dependencies {
+    paths = ["../zone"]
+  }
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+
+project_name    = "dev-tyler"
+project_owner   = "user:tyler@raisingthefloor.org"

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -92,6 +92,14 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
+    role = "roles/binaryauthorization.policyAdmin"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_bin_auth.email}",
+    ]
+  }
+
+  binding {
     role = "roles/cloudkms.admin"
 
     members = [
@@ -272,6 +280,16 @@ data "google_iam_policy" "combined" {
   # googleapi: Error 400: Request contains an invalid argument., badRequest
   binding {
     role = "roles/owner"
+
+    members = [
+      "${local.project_owners}",
+    ]
+  }
+
+  # Needed so that ADCs can impersonate the dedicated binary auth SA. See
+  # GPII-3860.
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
 
     members = [
       "${local.project_owners}",

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -246,6 +246,13 @@ data "google_iam_policy" "combined" {
     ]
   }
 
+  # Google IAM requires a special "invite" workflow for the Owner
+  # role when the account is not part of the Organization. This
+  # comes up when using user@rtf named accounts in the test
+  # Organization. The error might (unhelpfully) look like this,
+  # followed by a bunch of Go structs:
+  #
+  # googleapi: Error 400: Request contains an invalid argument., badRequest
   binding {
     role = "roles/owner"
 

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -58,6 +58,7 @@ variable "service_apis" {
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "cloudtrace.googleapis.com",
+    "containeranalysis.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "containerregistry.googleapis.com",

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -84,6 +84,14 @@ variable "service_apis" {
 
 data "google_iam_policy" "combined" {
   binding {
+    role = "roles/binaryauthorization.serviceAgent"
+
+    members = [
+      "serviceAccount:service-${google_project.project.number}@gcp-sa-binaryauthorization.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
     role = "roles/cloudkms.admin"
 
     members = [
@@ -121,6 +129,14 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.service_accounts}",
+    ]
+  }
+
+  binding {
+    role = "roles/containeranalysis.ServiceAgent"
+
+    members = [
+      "serviceAccount:service-${google_project.project.number}@container-analysis.iam.gserviceaccount.com",
     ]
   }
 

--- a/common/modules/gcp-project/service_accounts.tf
+++ b/common/modules/gcp-project/service_accounts.tf
@@ -32,3 +32,11 @@ resource "google_service_account" "gke_cluster_pod_k8s_snapshots" {
   display_name = "gke-cluster-pod-k8s-snapshots"
   project      = "${google_project.project.project_id}"
 }
+
+# Since we sometimes use ADCs, and since the binaryauthorization API does not
+# allow ADCs, we need a dedicated SA to manage binary auth. See GPII-3860.
+resource "google_service_account" "gke_cluster_bin_auth" {
+  account_id   = "gke-cluster-bin-auth"
+  display_name = "gke-cluster-bin-auth"
+  project      = "${google_project.project.project_id}"
+}

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -37,6 +37,14 @@ variable "enable_binary_authorization" {
   default = false
 }
 
+variable "binary_authorization_evaluation_mode" {
+  default = "ALWAYS_DENY"
+}
+
+variable "binary_authorization_enforcement_mode" {
+  default = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+}
+
 data "google_service_account" "gke_cluster_node" {
   account_id = "gke-cluster-node"
   project    = "${var.project_id}"
@@ -98,7 +106,9 @@ module "gke_cluster" {
   primary_pool_oauth_scopes       = ["cloud-platform"]
   primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"
 
-  enable_binary_authorization = "${var.enable_binary_authorization}"
+  enable_binary_authorization           = "${var.enable_binary_authorization}"
+  binary_authorization_evaluation_mode  = "${var.binary_authorization_evaluation_mode}"
+  binary_authorization_enforcement_mode = "${var.binary_authorization_enforcement_mode}"
 }
 
 # Workaround from

--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -45,6 +45,46 @@ variable "binary_authorization_enforcement_mode" {
   default = "ENFORCED_BLOCK_AND_AUDIT_LOG"
 }
 
+variable "binary_authorization_admission_whitelist_pattern_0" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_1" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_2" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_3" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_4" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_5" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_6" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
+variable "binary_authorization_admission_whitelist_pattern_7" {
+  # This value cannot be empty, so use a placeholder value that satisfies Google's API.
+  default = "PLACE.HOLDER/PATTERN"
+}
+
 data "google_service_account" "gke_cluster_node" {
   account_id = "gke-cluster-node"
   project    = "${var.project_id}"
@@ -106,9 +146,17 @@ module "gke_cluster" {
   primary_pool_oauth_scopes       = ["cloud-platform"]
   primary_pool_service_account    = "${data.google_service_account.gke_cluster_node.email}"
 
-  enable_binary_authorization           = "${var.enable_binary_authorization}"
-  binary_authorization_evaluation_mode  = "${var.binary_authorization_evaluation_mode}"
-  binary_authorization_enforcement_mode = "${var.binary_authorization_enforcement_mode}"
+  enable_binary_authorization                        = "${var.enable_binary_authorization}"
+  binary_authorization_evaluation_mode               = "${var.binary_authorization_evaluation_mode}"
+  binary_authorization_enforcement_mode              = "${var.binary_authorization_enforcement_mode}"
+  binary_authorization_admission_whitelist_pattern_0 = "${var.binary_authorization_admission_whitelist_pattern_0}"
+  binary_authorization_admission_whitelist_pattern_1 = "${var.binary_authorization_admission_whitelist_pattern_1}"
+  binary_authorization_admission_whitelist_pattern_2 = "${var.binary_authorization_admission_whitelist_pattern_2}"
+  binary_authorization_admission_whitelist_pattern_3 = "${var.binary_authorization_admission_whitelist_pattern_3}"
+  binary_authorization_admission_whitelist_pattern_4 = "${var.binary_authorization_admission_whitelist_pattern_4}"
+  binary_authorization_admission_whitelist_pattern_5 = "${var.binary_authorization_admission_whitelist_pattern_5}"
+  binary_authorization_admission_whitelist_pattern_6 = "${var.binary_authorization_admission_whitelist_pattern_6}"
+  binary_authorization_admission_whitelist_pattern_7 = "${var.binary_authorization_admission_whitelist_pattern_7}"
 }
 
 # Workaround from

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -107,7 +107,7 @@ task :apply_common_infra => [@gcp_creds_file] do
   services_list = JSON.parse(services_list)
 
   project_services.each do |service|
-     sh "gcloud services enable #{service}" unless services_list.any? { |s| s['serviceName'] == service }
+     sh "gcloud services enable #{service}" unless services_list.any? { |s| s["config"]["name"] == service }
   end
 
   tfstate_bucket = %x{

--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -127,13 +127,15 @@ task :set_org_perms => [@gcp_creds_file] do
     --filter bindings.members:user:* \
     --flatten="bindings[].members" \
     --format json | jq -r ".[].bindings.members"
-  }.split.uniq.each do |user|
+  }
+  user_roles.split.uniq.each do |user|
     existing_user_roles = %x{
       gcloud organizations get-iam-policy #{ENV["ORGANIZATION_ID"]} \
       --filter bindings.members:#{user} \
       --flatten="bindings[].members" \
       --format json | jq -r ".[].bindings.role"
-    }.split.each do |role|
+    }
+    existing_user_roles.split.each do |role|
       sh "gcloud organizations remove-iam-policy-binding #{ENV["ORGANIZATION_ID"]} \
         --member #{user} \
         --role #{role}"

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -194,7 +194,14 @@ task :configure_project_admin_roles do
     # The owner role can not be granted using other method than the console for
     # external users to a particular organization.
     # https://cloud.google.com/iam/docs/understanding-roles#invitation_flow
-    @project_admin_roles.push("roles/editor", "roles/resourcemanager.projectIamAdmin")
+    @project_admin_roles.push(
+      "roles/cloudkms.admin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+      "roles/logging.configWriter",
+      "roles/editor",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/storage.admin",
+    )
   end
 end
 


### PR DESCRIPTION
While [working on something else](https://github.com/gpii-ops/gpii-infra/pull/451#discussion_r303739632), I discovered that the current set of permissions is insufficient for managing an environment.

This PR (based on #451, so please ignore those commits) contains my WIP before I gave up on this error message during `rake deploy`:

```
module.gke_cluster.google_container_cluster.cluster-regional: Error running command [...]

Error from server (Forbidden): clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "tyler@[rtf]" cannot create resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
```