### PR TITLE
GPII-3888: Periodic task to remove expired access tokens from the production Couch database

### DIFF
--- a/gcp/live/dev/k8s/gpii/flushtokens/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/flushtokens/terraform.tfvars
@@ -1,0 +1,20 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gpii-flushtokens"
+  }
+
+  dependencies {
+    paths = [
+      "../couchdb",
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/live/prd/k8s/gpii/flushtokens/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/flushtokens/terraform.tfvars
@@ -1,0 +1,20 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gpii-flushtokens"
+  }
+
+  dependencies {
+    paths = [
+      "../couchdb",
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/live/stg/k8s/gpii/flushtokens/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/flushtokens/terraform.tfvars
@@ -1,0 +1,20 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//gpii-flushtokens"
+  }
+
+  dependencies {
+    paths = [
+      "../couchdb",
+      "../istio",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)
+

--- a/gcp/modules/gpii-flushtokens/main.tf
+++ b/gcp/modules/gpii-flushtokens/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "secrets_dir" {}
+variable "charts_dir" {}
+
+variable "flushtokens_repository" {}
+variable "flushtokens_checksum" {}
+
+variable "secret_couchdb_admin_username" {}
+variable "secret_couchdb_admin_password" {}
+
+data "template_file" "flushtokens_values" {
+  template = "${file("values.yaml")}"
+
+  vars {
+    flushtokens_repository = "${var.flushtokens_repository}"
+    flushtokens_checksum   = "${var.flushtokens_checksum}"
+
+    couchdb_admin_username = "${var.secret_couchdb_admin_username}"
+    couchdb_admin_password = "${var.secret_couchdb_admin_password}"
+  }
+}
+
+module "gpii-flushtokens" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name            = "flushtokens"
+  release_namespace       = "gpii"
+  release_values          = ""
+  release_values_rendered = "${data.template_file.flushtokens_values.rendered}"
+
+  chart_name   = "${var.charts_dir}/gpii-flushtokens"
+  force_update = true
+}

--- a/gcp/modules/gpii-flushtokens/values.yaml
+++ b/gcp/modules/gpii-flushtokens/values.yaml
@@ -1,0 +1,5 @@
+image:
+  repository: ${flushtokens_repository}
+  checksum: ${flushtokens_checksum}
+
+couchdbUrl: "http://${couchdb_admin_username}:${couchdb_admin_password}@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"

--- a/shared/charts/gpii-flushtokens/Chart.yaml
+++ b/shared/charts/gpii-flushtokens/Chart.yaml
@@ -1,0 +1,18 @@
+name: gpii-flushtokens
+version: 0.1.0
+appVersion: 
+home: https://github.com/gpii-ops/gpii-infra
+description: GPII Delete Expired Access Tokens Job.
+icon: https://gpii.net/sites/all/themes/gpii_main/logo.png
+keywords:
+  - gpii
+  - flushtokens
+sources:
+  - https://github.com/gpii-ops/gpii-infra
+maintainers:
+  - name: amatas
+    email: alfredo@raisingthefloor.org
+  - name: natarajaya
+    email: sergey@raisingthefloor.org
+  - name: mrtyler
+    email: tyler@raisingthefloor.org

--- a/shared/charts/gpii-flushtokens/README.md
+++ b/shared/charts/gpii-flushtokens/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the gpii-flushtokens ch
 Parameter | Description | Default
 --- | --- | ---
 `couchdbUrl` | couchdb url for flushtokens | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii`
+`maxDocsInBatchPerRequest` | maximum number of database documents to process in batch per each request for expired access token records | `10000`
 `image.repository` | container image repository | `gpii/universal`
 `image.checksum` | container image checksum | `sha256:fa3bbf3a8255be83552da35b84a1a005d5cb3a44627510171a5a5eb11b2aea89`
 `image.pullPolicy` | container image pullPolicy | `IfNotPresent`

--- a/shared/charts/gpii-flushtokens/README.md
+++ b/shared/charts/gpii-flushtokens/README.md
@@ -1,0 +1,51 @@
+# GPII Flushtokens
+
+The flush tokens job is a part of Global Public Inclusive Infrastructure.
+Check out more at [GPII GitHub account](https://github.com/gpii).
+
+## TL;DR;
+
+```console
+$ helm install path_to_chart/gpii-flushtokens
+```
+
+## Introduction
+
+This chart bootstraps a deployment of GPII Flushtokesn on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release path_to_chart/gpii-flushtokens
+```
+
+The command deploys gpii-flushtokens on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the gpii-flushtokens chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`couchdbUrl` | couchdb url for flushtokens | `http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii`
+`image.repository` | container image repository | `gpii/universal`
+`image.checksum` | container image checksum | `sha256:fa3bbf3a8255be83552da35b84a1a005d5cb3a44627510171a5a5eb11b2aea89`
+`image.pullPolicy` | container image pullPolicy | `IfNotPresent`
+`cronJobSchedule` | frequency with which flushtokens job runs | `*/15 * * * *`

--- a/shared/charts/gpii-flushtokens/templates/NOTES.txt
+++ b/shared/charts/gpii-flushtokens/templates/NOTES.txt
@@ -1,0 +1,1 @@
+GPII flushtokens has been deployed successfully!

--- a/shared/charts/gpii-flushtokens/templates/_helper.tpl
+++ b/shared/charts/gpii-flushtokens/templates/_helper.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "flushtokens.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flushtokens.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/shared/charts/gpii-flushtokens/templates/cronjob.yaml
+++ b/shared/charts/gpii-flushtokens/templates/cronjob.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "flushtokens.name" . }}
+spec:
+  schedule: "{{ .Values.cronJobSchedule }}"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  startingDeadlineSeconds: 200
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "flushtokens.name" . }}
+        spec:
+          shareProcessNamespace: true
+          containers:
+          - name: gpii-flushtokens
+            image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
+            command: [ "/bin/sh", "-c", "/app/scripts/dockerDeleteExpiredAccessTokens.sh" ]
+            env:
+            - name: GPII_COUCHDB_URL
+              value: '{{ .Values.couchdbUrl }}'
+            # Use '--deleteAll' to delete all of the access tokens
+            - name: DELETE_ALL
+              value: 'false'
+          - name: istio-proxy-manager
+            image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsUser: 1337
+            command: [ "/bin/sh", "-c" ]
+            args:
+              - while ! ps -o user | grep node > /dev/null;
+                do
+                  echo 'Waiting for dockerDeleteExpiredAccessTokens.sh to start...';
+                  sleep 2;
+                done;
+                echo 'dockerDeleteExpiredAccessTokens.sh started.';
+                while ps -o user | grep node > /dev/null;
+                do
+                  echo 'Waiting for dockerDeleteExpiredAccessTokens.sh to finish...';
+                  sleep 2;
+                done;
+                echo 'dockerDeleteExpiredAccessTokens.sh finished.';
+                while pgrep pilot-agent > /dev/null;
+                do
+                  echo 'Sending TERM to pilot-agent';
+                  pkill pilot-agent;
+                  sleep 2;
+                done;
+                echo 'pilot-agent terminated';
+          restartPolicy: OnFailure

