### PR TITLE
GPII-2865: Add names to ports for Preferences and Flowmanager

### DIFF
--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.flowmanagerListenPort }}
+          name: http
         env:
         - name: NODE_ENV
           value: '{{ .Values.nodeEnv }}'

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.preferencesListenPort }}
+          name: http
         env:
         - name: NODE_ENV
           value: {{ .Values.nodeEnv }}


### PR DESCRIPTION
I've missed to include this change in https://github.com/gpii-ops/gpii-infra/pull/485. Some of the network policies won't work without it.