### PR TITLE
[GPII-4068]: Bump CouchDB replica_count to 3 in dev

### DIFF
--- a/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
@@ -22,7 +22,7 @@ terragrunt = {
 backup_deltas     = "PT5M PT15M PT45M"
 release_namespace = "gpii"
 
-replica_count        = 2
+replica_count        = 3
 requests_cpu         = "500m"
 requests_memory      = "512Mi"
 limits_cpu           = "1000m"

--- a/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/dev/k8s/gpii/couchdb/terraform.tfvars
@@ -22,7 +22,6 @@ terragrunt = {
 backup_deltas     = "PT5M PT15M PT45M"
 release_namespace = "gpii"
 
-replica_count        = 3
 requests_cpu         = "500m"
 requests_memory      = "512Mi"
 limits_cpu           = "1000m"

--- a/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/prd/k8s/gpii/couchdb/terraform.tfvars
@@ -22,7 +22,6 @@ terragrunt = {
 backup_deltas     = "PT5M PT60M PT24H P7D P52W"
 release_namespace = "gpii"
 
-replica_count        = 3
 requests_cpu         = "1000m"
 requests_memory      = "512Mi"
 limits_cpu           = "1000m"

--- a/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
+++ b/gcp/live/stg/k8s/gpii/couchdb/terraform.tfvars
@@ -22,7 +22,6 @@ terragrunt = {
 backup_deltas     = "PT5M PT60M PT4H PT24H P7D"
 release_namespace = "gpii"
 
-replica_count        = 3
 requests_cpu         = "1000m"
 requests_memory      = "512Mi"
 limits_cpu           = "1000m"

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -14,7 +14,6 @@ variable "couchdb_tag" {}
 
 # Terragrunt variables
 
-variable "replica_count" {}
 variable "backup_deltas" {}
 variable "release_namespace" {}
 variable "requests_cpu" {}
@@ -33,6 +32,12 @@ variable "execute_recover_pvcs" {}
 variable "secret_couchdb_admin_password" {}
 variable "secret_couchdb_admin_username" {}
 variable "secret_couchdb_auth_cookie" {}
+
+# Default variables
+
+variable "replica_count" {
+  default = 3
+}
 
 data "template_file" "couchdb_values" {
   depends_on = ["null_resource.couchdb_recover_pvcs"]


### PR DESCRIPTION
To have consistency with stg and prd clusters.
We have enough room for one more replica, no need to change workers flavor (we actually have more than needed – after upgrade around 4CPUs and 4GB of RAM is still allocatable across all nodes).
I also verified some scenarios (CouchDB upgrade, K8s upgrade, preferences / flowmanager rollouts) and did not find any unwanted side effects.