### PR TITLE
Fix error with `data.kubernetes_service.istio-ingressgateway` on destroy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.1-google_gpii.0
+  - image: gpii/exekube:0.9.2-google_gpii.0
 
 version: 2
 jobs:

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.1-google_gpii.0
+    image: gpii/exekube:0.9.2-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.1-google_gpii.0
+    image: gpii/exekube:0.9.2-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/modules/gpii-flowmanager/dns.tf
+++ b/gcp/modules/gpii-flowmanager/dns.tf
@@ -3,6 +3,10 @@ data "kubernetes_service" "istio-ingressgateway" {
     name      = "istio-ingressgateway"
     namespace = "istio-system"
   }
+
+  # This dependency is to defer data source refresh until the apply phase and
+  # avoid an error when running destroy on non-existing cluster
+  depends_on = ["data.template_file.flowmanager_values"]
 }
 
 resource "google_dns_record_set" "flowmanager-dns" {


### PR DESCRIPTION
This PR fixes [GPII-4040](https://issues.gpii.net/browse/GPII-4040), error when running `destroy` on a non-existing cluster.

Changes introduced:
- Defer data source `kubernetes_service.istio-ingressgateway` refresh to apply phase
- Bump `exekube` to 0.9.2-google_gpii.0 - includes change to make `tiller_status` fail faster (see https://github.com/gpii-ops/exekube/pull/65 for details)

This PR depends on https://github.com/gpii-ops/exekube/pull/65.

Note: Circle CI tests will fail untill the `0.9.2` `exekube` image is created