### PR TITLE
GPII-3917 Fix testing org common-stg permissions

### DIFF
--- a/common/modules/gcp-external-backup/main.tf
+++ b/common/modules/gcp-external-backup/main.tf
@@ -8,10 +8,6 @@ provider "google" {
   region      = "${var.infra_region}"
 }
 
-data "google_project" "project" {
-  project_id = "gpii-gcp-${var.source_project_name}"
-}
-
 resource "null_resource" "retention_policy" {
   triggers = {
     days_until_delete = "${var.days_until_delete}"

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -304,6 +304,36 @@ data "google_iam_policy" "combined" {
     ]
   }
 
+  # Needed for setting up monitoring
+  # GPII-2782
+  binding {
+    role = "roles/logging.configWriter"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
+  # Needed for setting up monitoring
+  # GPII-2782
+  binding {
+    role = "roles/monitoring.alertPolicyEditor"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
+  # Needed for setting up monitoring
+  # GPII-2782
+  binding {
+    role = "roles/monitoring.notificationChannelEditor"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
   binding {
     role = "roles/logging.logWriter"
 


### PR DESCRIPTION
This PR fixes two issues in the common-stg of the testing organization:

1. The project owner SA needs permissions to modify the Stackdriver and logging services
2. There is a data resource that reads other projects that is not needed and gives a PERMISSION_DENIED.