### PR TITLE
GPII-3860: Fix missing permission for bin auth

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -166,6 +166,14 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
+    role = "roles/iam.serviceAccountTokenCreator"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
+  binding {
     role = "roles/iam.serviceAccountUser"
 
     members = [


### PR DESCRIPTION
This PR fixes missing permissions for the binary auth deployment.