### PR TITLE
[GPII-4074]: Populate sensitive env vars in GPII charts from secrets

### DIFF
--- a/shared/charts/couchdb-prometheus-exporter/Chart.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb-prometheus-exporter
-version: 0.1.0
+version: 0.2.0
 appVersion: 77a019a7707f581f70239783d0b76500ba25b9382d9ee0702452b0381d5722c2
 home: https://github.com/gesellix/couchdb-prometheus-exporter
 description: CouchDB Prometheus Exporter

--- a/shared/charts/couchdb-prometheus-exporter/templates/_helpers.tpl
+++ b/shared/charts/couchdb-prometheus-exporter/templates/_helpers.tpl
@@ -12,3 +12,14 @@ Create chart name and version as used by the chart label.
 {{- define "couchdb_prometheus_exporter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "couchdb_prometheus_exporter.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        app: couchdb-prometheus-exporter
+        app: {{ template "couchdb_prometheus_exporter.name" . }}
       annotations:
         # This annotation is needed to allow traffic to metadata.google.internal
         # until Istio's issue with FQDNs in ServiceEntries is not resolved:
@@ -30,12 +30,18 @@ spec:
         env:
         - name: COUCHDB_URI
           value: {{ .Values.couchdb.uri }}
-        - name: COUCHDB_USERNAME
-          value: {{ .Values.couchdb.username }}
-        - name: COUCHDB_PASSWORD
-          value: {{ .Values.couchdb.password }}
         - name: COUCHDB_DATABASES
           value: {{ .Values.couchdb.databases }}
+        - name: COUCHDB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "couchdb_prometheus_exporter.name" . }}
+              key: couchdbUsername
+        - name: COUCHDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "couchdb_prometheus_exporter.name" . }}
+              key: couchdbPassword
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: prometheus-to-sd

--- a/shared/charts/couchdb-prometheus-exporter/templates/secrets.yaml
+++ b/shared/charts/couchdb-prometheus-exporter/templates/secrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "couchdb_prometheus_exporter.name" . }}
+  labels:
+    app: {{ template "couchdb_prometheus_exporter.name" . }}
+type: Opaque
+data:
+  couchdbUsername: {{ template "couchdb_prometheus_exporter.defaultsecret" .Values.couchdb.username }}
+  couchdbPassword: {{ template "couchdb_prometheus_exporter.defaultsecret" .Values.couchdb.password }}

--- a/shared/charts/gpii-dataloader/Chart.yaml
+++ b/shared/charts/gpii-dataloader/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-dataloader
-version: 0.2.0
+version: 0.3.0
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Dataloader Job.

--- a/shared/charts/gpii-dataloader/templates/_helpers.tpl
+++ b/shared/charts/gpii-dataloader/templates/_helpers.tpl
@@ -12,3 +12,14 @@ Create chart name and version as used by the chart label.
 {{- define "dataloader.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "dataloader.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/gpii-dataloader/templates/job.yaml
+++ b/shared/charts/gpii-dataloader/templates/job.yaml
@@ -15,5 +15,8 @@ spec:
         command: [ '/app/scripts/deleteAndLoadSnapsets.sh' ]
         env:
         - name: GPII_COUCHDB_URL
-          value: '{{ .Values.couchdb.url }}'
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "dataloader.name" . }}
+              key: couchdbUrl
       restartPolicy: OnFailure

--- a/shared/charts/gpii-dataloader/templates/secrets.yaml
+++ b/shared/charts/gpii-dataloader/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "dataloader.name" . }}
+  labels:
+    app: {{ template "dataloader.name" . }}
+type: Opaque
+data:
+  couchdbUrl: {{ template "dataloader.defaultsecret" .Values.couchdb.url }}

--- a/shared/charts/gpii-flowmanager/Chart.yaml
+++ b/shared/charts/gpii-flowmanager/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-flowmanager
-version: 1.4.0
+version: 1.5.0
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Flowmanager Service.

--- a/shared/charts/gpii-flowmanager/templates/_helpers.tpl
+++ b/shared/charts/gpii-flowmanager/templates/_helpers.tpl
@@ -12,3 +12,14 @@ Create chart name and version as used by the chart label.
 {{- define "flowmanager.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "flowmanger.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/gpii-flowmanager/templates/_helpers.tpl
+++ b/shared/charts/gpii-flowmanager/templates/_helpers.tpl
@@ -16,7 +16,7 @@ Create chart name and version as used by the chart label.
 {{/*
 Create a random string if the supplied key does not exist
 */}}
-{{- define "flowmanger.defaultsecret" -}}
+{{- define "flowmanager.defaultsecret" -}}
 {{- if . -}}
 {{- . | b64enc | quote -}}
 {{- else -}}

--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: flowmanager
+        app: {{ template "flowmanager.name" . }}
       annotations:
         # This annotation is needed to allow traffic to metadata.google.internal
         # until Istio's issue with FQDNs in ServiceEntries is not resolved:
@@ -31,12 +31,15 @@ spec:
           value: '{{ .Values.nodeEnv }}'
         - name: GPII_FLOWMANAGER_LISTEN_PORT
           value: '{{ .Values.flowmanagerListenPort }}'
-        - name: GPII_DATASOURCE_HOSTNAME
-          value: '{{ .Values.datasourceHostname }}'
         - name: GPII_DATASOURCE_PORT
           value: '{{ .Values.datasourceListenPort }}'
         - name: GPII_FLOWMANAGER_TO_PREFERENCESSERVER_URL
           value: '{{ .Values.preferences.url }}'
+        - name: GPII_DATASOURCE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "preferences.name" . }}
+              key: datasourceHostname
         {{- if .Values.enableStackdriverTrace }}
         - name: GPII_ENABLE_STACKDRIVER_TRACE
           value: 'true'