--- a/shared/charts/gpii-flushtokens/templates/cronjob.yaml
+++ b/shared/charts/gpii-flushtokens/templates/cronjob.yaml
@@ -24,9 +24,8 @@ spec:
             env:
             - name: GPII_COUCHDB_URL
               value: '{{ .Values.couchdbUrl }}'
-            # Use '--deleteAll' to delete all of the access tokens
-            - name: DELETE_ALL
-              value: 'false'
+            - name: MAX_DOCS_IN_BATCH_PER_REQUEST
+              value: '{{ .Values.maxDocsInBatchPerRequest }}'
           - name: istio-proxy-manager
             image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
             securityContext:

--- a/shared/charts/gpii-flushtokens/values.yaml
+++ b/shared/charts/gpii-flushtokens/values.yaml
@@ -1,0 +1,14 @@
+# Default values for gpii-flushtokens.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+couchdbUrl: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"
+
+image:
+  repository: gpii/universal
+  checksum: sha256:652ed9dc86639d51e806356737567336339c9eb675193ba04b2c5346de3bdee6
+  pullPolicy: IfNotPresent
+
+nameOverride: flushtokens
+
+cronJobSchedule: "*/15 * * * *"

--- a/shared/charts/gpii-flushtokens/values.yaml
+++ b/shared/charts/gpii-flushtokens/values.yaml
@@ -3,12 +3,13 @@
 # Declare variables to be passed into your templates.
 
 couchdbUrl: "http://admin:password@couchdb-svc-couchdb.gpii.svc.cluster.local:5984/gpii"
+maxDocsInBatchPerRequest: "10000"
+cronJobSchedule: "*/15 * * * *"
 
 image:
-  repository: gpii/universal
-  checksum: sha256:652ed9dc86639d51e806356737567336339c9eb675193ba04b2c5346de3bdee6
+  repository: cindyqili/universal
+  checksum: sha256:d41d5fa6ebb015f587a52555ad522cf001d1d1077b637e96fc887731896b7e27
   pullPolicy: IfNotPresent
 
 nameOverride: flushtokens
 
-cronJobSchedule: "*/15 * * * *"

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -71,28 +71,28 @@ couchdb:
     tag: 2.3.1
 dataloader:
   upstream:
-    repository: gpii/universal
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    tag: latest
   generated:
-    repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
+    tag: latest
 flushtokens:
   upstream:
-    repository: gpii/universal
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    tag: latest
   generated:
-    repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
+    tag: latest
 flowmanager:
   upstream:
-    repository: gpii/universal
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    tag: latest
   generated:
