### PR TITLE
GPII-2865: Fix default deny network policy

### DIFF
--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -7,8 +7,6 @@ resource "kubernetes_network_policy" "deny-default" {
   spec {
     pod_selector {}
 
-    ingress {}
-
     policy_types = ["Ingress"]
   }
 }


### PR DESCRIPTION
Second try to implement default deny Network Policy for services in GPII namespace - [GPII-2865](https://issues.gpii.net/browse/GPII-2865).

While Terraform Kubernetes provider [documentation](https://www.terraform.io/docs/providers/kubernetes/r/network_policy.html) says:
> ingress - (Optional) List of ingress rules ....... **If this field is empty then this NetworkPolicy does not allow any traffic** (and serves solely to ensure that the pods it selects are isolated by default).

it in fact results in policy allowing all traffic. To get policy denying all traffic, this field has to be omitted.

*Note: I intend to follow up with PR against Terraform provider to improve the documentation, will be linked.*

This PR:
- Fixes default deny Ingress Network Policy for GPII namespace to actually block all traffic

I was able to replicate the issue and tested this fix also on cluster created from scratch (Network policies take a while to come in effect sometimes and I didn't catch this in the previous PR).

Deploy plan:
- Verify that deny policy is in effect by starting an interactive container `kubectl run -it --rm --restart=Never --image=gcr.io/gpii-common-prd/gpii__locust:0.9.0-gpii.6 test -n gpii -- /bin/sh` and running following commands:
   ```console
    $ curl -k -s -w "%{http_code}" -o /dev/null http://preferences.gpii.svc.cluster.local/health
    503~ $
    $ curl -k -s -w "%{http_code}" -o /dev/null http://flowmanager.gpii.svc.cluster.local/health
    503~ $
    $ curl -k -s -w "%{http_code}" -o /dev/null http://couchdb-svc-couchdb.gpii.svc.cluster.local:5984/_up
    503~ $
   ```
    Expected reply is `503` signalling Istio can't connect to upstream (as opposed to `200`s and `401` that are returned when network policies are not applied)
  - [ ] - stg
  - [ ] - prd