### PR TITLE
GPII-2865: Implement Network policies - pt. 2

### DIFF
--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -1,0 +1,14 @@
+resource "kubernetes_network_policy" "deny-default" {
+  metadata {
+    name      = "deny-default"
+    namespace = "${kubernetes_namespace.gpii.metadata.0.name}"
+  }
+
+  spec {
+    pod_selector {}
+
+    ingress {}
+
+    policy_types = ["Ingress"]
+  }
+}


### PR DESCRIPTION
This PR is the second part of implementing Network Policies for services in GPII namespace - [GPII-2865](https://issues.gpii.net/browse/GPII-2865).

This PR implements default "deny" and should only be merged after #485.

This PR:
- Adds default deny Ingress Network Policy for GPII namespace

Deploy plan:
- Verify that deny policy is in effect by starting an interactive container `kubectl run -it --restart=Never --image=gcr.io/gpii-common-prd/gpii__locust:0.9.0-gpii.6 test -n gpii -- /bin/sh` and running following commands:
   ```console
    $ curl -k -s -w "%{http_code}" -o /dev/null http://preferences.gpii.svc.cluster.local/health
    503~ $
    $ curl -k -s -w "%{http_code}" -o /dev/null http://flowmanager.gpii.svc.cluster.local/health
    503~ $
    $ curl -k -s -w "%{http_code}" -o /dev/null http://couchdb-svc-couchdb.gpii.svc.cluster.local:5984/_up
    503~ $
   ```
    Expected reply is `503` signalling Istio can't connect to upstream (as opposed to `200`s and `401` that are returned when network policies are not applied)
  - [ ] - stg
  - [ ] - prd