### PR TITLE
GPII-4061: Clean up fw rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.2-google_gpii.0
+  - image: gpii/exekube:0.9.3-google_gpii.0
 
 version: 2
 jobs:

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.2-google_gpii.0
+    image: gpii/exekube:0.9.3-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -489,10 +489,11 @@ locals {
 }
 
 resource "google_project" "project" {
-  name            = "${var.organization_name}-gcp-${var.project_name}"
-  project_id      = "${var.organization_name}-gcp-${var.project_name}"
-  billing_account = "${var.billing_id}"
-  org_id          = "${var.organization_id}"
+  name                = "${var.organization_name}-gcp-${var.project_name}"
+  project_id          = "${var.organization_name}-gcp-${var.project_name}"
+  billing_account     = "${var.billing_id}"
+  org_id              = "${var.organization_id}"
+  auto_create_network = false
 }
 
 resource "google_project_services" "project" {

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.2-google_gpii.0
+    image: gpii/exekube:0.9.3-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/modules/gke-network/main.tf
+++ b/gcp/modules/gke-network/main.tf
@@ -49,6 +49,7 @@ module "gke_network" {
 
   static_ip_region         = "${var.infra_region}"
   create_static_ip_address = false
+  delete_default_network   = false
 }
 
 # ------------------------------------------------------------------------------

--- a/shared/rakefiles/scripts/clean_fw_rules.sh
+++ b/shared/rakefiles/scripts/clean_fw_rules.sh
@@ -5,7 +5,7 @@
 # Enable debug output if $DEBUG is set to true
 [ "${DEBUG:=false}" = 'true' ] && set -x
 
-# Get script name
+# Only print commands to delete rules by default
 DRY_RUN=${DRY_RUN:='true'}
 
 # Get projects
@@ -19,8 +19,7 @@ for p in ${PROJECTS}; do
   # Verify we have expected number of rules with tag (5 or 0)
   echo "GKE FWs:     $(gcloud -q --project "${p}" compute firewall-rules list --filter="targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | wc -l)"
 
-  # Count bad rules - 2 are dupes from exekube - will be removed after this PR
-  # rest are orphaned ones
+  # Count bad - orphaned - rules
   BAD_FW_RULES="$(gcloud -q --project "${p}" compute firewall-rules list --filter="NOT targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | tr '\r\n' ' ')"
   echo "Bad FWs:     $(echo "${BAD_FW_RULES}" | wc -w)"
   

--- a/shared/rakefiles/scripts/clean_fw_rules.sh
+++ b/shared/rakefiles/scripts/clean_fw_rules.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+# This script cleans orphaned FW rules across all projects
+
+# Enable debug output if $DEBUG is set to true
+[ "${DEBUG:=false}" = 'true' ] && set -x
+
+# Get script name
+DRY_RUN=${DRY_RUN:='true'}
+
+# Get projects
+PROJECTS=$(gcloud projects list --format="value(project_id)")
+
+for p in ${PROJECTS}; do
+  echo "## ${p}:"
+  # Get GKE cluster tag
+  GCP_TAG="$(gcloud -q --project "${p}" compute instance-templates list --filter="name : gke-k8s-cluster-terraform" --format="value(properties.tags.items[0])" --limit=1 2>/dev/null)"
+
+  # Verify we have expected number of rules with tag (5 or 0)
+  echo "GKE FWs:     $(gcloud -q --project "${p}" compute firewall-rules list --filter="targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | wc -l)"
+
+  # Count bad rules - 2 are dupes from exekube - will be removed after this PR
+  # rest are orphaned ones
+  BAD_FW_RULES="$(gcloud -q --project "${p}" compute firewall-rules list --filter="NOT targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | tr '\r\n' ' ')"
+  echo "Bad FWs:     $(echo "${BAD_FW_RULES}" | wc -w)"
+  
+  # If we have any bad rules, delete them 
+  if [ -n "${BAD_FW_RULES}" ]; then
+    if [ "${DRY_RUN}" = 'true' ] || [ "${p}" = 'gpii-gcp-prd' ] || [ "${p}" = 'gpii-gcp-stg' ]; then
+      echo gcloud -q --project "${p}" compute firewall-rules delete ${BAD_FW_RULES}
+    else
+      gcloud -q --project "${p}" compute firewall-rules delete ${BAD_FW_RULES}
+    fi
+  fi
+done


