### PR TITLE
GPII-3916 - Fix Backup exporter alert definitions

### DIFF
--- a/common/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots_prd.json
+++ b/common/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots_prd.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Backup-exporter of prd snapshots are missing for more than 12 hours",
+  "display_name": "Backup-exporter of prd snapshots are ok for 12 hours",
   "combiner": "OR",
   "conditions": [
     {
@@ -26,7 +26,7 @@
           "count": 1
         }
       },
-      "display_name": "Log-based snapshot_created for Backup-exporter"
+      "display_name": "Backup-exporter of prd snapshots are missing in the last 12 hours"
     }
   ],
   "notification_channels": [],

--- a/common/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots_stg.json
+++ b/common/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots_stg.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Backup-exporter of stg snapshots are missing for more than 12 hours",
+  "display_name": "Backup-exporter of stg snapshots are ok for 12 hours",
   "combiner": "OR",
   "conditions": [
     {
@@ -26,7 +26,7 @@
           "count": 1
         }
       },
-      "display_name": "Log-based snapshot_created for Backup-exporter"
+      "display_name": "Backup-exporter of stg snapshots are missing in the last 12 hours"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
@@ -12,7 +12,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
@@ -4,34 +4,42 @@
   "conditions": [
     {
       "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.error\" resource.type=\"k8s_container\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 0.0,
+        "duration": {
+          "seconds": 900,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0.0
+        },
         "aggregations": [
           {
             "alignment_period": {
               "seconds": 60,
-              "nanos" : 0
+              "nanos": 0
             },
+            "per_series_aligner": "ALIGN_MEAN",
             "cross_series_reducer": "REDUCE_MAX",
             "group_by_fields": [
               "metric.label.log"
-            ],
-            "per_series_aligner": "ALIGN_MEAN"
+            ]
           }
         ],
-        "comparison": "COMPARISON_GT",
-        "duration": {
-          "seconds": 900,
-          "nanos" : 0
-        },
-        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.error\" resource.type=\"k8s_container\"",
-        "trigger": {
-          "count": 1
-        }
+        "denominator_filter": "",
+        "denominator_aggregations": [
+
+        ]
       },
       "display_name": "Log-based errors for Backup-exporter"
     }
   ],
-  "notification_channels": [],
-  "user_labels": {},
+  "notification_channels": [
+  ],
+  "user_labels": {
+  },
   "enabled": {
     "value": ${enabled}
   }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Backup-exporter process reports one or more errors",
+  "display_name": "Backup-exporter process does not report one or more errors",
   "combiner": "OR",
   "conditions": [
     {
@@ -31,7 +31,7 @@
         "denominator_filter": "",
         "denominator_aggregations": []
       },
-      "display_name": "Log-based errors for Backup-exporter"
+      "display_name": "Backup-exporter process reports one or more errors"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_errors.json
@@ -35,8 +35,7 @@
     }
   ],
   "notification_channels": [],
-  "user_labels": {
-  },
+  "user_labels": {},
   "enabled": {
     "value": ${enabled}
   }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
@@ -10,7 +10,7 @@
           "nanos": 0
         },
         "trigger": {
-          "count": 1,
+          "count": 0,
           "percent": 0.0
         },
         "aggregations": [

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Backup-exporter snapshots are missing for more than 12 hours",
+  "display_name": "Backup-exporter snapshots are ok for 12 hours",
   "combiner": "OR",
   "conditions": [
     {
@@ -27,7 +27,7 @@
           }
         ]
       },
-      "display_name": "Log-based snapshot_created for Backup-exporter"
+      "display_name": "Backup-exporter snapshots failed in less than 12 hours"
     }
   ],
   "notification_channels": [],

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
@@ -4,33 +4,36 @@
   "conditions": [
     {
       "condition_absent": {
+        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.snapshot_created\" resource.type=\"k8s_container\"",
+        "duration": {
+          "seconds": 43200,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 1,
+          "percent": 0.0
+        },
         "aggregations": [
           {
             "alignment_period": {
               "seconds": 60,
-              "nanos" : 0
+              "nanos": 0
             },
+            "per_series_aligner": "ALIGN_COUNT",
             "cross_series_reducer": "REDUCE_MAX",
             "group_by_fields": [
               "metric.label.log"
-            ],
-            "per_series_aligner": "ALIGN_COUNT"
+            ]
           }
-        ],
-        "duration": {
-          "seconds": 43200,
-          "nanos" : 0
-        },
-        "filter": "metric.type=\"logging.googleapis.com/user/backup-exporter.snapshot_created\" resource.type=\"k8s_container\"",
-        "trigger": {
-          "count": 1
-        }
+        ]
       },
       "display_name": "Log-based snapshot_created for Backup-exporter"
     }
   ],
-  "notification_channels": [],
-  "user_labels": {},
+  "notification_channels": [
+  ],
+  "user_labels": {
+  },
   "enabled": {
     "value": ${enabled}
   }

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/backup_exporter_snapshots.json
@@ -30,10 +30,8 @@
       "display_name": "Log-based snapshot_created for Backup-exporter"
     }
   ],
-  "notification_channels": [
-  ],
-  "user_labels": {
-  },
+  "notification_channels": [],
+  "user_labels": {},
   "enabled": {
     "value": ${enabled}
   }


### PR DESCRIPTION
Second attempt to fix the "always update" issue when the monitoring is deployed in stg and prd. This time I've saved the JSON definition directly from Stackdriver.

`rake deploy_module["k8s/stackdriver/monitoring"]` output:
```
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Pod `couchdb-prometheus-exporter` exports a metric" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "IAM audit logs do not contain policy modification events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Snapshots are being created for persistent volumes of CouchDB stateful set" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Stackdriver audit log does not contain alert policy modification events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Backup-exporter process reports one or more errors" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "GKE audit log does not contain cluster creation events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "CloudDNS audit log does not contain zone modification events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Uptime check on `flowmanager.alfredo.dev.gcp.gpii.net` is green" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "GCE audit log does not contain firewall modification events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "GCE audit log does not contain non-GKE instance creation events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s cluster allocatable resource utilization stays within 85% of capacity" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Service management log does not contain API enabling / disabling events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s-snapshots logs do not contain errors" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s cluster API logs do not contain `kubectl exec` events" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "Backup-exporter snapshots are missing for more than 12 hours" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s pods utilize less than 85% of persistent volume capacity" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s containers does not restart more often than 1.5 times per minute" is up-to-date...
null_resource.apply_stackdriver_monitoring (local-exec): Alert policy "K8s container CPU utilization stays within 85% of limit" is up-to-date...

```