--- a/shared/charts/gpii-flowmanager/templates/deployment.yaml
+++ b/shared/charts/gpii-flowmanager/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: GPII_DATASOURCE_HOSTNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "preferences.name" . }}
+              name: {{ template "flowmanager.name" . }}
               key: datasourceHostname
         {{- if .Values.enableStackdriverTrace }}
         - name: GPII_ENABLE_STACKDRIVER_TRACE

--- a/shared/charts/gpii-flowmanager/templates/secrets.yaml
+++ b/shared/charts/gpii-flowmanager/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "flowmanager.name" . }}
+  labels:
+    app: {{ template "flowmanager.name" . }}
+type: Opaque
+data:
+  datasourceHostname: {{ template "flowmanager.defaultsecret" .Values.datasourceHostname }}

--- a/shared/charts/gpii-flushtokens/Chart.yaml
+++ b/shared/charts/gpii-flushtokens/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-flushtokens
-version: 0.2.0
+version: 0.3.0
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Delete Expired Access Tokens Job.
 icon: https://gpii.net/sites/all/themes/gpii_main/logo.png

--- a/shared/charts/gpii-flushtokens/templates/_helpers.tpl
+++ b/shared/charts/gpii-flushtokens/templates/_helpers.tpl
@@ -12,3 +12,14 @@ Create chart name and version as used by the chart label.
 {{- define "flushtokens.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "flushtokens.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/gpii-flushtokens/templates/cronjob.yaml
+++ b/shared/charts/gpii-flushtokens/templates/cronjob.yaml
@@ -22,10 +22,13 @@ spec:
             image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
             command: [ "/bin/sh", "-c", "/app/scripts/dockerDeleteExpiredAccessTokens.sh" ]
             env:
-            - name: GPII_COUCHDB_URL
-              value: '{{ .Values.couchdb.url }}'
             - name: MAX_DOCS_IN_BATCH_PER_REQUEST
               value: '{{ .Values.maxDocsInBatchPerRequest }}'
+            - name: GPII_COUCHDB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "flushtokens.name" . }}
+                  key: couchdbUrl
           - name: istio-proxy-manager
             image: "{{ .Values.image.repository }}@{{ .Values.image.checksum }}"
             securityContext:

--- a/shared/charts/gpii-flushtokens/templates/secrets.yaml
+++ b/shared/charts/gpii-flushtokens/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "flushtokens.name" . }}
+  labels:
+    app: {{ template "flushtokens.name" . }}
+type: Opaque
+data:
+  couchdbUrl: {{ template "flushtokens.defaultsecret" .Values.couchdb.url }}

--- a/shared/charts/gpii-preferences/Chart.yaml
+++ b/shared/charts/gpii-preferences/Chart.yaml
@@ -1,5 +1,5 @@
 name: gpii-preferences
-version: 1.4.0
+version: 1.5.0
 appVersion: 57d0a17da505c8bc28c221c88b8de54447c78dc873c355d0bfd435d28f8b09ee
 home: https://github.com/gpii-ops/gpii-infra
 description: GPII Preferences Service.

--- a/shared/charts/gpii-preferences/templates/_helpers.tpl
+++ b/shared/charts/gpii-preferences/templates/_helpers.tpl
@@ -12,3 +12,14 @@ Create chart name and version as used by the chart label.
 {{- define "preferences.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "preferences.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/gpii-preferences/templates/deployment.yaml
+++ b/shared/charts/gpii-preferences/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: preferences
+        app: {{ template "preferences.name" . }}
       annotations:
         # This annotation is needed to allow traffic to metadata.google.internal
         # until Istio's issue with FQDNs in ServiceEntries is not resolved:
@@ -31,10 +31,13 @@ spec:
           value: {{ .Values.nodeEnv }}
         - name: GPII_PREFERENCESSERVER_LISTEN_PORT
           value: '{{ .Values.preferencesListenPort }}'
-        - name: GPII_DATASOURCE_HOSTNAME
-          value:  '{{ .Values.datasourceHostname }}'
         - name: GPII_DATASOURCE_PORT
           value: '{{ .Values.datasourceListenPort }}'
+        - name: GPII_DATASOURCE_HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "preferences.name" . }}
+              key: datasourceHostname
         {{- if .Values.enableStackdriverTrace }}
         - name: GPII_ENABLE_STACKDRIVER_TRACE
           value: 'true'

--- a/shared/charts/gpii-preferences/templates/secrets.yaml
+++ b/shared/charts/gpii-preferences/templates/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "preferences.name" . }}
+  labels:
+    app: {{ template "preferences.name" . }}
+type: Opaque
+data:
+  datasourceHostname: {{ template "preferences.defaultsecret" .Values.datasourceHostname }}


### PR DESCRIPTION
This PR moves all sensitive data in GPII charts into secrets.
I tried to rollout this change against current master and looks like it is safe to deploy as-is and no downtime is needed.