### PR TITLE
[GPII-4037]: Improve CouchDB monitoring

### DIFF
--- a/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/couchdb_membership_error.json
+++ b/gcp/modules/gcp-stackdriver-lbm/resources/log_based_metrics/couchdb_membership_error.json
@@ -1,0 +1,4 @@
+{
+  "name": "couchdb_membership.error",
+  "filter": "resource.type=\"k8s_container\" AND resource.labels.container_name=\"couchdb-statefulset-assembler\" AND severity>=\"ERROR\""
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_membership_errors.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_membership_errors.json
@@ -1,0 +1,44 @@
+{
+  "display_name": "CouchDB membership check logs do not contain errors",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"logging.googleapis.com/user/couchdb_membership.error\" resource.type=\"k8s_container\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 1.0,
+        "duration": {
+          "seconds": 0,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 600,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_SUM",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "Error found in CouchDB membership check logs"
+    }
+  ],
+  "documentation": {
+    "content": "[Use this link to explore policy events in Logs Viewer](https://console.cloud.google.com/logs/viewer?project=${project_id}&minLogLevel=0&expandAll=false&interval=PT1H&advancedFilter=resource.type%3D%22k8s_container%22%20AND%20resource.labels.container_name%3D%22couchdb-statefulset-assembler%22%20AND%20severity%3E%3D%22ERROR%22)",
+    "mime_type": "text/markdown"
+  },
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_request_time.json
+++ b/gcp/modules/gcp-stackdriver-monitoring/resources/alert_policies/couchdb_request_time.json
@@ -1,0 +1,40 @@
+{
+  "display_name": "CouchDB request time stays within 100ms",
+  "combiner": "OR",
+  "conditions": [
+    {
+      "condition_threshold": {
+        "filter": "metric.type=\"custom.googleapis.com/couchdb/httpd_request_time\" resource.type=\"gke_container\"",
+        "comparison": "COMPARISON_GT",
+        "threshold_value": 100,
+        "duration": {
+          "seconds": 180,
+          "nanos": 0
+        },
+        "trigger": {
+          "count": 0,
+          "percent": 0.0
+        },
+        "aggregations": [
+          {
+            "alignment_period": {
+              "seconds": 60,
+              "nanos": 0
+            },
+            "per_series_aligner": "ALIGN_MEAN",
+            "cross_series_reducer": "REDUCE_NONE",
+            "group_by_fields": []
+          }
+        ],
+        "denominator_filter": "",
+        "denominator_aggregations": []
+      },
+      "display_name": "CouchDB request time exceeded 100ms"
+    }
+  ],
+  "notification_channels": [],
+  "user_labels": {},
+  "enabled": {
+    "value": true
+  }
+}

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -32,7 +32,7 @@ cloud_sdk:
 couchdb_helper:
   upstream:
     repository: gpii/couchdb-statefulset-assembler
-    tag: 1.3.0-gpii.0
+    tag: 1.4.0-gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/gpii__couchdb-statefulset-assembler
     sha: sha256:aee756f436ff1daf32701d21da929e8c0b657b5b5ed7755d84e3f0f3c8c75116


### PR DESCRIPTION
This PR adds LBM and alert policies to monitor CouchDB response latency and cluster membership status.
It uses membership check feature of `couchdb-statefulset-assembler` added in https://github.com/gpii-ops/couchdb-statefulset-assembler/pull/3.

Bumping `couchdb-statefulset-assembler` to new version will require stateful set restart and is currently disruptive (until my work on GPII-4068 lands).