### PR TITLE
GPII-4057: Fix use of removed to_hash in custom Stackdriver code

### DIFF
--- a/shared/rakefiles/stackdriver.rb
+++ b/shared/rakefiles/stackdriver.rb
@@ -85,7 +85,7 @@ def get_alert_policy_identifier(alert_policy)
 end
 
 def compare_alert_policies(stackdriver_alert_policy, alert_policy)
-  stackdriver_alert_policy = JSON.parse(stackdriver_alert_policy.to_hash.to_json)
+  stackdriver_alert_policy = JSON.parse(stackdriver_alert_policy.to_h.to_json)
   ["name", "creation_record", "mutated_by", "mutation_record"]. each do |attribute|
     stackdriver_alert_policy.delete(attribute)
   end
@@ -108,13 +108,13 @@ def compare_alert_policies(stackdriver_alert_policy, alert_policy)
 end
 
 def compare_notification_channels(stackdriver_notification_channel, notification_channel)
-  stackdriver_notification_channel = JSON.parse(stackdriver_notification_channel.to_hash.to_json)
+  stackdriver_notification_channel = JSON.parse(stackdriver_notification_channel.to_h.to_json)
 
   return stackdriver_notification_channel != notification_channel
 end
 
 def debug_output(resource)
-  return JSON.pretty_generate(resource.to_hash)
+  return JSON.pretty_generate(resource.to_h)
 end
 
 def apply_log_based_metrics(log_based_metrics = [])


### PR DESCRIPTION
Ruby protobuf library removed `to_hash` methods (see details https://github.com/protocolbuffers/protobuf/pull/6166) which breaks our Stackdriver code. This PR fixes the issue.

Changes:
- Use `to_h` instead of removed `to_hash` method

The error below happens on the current fresh build of `exekube` image (although is not present in the `gpii/exekube:0.9.2-google_gpii.0` tag):
```
/rakefiles/stackdriver.rb:111:in `method_missing': undefined method `to_hash' for #<Google::Monitoring::V3::NotificationChannel:0x000056471d319420> 
```

_Note: Looks like our `exekube` builds are a bit behind, so quite a few libraries got updated when rebuilding from scratch, probably caused by combination of caching and use of `alpine:3.8`:_
```
google-cloud-env (1.0.5)                            | google-cloud-env (1.2.0)
google-gax (1.5.0)                                  | google-gax (1.7.0)
google-protobuf (3.7.1, 3.6.1)                      | google-protobuf (3.9.0, 3.6.1)
grpc (1.20.0)                                       | grpc (1.22.0)
jwt (2.1.0)                                         | jwt (2.2.1)
multipart-post (2.0.0)                              | multipart-post (2.1.1)
public_suffix (3.0.3)                               | public_suffix (3.1.1)
rake (12.3.2)                                       | rake (12.3.3)
```

_Moving to newer Alpine (`3.10` is latest) is still blocked by `grpc` (which is required for Stackdriver code) failing to build with `gcc8` (see https://github.com/grpc/grpc/pull/14452 for details)._