### PR TITLE
Helm - set ENV variables to make helm work out of the box

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -199,8 +199,7 @@ See [CI-CD.md#running-in-non-dev-environments](../CI-CD.md#running-manually-in-n
 
 1. `cd gcp/live/dev` (or another environment)
 1. `rake sh`
-1. `helm --tiller-namespace kube-system list --tls --tls-verify --tls-ca-cert /project/live/dev/secrets/kube-system/helm-tls/ca.cert.pem --tls-cert /project/live/dev/secrets/kube-system/helm-tls/helm.cert.pem  --tls-key /project/live/dev/secrets/kube-system/helm-tls/helm.key.pem`
-   * Adjust paths for the environment you're using.
+1. `helm list` (or other command)
 
 ### I want to spin up my dev environment in a different region
 

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -35,6 +35,13 @@ services:
       # TF_VAR_charts_dir is the place where common charts live, relative to modules
       TF_VAR_charts_dir: ../../../../../charts
 
+      # HELM_ variables are used to set paths to Helm certs and other TLS settings
+      HELM_TLS_CERT:
+      HELM_TLS_KEY:
+      HELM_TLS_CA_CERT:
+      HELM_TLS_ENABLE:
+      HELM_TLS_VERIFY:
+
     # File with other environment variables will be populated by rake
     env_file:
       - live/${ENV}/compose.env

--- a/shared/rakefiles/tests/spec/vars_spec.rb
+++ b/shared/rakefiles/tests/spec/vars_spec.rb
@@ -231,7 +231,18 @@ describe Vars do
     Vars.set_versions()
     expect(ENV).to have_received(:[]=).with("TF_VAR_flowmanager_tag", "#{fake_tag}")
   end
-end
 
+  it "set_vars sets Helm TLS variables" do
+    allow(ENV).to receive(:[]).with("TF_VAR_project_id").and_return("fake-project-id")
+    env = "xyz"
+    project_type = "fake-project-type"
+    Vars.set_vars(env, project_type)
+    expect(ENV).to have_received(:[]=).with("HELM_TLS_CERT", "/project/live/#{env}/secrets/kube-system/helm-tls/helm.cert.pem")
+    expect(ENV).to have_received(:[]=).with("HELM_TLS_KEY", "/project/live/#{env}/secrets/kube-system/helm-tls/helm.key.pem")
+    expect(ENV).to have_received(:[]=).with("HELM_TLS_CA_CERT", "/project/live/#{env}/secrets/kube-system/helm-tls/ca.cert.pem")
+    expect(ENV).to have_received(:[]=).with("HELM_TLS_ENABLE", "true")
+    expect(ENV).to have_received(:[]=).with("HELM_TLS_VERIFY", "true")
+  end
+end
 
 # vim: set et ts=2 sw=2:

--- a/shared/rakefiles/vars.rb
+++ b/shared/rakefiles/vars.rb
@@ -51,6 +51,13 @@ class Vars
     # Hack to force Terraform to reapply some resources on every run
     ENV["TF_VAR_nonce"] = SecureRandom.hex
 
+    # Set HELM TLS variables
+    ENV["HELM_TLS_CERT"]    = "/project/live/#{env}/secrets/kube-system/helm-tls/helm.cert.pem"
+    ENV["HELM_TLS_KEY"]     = "/project/live/#{env}/secrets/kube-system/helm-tls/helm.key.pem"
+    ENV["HELM_TLS_CA_CERT"] = "/project/live/#{env}/secrets/kube-system/helm-tls/ca.cert.pem"
+    ENV["HELM_TLS_ENABLE"]  = "true"
+    ENV["HELM_TLS_VERIFY"]  = "true"
+
     if ENV["TF_VAR_project_id"].nil?
       if ["dev"].include?(env)
         ENV["TF_VAR_project_id"] = "#{ENV["TF_VAR_organization_name"]}-#{project_type}-#{env}-#{ENV["USER"]}"


### PR DESCRIPTION
This PR sets Helm's `HELM_TLS_*` variables to point to correct paths and enables TLS, so that `helm` command works out of the box.