### PR TITLE
GPII-3917 Fix issues on deployment

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -178,11 +178,20 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.service_accounts}",
+      "serviceAccount:${google_project.project.number}@cloudbuild.gserviceaccount.com",
     ]
   }
 
   binding {
     role = "roles/iam.serviceAccountActor"
+
+    members = [
+      "serviceAccount:${google_project.project.number}@cloudbuild.gserviceaccount.com",
+    ]
+  }
+
+  binding {
+    role = "roles/iam.serviceAccountTokenCreator"
 
     members = [
       "serviceAccount:${google_project.project.number}@cloudbuild.gserviceaccount.com",

--- a/gcp/live/prd/k8s/kube-system/backup-exporter/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/backup-exporter/terraform.tfvars
@@ -18,8 +18,8 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-# `destination_bucket` - The destination GCS bucket, i.e "gs://gpii-backup-external-prd".
-destination_bucket = "gs://gpii-backup-prd"
+# `destination_bucket` - The destination GCS bucket, i.e "gpii-backup-external-prd".
+destination_bucket = "gpii-backup-prd"
 
 # `replica_count` - the number of CouchDB replicas that the cluster has. This is important for copying all the snapshots of the cluster at the same time.
 replica_count      = 3

--- a/gcp/live/stg/k8s/kube-system/backup-exporter/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/backup-exporter/terraform.tfvars
@@ -18,8 +18,8 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
-# `destination_bucket` - The destination GCS bucket, i.e "gs://gpii-backup-external-prd".
-destination_bucket = "gs://gpii-backup-stg"
+# `destination_bucket` - The destination GCS bucket, i.e "gpii-backup-external-prd".
+destination_bucket = "gpii-backup-stg"
 
 # `replica_count` - the number of CouchDB replicas that the cluster has. This is important for copying all the snapshots of the cluster at the same time.
 replica_count      = 3

--- a/gcp/modules/backup-exporter/main.tf
+++ b/gcp/modules/backup-exporter/main.tf
@@ -61,7 +61,11 @@ module "backup-exporter" {
 
 resource "google_storage_bucket" "backup_daisy_bkt" {
   project = "${data.google_project.project.project_id}"
-  name    = "${data.google_project.project.name}-daisy-bkt"
+
+  # The Daisy bucket can use a different name depending on the zone where the
+  # Cloudbuild runs. By default it uses [project_name]-daisy-bkt but if the zone
+  # is set to us-* the name of the bucket will end with -us
+  name = "${data.google_project.project.name}-daisy-bkt-us"
 
   force_destroy = true
 }

--- a/gcp/modules/backup-exporter/main.tf
+++ b/gcp/modules/backup-exporter/main.tf
@@ -7,7 +7,7 @@ variable "charts_dir" {}
 variable "cloud_sdk_repository" {}
 variable "cloud_sdk_tag" {}
 
-# `destination_bucket` - The destination GCS bucket, i.e "gs://gpii-backup-external-prd".
+# `destination_bucket` - The destination GCS bucket, i.e "gpii-backup-external-prd".
 variable "destination_bucket" {}
 
 variable "project_id" {}
@@ -41,7 +41,7 @@ data "template_file" "backup-exporter" {
     destination_bucket        = "${var.destination_bucket}"
     local_intermediate_bucket = "${google_storage_bucket.backup_daisy_bkt.name}"
     replica_count             = "${var.replica_count}"
-    log_bucket                = "gs://${google_storage_bucket.backup_daisy_bkt.name}/logs"
+    log_bucket                = "${google_storage_bucket.backup_daisy_bkt.name}"
     schedule                  = "${var.schedule}"
   }
 }

--- a/shared/charts/backup-exporter/templates/configmap.yaml
+++ b/shared/charts/backup-exporter/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
         gcloud -q compute images delete "image-disk-${snapshot}"
       fi
       gcloud -q compute images create "image-disk-${snapshot}" --source-snapshot "${snapshot}"
-      gcloud -q --verbosity=debug compute images export --log-location "${LOG_BUCKET}" --destination-uri "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" --image "image-disk-${snapshot}"
+      gcloud -q --verbosity=debug compute images export --log-location "gs://${LOG_BUCKET}/logs" --destination-uri "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" --image "image-disk-${snapshot}"
       gcloud -q compute images delete "image-disk-${snapshot}"
-      gsutil -q mv "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" "${DESTINATION_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz"
+      gsutil -q mv "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" "gs://${DESTINATION_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz"
     done

--- a/shared/charts/backup-exporter/templates/configmap.yaml
+++ b/shared/charts/backup-exporter/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
         gcloud -q compute images delete "image-disk-${snapshot}"
       fi
       gcloud -q compute images create "image-disk-${snapshot}" --source-snapshot "${snapshot}"
-      gcloud -q --verbosity=debug compute images export --log-location "gs://${LOG_BUCKET}/logs" --destination-uri "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" --image "image-disk-${snapshot}"
+      gcloud -q compute images export --log-location "gs://${LOG_BUCKET}/logs" --destination-uri "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" --image "image-disk-${snapshot}" --network "network" --subnet "nodes" --zone "us-central1-a"
       gcloud -q compute images delete "image-disk-${snapshot}"
       gsutil -q mv "gs://${INTERMEDIATE_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz" "gs://${DESTINATION_BUCKET}/${TIMESTAMP}-${snapshot}.tar.gz"
     done


### PR DESCRIPTION
Changes of this repository:

1. Some path of the buckets were not properly set because the first check of the script fails.
1. Some roles were missing for the SA that is used to access the destination buckets.  The first time that CloudBuild runs tries to set all the permissions by itself. Of course, this is not possible in our environment because the SA that it uses is very limited. So we are setting the permissions instead.
1. STG and PRD don't have the default network that we have in DEV, so the command has been modified to use a particular region, just to store the images before they are sent to the destination bucket.
1. When we change the region, the working bucket used by the Daisy scripts changes.