### PR DESCRIPTION
This PR addresses [GPII-4061 - Review & clean up GCP firewall rules](https://issues.gpii.net/browse/GPII-4061).

**Changes introduced:**
- Remove duplicate firewall rules created by exekube (see https://github.com/gpii-ops/exekube/pull/66 for details)
- Move default network deletion to native TF
- Manual cleanup of orphaned FW rules and default networks (see deployment plan)

This PR depends on https://github.com/gpii-ops/exekube/pull/66

_Note: Circle CI should pass once https://github.com/gpii-ops/exekube/pull/66 is merged and tag created._

**Deployment plan:**
- [ ] Merge this PR and deploy to all env
- [ ] Manual cleanup of orphaned rules
  - [ ] Run the below-attached script to cleanup orphaned FW rules (all but `stg` & `prd` envs)
  - [ ] Review and execute commands for `gpii-gcp-stg` and `gpii-gcp-prd` projects
- [ ] Manual cleanup of `default` network - run
   ```
   gcloud compute networks delete default --project gpii2test-common-stg
   gcloud compute networks delete default --project gpii-common-prd
  ```
- [ ] Manual cleanup of `forseti` network
  ```
  gcloud compute networks delete forseti --project gpii2test-common-stg
  ```

FW rules cleanup script:
```bash
#!/bin/bash

# Get projects
PROJECTS=$(gcloud projects list --format="value(project_id)")
DRY_RUN="true"

for p in ${PROJECTS}; do
  echo "## ${p}:"
  # Get GKE cluster tag
  GCP_TAG="$(gcloud -q --project "${p}" compute instance-templates list --filter="name : gke-k8s-cluster-terraform" --format="value(properties.tags.items[0])" --limit=1 2>/dev/null)"

  # Verify we have expected number of rules with tag (5 or 0)
  echo -n "GKE FWs:     "
  gcloud -q --project "${p}" compute firewall-rules list --filter="targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | wc -l

  # Count bad rules - 2 are dupes from exekube - will be removed after this PR
  # rest are orphaned ones
  BAD_FW_RULES="$(gcloud -q --project "${p}" compute firewall-rules list --filter="NOT targetTags :( ${GCP_TAG} )" --format="value(name)" 2>/dev/null | tr '\r\n' ' ')"
  echo -n "Bad FWs:     "
  echo "${BAD_FW_RULES}" | wc -w
   
  if [ "${DRY_RUN}" == "true" ] || [ "${p}" == "gpii-gcp-prd" ] || [ "${p}" == "gpii-gcp-stg" ]; then
    echo gcloud compute firewall-rules delete ${BAD_FW_RULES}
  else
    gcloud compute firewall-rules delete ${BAD_FW_RULES}
  fi
done
```

Output of dry-run:
```console
## gpii-gcp-dev-duhrer:
GKE FWs:            0
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## gpii2test-gcp-dev-tyler:
GKE FWs:            0
Bad FWs:            5
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal no-access no-access-in tyler-ssh
## authentic-host-239215:
GKE FWs:            0
Bad FWs:            0
gcloud compute firewall-rules delete
## rtfwebsite:
GKE FWs:            0
Bad FWs:            0
gcloud compute firewall-rules delete
## rtfwebsite-1556634123866:
GKE FWs:            0
Bad FWs:            0
gcloud compute firewall-rules delete
## gpii-gcp-dev-cindyli:
GKE FWs:            5
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## gpii-gcp-dev-jj:
GKE FWs:            0
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## gpii-gcp-dev-clown:
GKE FWs:            5
Bad FWs:           10
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal k8s-4d0cc07304e8ca18-node-http-hc k8s-bdf13e863255a06e-node-http-hc k8s-d8ffdc61f192d0cd-node-http-hc k8s-e91635a598ff6b86-node-http-hc k8s-fw-a0d9e25ea3ba311e9abab42010a8000e k8s-fw-a85f8b52c3ebf11e9a75342010a80009 k8s-fw-a97de787e3c6e11e984fc42010a800fc k8s-fw-ace9e22df4a7f11e9a9fa42010a80001
## gpii-gcp-dev-jhernandez:
GKE FWs:            0
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## gpii-gcp-dev-sgithens:
GKE FWs:            5
Bad FWs:            4
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal k8s-ad55a29098f0fabd-node-http-hc k8s-fw-a7a4809d83f8b11e9b84c42010a800fe
## gpii-gcp-dev-stepan:
GKE FWs:            5
Bad FWs:            5
gcloud compute firewall-rules delete allow-icmp-work allow-nodes-internal allow-pods-internal allow-ssh-test allow-ssh-work
## gpii-gcp-dev:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii-gcp-stg:
GKE FWs:            5
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## support-215616:
GKE FWs:            0
Bad FWs:            0
gcloud compute firewall-rules delete
## gpii2test-gcp-dev-doe:
GKE FWs:            0
Bad FWs:           39
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal k8s-0513ae3669abe2ec-node-http-hc k8s-0aaa16bce02fcd98-node-http-hc k8s-20b67fe1901d6d74-node-http-hc k8s-283302e91fc58851-node-http-hc k8s-2908bd57f774f505-node-http-hc k8s-4e0e93890537ba4a-node-http-hc k8s-59f2084ed091d6e2-node-http-hc k8s-5d93d2decce83406-node-http-hc k8s-613644deab3dcbe1-node-http-hc k8s-646135b3a5da7aef-node-http-hc k8s-75124e9d3a5daffd-node-http-hc k8s-75abdfc0ed0d218c-node-http-hc k8s-762de67562c2389e-node-http-hc k8s-8574852f5da93b05-node-http-hc k8s-879a92af1f812277-node-http-hc k8s-8b8809eb57682696-node-http-hc k8s-b55baff1c8c45a85-node-http-hc k8s-c54a3204846b3b46-node-http-hc k8s-f7107651ab1b0927-node-http-hc k8s-fw-a08f5728238ff11e9b7f642010a8e011 k8s-fw-a1cd8415e3c7011e9a5e342010a8e00e k8s-fw-a24118b0b38c811e98bcb42010a8e014 k8s-fw-a2c7483263ee011e98ceb42010a8e001 k8s-fw-a3d8f5e8c407d11e9acdb42010a8e010 k8s-fw-a49ad5241494811e98db242010a8e015 k8s-fw-a589f487f82f011e9954f42010a96005 k8s-fw-a67cef5a43a5a11e99d3542010a8e003 k8s-fw-a694020125fec11e98ebc42010a960fc k8s-fw-a6f032c1b3e7e11e9987642010a8e009 k8s-fw-a7089af095fad11e9b10542010a96010 k8s-fw-a741392a5399111e99e6542010a8e01b k8s-fw-a77f7f70b419311e9b10142010a8e019 k8s-fw-a78ad1739460c11e9940342010a8e004 k8s-fw-a9a1165e43e9011e9a5ac42010a8e009 k8s-fw-aca98fde849ac11e9a1ee42010a8e0fd k8s-fw-addc819703ea711e9bc3442010a8e01a k8s-fw-af1da039c460f11e986af42010a8e008
## gpii2test-gcp-dev:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii2test-gcp-prd:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii2test-gcp-stg:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii2test-common-stg:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii-gcp-dev-alfredo:
GKE FWs:            0
Bad FWs:           13
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal allow-ssh k8s-11b580ee59203a5f-node-http-hc k8s-29c6cb4befa3d806-node-http-hc k8s-778f5eac8ed3f7fd-node-http-hc k8s-83097955666448c3-node-http-hc k8s-ca16d1c80684a106-node-http-hc k8s-fw-a00351f8f45ae11e9aadf42010a80013 k8s-fw-a7f0ff2b03b7e11e9beca42010a80010 k8s-fw-a7fd7046550ad11e9aa0842010a80000 k8s-fw-ae5ce4d053e7911e9b75642010a80013 k8s-fw-ae81757203b8511e9850242010a80003
## gpii-common-prd:
GKE FWs:            0
Bad FWs:            4
gcloud compute firewall-rules delete default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh
## gpii-gcp-dev-gitlab-runner:
GKE FWs:            0
Bad FWs:          132
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal k8s-0468facde05c1bac-node-http-hc k8s-04b78d5103069443-node-http-hc k8s-06590eecf604d62f-node-http-hc k8s-06967be4c217f859-node-http-hc k8s-072b21e4528fabf8-node-http-hc k8s-090ca3dc6c51c910-node-http-hc k8s-0b648717b1576d47-node-http-hc k8s-10496d5b46eb17ad-node-http-hc k8s-10676c604a50cd93-node-http-hc k8s-106b834fb6c0970e-node-http-hc k8s-155ca02a139c3359-node-http-hc k8s-17488fba59e9214f-node-http-hc k8s-1a24b392c52b6bc4-node-http-hc k8s-1abcb3b54be581cc-node-http-hc k8s-1b70b519c7c30166-node-http-hc k8s-1dc9b518ea63ee1a-node-http-hc k8s-1edfdaaea2a5bcaa-node-http-hc k8s-1f097d02db82da55-node-http-hc k8s-1f6bbbc316f2391f-node-http-hc k8s-2263665db7eaeb41-node-http-hc k8s-2462b0da56ec5787-node-http-hc k8s-29e23eaf22b5ef10-node-http-hc k8s-2a96e4bcf70e7d4e-node-http-hc k8s-2b52bb7dabf3fe2a-node-http-hc k8s-2baad26f5911e91c-node-http-hc k8s-2e62b0f0cd6d029e-node-http-hc k8s-2e9fc8a2879a7c0d-node-http-hc k8s-315773bceecb4c06-node-http-hc k8s-316326e5115a214c-node-http-hc k8s-3454f88ee3eb1a3d-node-http-hc k8s-347958e03fd25b8c-node-http-hc k8s-363de2f6c97aba81-node-http-hc k8s-3672f9d927710f73-node-http-hc k8s-37e7891f69c493b0-node-http-hc k8s-38d4a1d4fc4d5478-node-http-hc k8s-44089ae8236d3bae-node-http-hc k8s-450ca9b806bfb0f7-node-http-hc k8s-4512078be9302d82-node-http-hc k8s-4651bd44a2399a85-node-http-hc k8s-47aae29191eca06c-node-http-hc k8s-47bf889e707e8694-node-http-hc k8s-49d39d77234d0dc2-node-http-hc k8s-4a7bdc3bc6bc5d58-node-http-hc k8s-4c1a5257c74ffca8-node-http-hc k8s-4ccf742014f2120b-node-http-hc k8s-4d2d0a2d232a88ba-node-http-hc k8s-51bcce7c30c30863-node-http-hc k8s-53f6dc79fc393312-node-http-hc k8s-558c4e110916802b-node-http-hc k8s-55dd757292931772-node-http-hc k8s-5628c08beb7c90c0-node-http-hc k8s-56e8231426d45a9f-node-http-hc k8s-5a69ed2be357d7ed-node-http-hc k8s-5c8e508d6a981a76-node-http-hc k8s-5d9508a7a3445c34-node-http-hc k8s-60c1eb16763cf1ab-node-http-hc k8s-60d36c63e44111f3-node-http-hc k8s-61fc3a2c8e89a3b5-node-http-hc k8s-63e98ae966989c40-node-http-hc k8s-64ca502cfb9980f0-node-http-hc k8s-65953ea0260d9016-node-http-hc k8s-6765f6cf351fb296-node-http-hc k8s-68d4c2d613593b36-node-http-hc k8s-6974682dab1b5640-node-http-hc k8s-6a80036de013d67f-node-http-hc k8s-6b917a1163b63688-node-http-hc k8s-6c69a91a5f3435a4-node-http-hc k8s-6df5d3547bca2909-node-http-hc k8s-6ee27efb35083baa-node-http-hc k8s-719a433242009659-node-http-hc k8s-78f016e341a85290-node-http-hc k8s-79c04a20fb4c9bb2-node-http-hc k8s-7a414b715cbe8e92-node-http-hc k8s-7d52cda875d322d5-node-http-hc k8s-7dea87701ddea831-node-http-hc k8s-823bfb7653ba9a2b-node-http-hc k8s-8260647d2674b566-node-http-hc k8s-827407de91a836ee-node-http-hc k8s-835fc22ed17366bb-node-http-hc k8s-87d963d401edcd9d-node-http-hc k8s-89b52677670208fe-node-http-hc k8s-911d69049c4c5306-node-http-hc k8s-948f56eda60f5386-node-http-hc k8s-96aa92b88f67e2e0-node-http-hc k8s-96d8f3fcbc9a7da2-node-http-hc k8s-9959a831450a9533-node-http-hc k8s-9a214137173ea107-node-http-hc k8s-9b5af35b005f9699-node-http-hc k8s-9ca329ad1f9c5eda-node-http-hc k8s-9ee45c834320975b-node-http-hc k8s-a18460ffb946c178-node-http-hc k8s-a39b373736f37c68-node-http-hc k8s-a5a1ed83a01ce31e-node-http-hc k8s-a5d86f02dbb6ba93-node-http-hc k8s-a7b1b305d71d5b01-node-http-hc k8s-a9eef28684f371ae-node-http-hc k8s-b1155483c4c0ff37-node-http-hc k8s-b487cf0c1d5c5ef0-node-http-hc k8s-b73b3cb65afd7d46-node-http-hc k8s-b9fc966596e5b5de-node-http-hc k8s-bc575bfaa6bfffa8-node-http-hc k8s-bcab5ac0452d2a7b-node-http-hc k8s-c161c06d113e54d9-node-http-hc k8s-c3f2afb4f85b86b7-node-http-hc k8s-c4f5ca82be4e3b64-node-http-hc k8s-ccf219b17d62c252-node-http-hc k8s-d15555cf64a17613-node-http-hc k8s-d35e1087b22c948a-node-http-hc k8s-d515f75a4d1aebd7-node-http-hc k8s-d622334ba71fe5a2-node-http-hc k8s-d89f7a0f439ba239-node-http-hc k8s-da2ed819881984c7-node-http-hc k8s-dde1b99ae266a7a8-node-http-hc k8s-deb17f474c736a91-node-http-hc k8s-e1d32c6345d9752c-node-http-hc k8s-e2ccab67018b3a20-node-http-hc k8s-e9be266c2e1b16ab-node-http-hc k8s-e9f34ee7b4249f87-node-http-hc k8s-ecdcc832e38b9ca1-node-http-hc k8s-f0d2380b2a699199-node-http-hc k8s-f25c52062d4716d2-node-http-hc k8s-f357fbecb313c91a-node-http-hc k8s-f61de35c229f9304-node-http-hc k8s-f9ecd61c944fa63a-node-http-hc k8s-fw-a10360802499711e9b2da42010a8e008 k8s-fw-a275b94ef39f111e9a2e342010a8e018 k8s-fw-a3a5e6343474511e9a0da42010a8e0fc k8s-fw-a59c5cbc2409111e989a742010a8e01a k8s-fw-a6b8b1b6c4a5b11e9bd3442010a8e00b k8s-fw-a93ef677a468411e9bde342010a8e00a
## gpii-gcp-prd:
GKE FWs:            5
Bad FWs:            2
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal
## gpii-gcp-dev-natarajaya:
GKE FWs:            5
Bad FWs:           19
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal k8s-43991a982875c1aa-node-http-hc k8s-54021690cb9a7be6-node-http-hc k8s-6d126be8eee734c1-node-http-hc k8s-869ed3585bee9c40-node-http-hc k8s-9b150f7f33685c3d-node-http-hc k8s-a351bdaf0601b624-node-http-hc k8s-a8b3dc2b9574d967-node-http-hc k8s-b2aa4c2d31dae0fe-node-http-hc k8s-bf14872aeac9bede-node-http-hc k8s-c1eddcce432b1d93-node-http-hc k8s-c416a6bbac0270de-node-http-hc k8s-d306bec06bd4d7e7-node-http-hc k8s-dc5934be84b78b4c-node-http-hc k8s-f730b79230936f98-node-http-hc k8s-fw-a40f6064d398411e9a6a742010a800fe k8s-fw-a6b117781371611e99ec842010a80002 k8s-fw-a74d3c9cca74511e9aa2e42010a8001d
## gpii-gcp-dev-tyler:
GKE FWs:            0
Bad FWs:           26
gcloud compute firewall-rules delete allow-nodes-internal allow-pods-internal default-allow-icmp default-allow-internal default-allow-rdp default-allow-ssh k8s-0052661d31987f7f-node-http-hc k8s-03cf8c7c12ab9854-node-http-hc k8s-0e7f6ef5d0625368-node-http-hc k8s-1a264658d397cb56-node-http-hc k8s-2d0e373795743eb5-node-http-hc k8s-3983d43546c48d91-node-http-hc k8s-4777519bc67382a4-node-http-hc k8s-55c935adb445e3d9-node-http-hc k8s-6af65d8d6b33a879-node-http-hc k8s-e5a6ecbace6e6cfb-node-http-hc k8s-f548be3cd6eaed2d-node-http-hc k8s-f6a677f9a6afa956-node-http-hc k8s-fffbffe9ab7855e7-node-http-hc k8s-fw-a1755eb384b9511e9803c42010a8000f k8s-fw-a4cfafd68484c11e9b19942010a96005 k8s-fw-a7179a314499511e995e542010a8e009 k8s-fw-a7958b005481b11e9b89f42010a8e006 k8s-fw-ab5ce514d4ac111e9be3f42010a8e007 k8s-fw-ac949ec67402e11e99b0542010a80006 k8s-fw-aef645f817c1a11e9958f42010a80005
```