-    repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
+    tag: latest
 k8s_snapshots:
   upstream:
     repository: elsdoerfer/k8s-snapshots
@@ -111,12 +111,12 @@ locust:
     tag: 0.9.0-gpii.6
 preferences:
   upstream:
-    repository: gpii/universal
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    tag: latest
   generated:
-    repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
-    tag: 20190801163411-26be63f
+    repository: cindyqili/universal
+    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
+    tag: latest
 service_account_assigner:
   upstream:
     repository: gpii/service-account-assigner

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -72,19 +72,27 @@ couchdb:
 dataloader:
   upstream:
     repository: gpii/universal
-    tag: 20190522142238-4a52f56
+    tag: 20190801163411-26be63f
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076
-    tag: 20190522142238-4a52f56
+    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
+    tag: 20190801163411-26be63f
+flushtokens:
+  upstream:
+    repository: gpii/universal
+    tag: 20190801163411-26be63f
+  generated:
+    repository: gcr.io/gpii-common-prd/gpii__universal
+    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
+    tag: 20190801163411-26be63f
 flowmanager:
   upstream:
     repository: gpii/universal
-    tag: 20190522142238-4a52f56
+    tag: 20190801163411-26be63f
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076
-    tag: 20190522142238-4a52f56
+    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
+    tag: 20190801163411-26be63f
 k8s_snapshots:
   upstream:
     repository: elsdoerfer/k8s-snapshots
@@ -104,11 +112,11 @@ locust:
 preferences:
   upstream:
     repository: gpii/universal
-    tag: 20190522142238-4a52f56
+    tag: 20190801163411-26be63f
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
-    sha: sha256:57606b63cc431e1608c00d124e86a60b8f6d24196d0e600b0d279dee31395076
-    tag: 20190522142238-4a52f56
+    sha: sha256:fb90080bee40bf89684afd166797b700d8fed3342f043a5f71914ce69aae326e
+    tag: 20190801163411-26be63f
 service_account_assigner:
   upstream:
     repository: gpii/service-account-assigner

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -71,28 +71,28 @@ couchdb:
     tag: 2.3.1
 dataloader:
   upstream:
-    repository: cindyqili/universal
-    tag: latest
+    repository: gpii/universal
+    tag: 20190809170605-f8485e9
   generated:
-    repository: cindyqili/universal
-    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
-    tag: latest
+    repository: gpii/universal
+    sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
+    tag: 20190809170605-f8485e9
 flushtokens:
   upstream:
-    repository: cindyqili/universal
-    tag: latest
+    repository: gpii/universal
+    tag: 20190809170605-f8485e9
   generated:
-    repository: cindyqili/universal
-    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
-    tag: latest
+    repository: gpii/universal
+    sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
+    tag: 20190809170605-f8485e9
 flowmanager:
   upstream:
-    repository: cindyqili/universal
-    tag: latest
+    repository: gpii/universal
+    tag: 20190809170605-f8485e9
   generated:
-    repository: cindyqili/universal
-    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
-    tag: latest
+    repository: gpii/universal
+    sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
+    tag: 20190809170605-f8485e9
 k8s_snapshots:
   upstream:
     repository: elsdoerfer/k8s-snapshots
@@ -111,12 +111,12 @@ locust:
     tag: 0.9.0-gpii.6
 preferences:
   upstream:
-    repository: cindyqili/universal
-    tag: latest
+    repository: gpii/universal
+    tag: 20190809170605-f8485e9
   generated:
-    repository: cindyqili/universal
-    sha: sha256:f9020505bf92b32ed2865715c8748b118a962b7d8a0078e2136b120a5850f4e0
-    tag: latest
+    repository: gpii/universal
+    sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
+    tag: 20190809170605-f8485e9
 service_account_assigner:
   upstream:
     repository: gpii/service-account-assigner


### PR DESCRIPTION
**NOTE**: As of 09-Aug-2019, this pull request references a tagged version of the [gpii-universal docker image](https://ci.gpii.net/job/docker-gpii-universal-master-calculate-tag/33/console):
```
repository: gpii/universal
tag: 20190809170605-f8485e9
```
**NOTE**:  There should be an associated pull request for `gpii-version-updater`, but as of 09-Aug-2019, when attempting to create one, github says there are no differences with respect to the master branch and my GPII-3888 branch.  For now, the associated pull request is [PR #22](https://github.com/gpii-ops/gpii-version-updater/pull/22), which has already been merged into master.

JIRA: https://issues.gpii.net/browse/GPII-3888

<del>
**NOTE**: As of 09-Aug-2019, this pull request references @cindyli's development version of the docker image of gpii-universal:
```
repository: cindyqili/universal
tag: latest
```
This MUST be replaced with the official tagged docker image provided by CI's tag calculation process (`https://ci.gpii.net/job/docker-gpii-universal-master-calculate-tag/...`).
</del>
