### PR TITLE
GPII-4023: CouchDB UI access - add docs and make ui user password immutable

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -77,16 +77,6 @@ Users who already had an RtF email address/Google account usually have performed
 1. `rake plain_sh` is like `rake sh`, but not all configuration is performed. This can be helpful for debugging (e.g. when `rake sh` does not work) and with interactive commands.
 1. To `curl` a single couchdb instance: `kubectl exec --namespace gpii couchdb-couchdb-0 -c couchdb -- curl -s http://$TF_VAR_secret_couchdb_admin_username:$TF_VAR_secret_couchdb_admin_password@127.0.0.1:5984/`
 
-#### Accessing CouchDB and CouchDB Web UI 
-
-1. Running `rake couchdb_ui` will set up port-forwarding of CouchDB port to local
-   machine and print a link and credentials to access CouchDB Fauxton Web UI.
-1. *(optional)* You can also use the displayed credentials to interact with
-   CouchDB API directly via the forwarded port (`35984`), e.g.:
-   ```
-   curl http://ui:$password@localhost:35984/_up
-   ```
-
 ### Tearing down an environment
 
 1. `cd gpii-infra/gcp/live/dev`
@@ -435,6 +425,17 @@ See [Getting started: One-time Stackdriver Workspace setup](README.md#one-time-s
 ## Working with CouchDB data
 
 You can run all `kubectl` commands mentioned below inside of an interactive shell started with `rake sh`.
+
+### Accessing CouchDB and CouchDB Web UI
+
+1. Running `rake couchdb_ui` task in corresponding environment direcotry (e.g.
+   `gcp/live/dev`) will set up port-forwarding of CouchDB port to your local
+   machine and print a link and credentials to access CouchDB Fauxton Web UI.
+1. *(optional)* You can also use the displayed credentials to interact with
+   CouchDB API directly via the forwarded port (`35984`), e.g.:
+   ```
+   curl http://ui:$password@localhost:35984/_up
+   ```
 
 ### The CouchDB cluster won't converge because one of its disks is in the wrong zone
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -77,6 +77,16 @@ Users who already had an RtF email address/Google account usually have performed
 1. `rake plain_sh` is like `rake sh`, but not all configuration is performed. This can be helpful for debugging (e.g. when `rake sh` does not work) and with interactive commands.
 1. To `curl` a single couchdb instance: `kubectl exec --namespace gpii couchdb-couchdb-0 -c couchdb -- curl -s http://$TF_VAR_secret_couchdb_admin_username:$TF_VAR_secret_couchdb_admin_password@127.0.0.1:5984/`
 
+#### Accessing CouchDB and CouchDB Web UI 
+
+1. Running `rake couchdb_ui` will set up port-forwarding of CouchDB port to local
+   machine and print a link and credentials to access CouchDB Fauxton Web UI.
+1. *(optional)* You can also use the displayed credentials to interact with
+   CouchDB API directly via the forwarded port (`35984`), e.g.:
+   ```
+   curl http://ui:$password@localhost:35984/_up
+   ```
+
 ### Tearing down an environment
 
 1. `cd gpii-infra/gcp/live/dev`


### PR DESCRIPTION
This PR:
- Adds documentation about accessing CouchDB UI and using port-forwarding
- Makes `ui` user password immutable for the lifetime of the given cluster (this is based on cluster's master IP, the user is still deleted when forwarding is stopped).

**TL;DR**: This change should make it more comfortable to use `couchdb_ui` port-forwarding feature.

I've implemented this based on Javi's feedback and discovery that some browsers don't accept user credentials in URL (`user:password`) anymore (Firefox generally works, Chrome is complicated - older versions work, newer ones will accept credentials once and cache these & ask for manual input should these change, Safari will always ask...). There's even RFC suggesting this form as deprecated - https://www.ietf.org/rfc/rfc3986.txt. Making the credentials immutable for the cluster lifetime will releave the user from having to enter these manually every time.
