### PR TITLE
Add note about using couchdb_ui credentials to run scripts

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -437,6 +437,18 @@ You can run all `kubectl` commands mentioned below inside of an interactive shel
    curl http://ui:$password@localhost:35984/_up
    ```
 
+_Note: Temporary credentials from `couchdb_ui` rake task can be handy for
+executing ad hoc scripts against the database, however CouchDB does not
+replicate these across the cluster, therefore they will only work when querying
+the same node where they were created. This will not be an issue when running
+queries from your local machine (`kubectl port-forward` always terminates the
+connection at the same pod). If you need to run queries from within docker
+container, you can use `docker` with `--net host` to do so, e.g. `docker run -it
+--rm --net host --entrypoint /bin/sh
+gcr.io/gpii-common-prd/gpii__universal:20190801163411-26be63f`, and CouchDB will
+be accessible using the url printed by the `couchdb_ui` rake task._
+
+
 ### The CouchDB cluster won't converge because one of its disks is in the wrong zone
 
 Consider this scenario:


### PR DESCRIPTION
This PR adds a note about using `couchdb_ui` credentials to execute ad hoc commands against the database and an example of probably the simplest way to do so from within a docker container.

(Should you want to run queries from within the cluster, e.g. using `kubectl run`, you can still use the credentials but you'll need to find out and use DNS specific for one pod, e.g. `couchdb-couchdb-0.couchdb-couchdb.gpii.svc.cluster.local`. I left this out as I believe the documented way is easier).
