### PR TITLE
[GPII-3902]: Add missing websecurityscanner.serviceAgent binding to gcp-project

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -335,6 +335,14 @@ data "google_iam_policy" "combined" {
   }
 
   binding {
+    role = "roles/websecurityscanner.serviceAgent"
+
+    members = [
+      "serviceAccount:service-${google_project.project.number}@gcp-sa-websecurityscanner.iam.gserviceaccount.com",
+    ]
+  }
+
+  binding {
     role = "roles/cloudtrace.agent"
 
     members = [


### PR DESCRIPTION
This binding is created by default when Web Security Scanner API is enabled, seems to solve `One of the starting URLs is not hosted on the current project` problem.