### PR TITLE
GPII-3916 - Change the order in the JSON fields

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
@@ -4,28 +4,32 @@
   "conditions": [
     {
       "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.error\" resource.type=\"k8s_container\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 900,
+          "nanos" : 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0.0
+        },
         "aggregations": [
           {
             "alignment_period": {
               "seconds": 60,
               "nanos" : 0
             },
+            "per_series_aligner": "ALIGN_MEAN",
             "cross_series_reducer": "REDUCE_MAX",
             "group_by_fields": [
               "metric.label.log"
-            ],
-            "per_series_aligner": "ALIGN_MEAN"
+            ]
           }
         ],
-        "comparison": "COMPARISON_GT",
-        "duration": {
-          "seconds": 900,
-          "nanos" : 0
-        },
-        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.error\" resource.type=\"k8s_container\"",
-        "trigger": {
-          "count": 1
-        }
+        "denominator_filter": "",
+        "denominator_aggregations": []
       },
       "display_name": "Log-based errors for Backup-exporter"
     }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
@@ -4,27 +4,28 @@
   "conditions": [
     {
       "condition_absent": {
+        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.snapshot_created\" resource.type=\"k8s_container\"",
+        "duration": {
+          "seconds": 43200,
+          "nanos" : 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0.0
+        },
         "aggregations": [
           {
             "alignment_period": {
               "seconds": 60,
               "nanos" : 0
             },
+            "per_series_aligner": "ALIGN_COUNT",
             "cross_series_reducer": "REDUCE_MAX",
             "group_by_fields": [
               "metric.label.log"
-            ],
-            "per_series_aligner": "ALIGN_COUNT"
+            ]
           }
-        ],
-        "duration": {
-          "seconds": 43200,
-          "nanos" : 0
-        },
-        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.snapshot_created\" resource.type=\"k8s_container\"",
-        "trigger": {
-          "count": 1
-        }
+        ]
       },
       "display_name": "Log-based snapshot_created for Backup-exporter"
     }


### PR DESCRIPTION
This PR fixes the behavior of always update these JSON definitions. 

It seems that Stackdriver returns the definition of the alerts with the fields in a particular order, so when the `stackdriver.rb` compares the two versions always returns that needs to be updated