### PR TITLE
GPII-3591: Remove aws-unit-tests from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,4 +37,3 @@ workflows:
     jobs:
       - terraform-fmt-check
       - gcp-unit-tests
-      - aws-unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,19 +31,6 @@ jobs:
             bundle install;
             rake
 
-  aws-unit-tests:
-    <<: *default_docker
-    working_directory: /workspace
-    steps:
-      - checkout
-      - run:
-          name: AWS Unit Tests
-          command: |
-            echo "Running AWS unit tests...";
-            cd /workspace/aws/rakefiles/tests;
-            gem install test-unit --no-ri --no-rdoc;
-            rake
-
 workflows:
   version: 2
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.5.1-google_gpii.0
+  - image: gpii/exekube:0.7.2-google_gpii.0
 
 version: 2
 jobs:


### PR DESCRIPTION
No reason to run them, since AWS infra is no more.