### PR TITLE
GPII-4085: Fix race condition for Istio tracing rule

### DIFF
--- a/gcp/modules/istio/tracing.tf
+++ b/gcp/modules/istio/tracing.tf
@@ -4,11 +4,15 @@ data "external" "istio_tracing" {
     "-c",
     "MATCH=$$(kubectl get -n istio-system --request-timeout 5s rule stackdriver-tracing-rule -o jsonpath='{.spec.match}'); [ \"$$MATCH\" != 'context.protocol == \"http\" || context.protocol == \"grpc\"' ] && MATCH=\"$$RANDOM\"; jq -n --arg match \"$$MATCH\" '{match:$$match}'",
   ]
+
+  query = {
+    depends_on = "${null_resource.ingress_ip_wait.id}"
+  }
 }
 
 resource "null_resource" "istio_tracing" {
   triggers = {
-    match = "${data.external.istio_tracing.result.match}"
+    match = "${data.external.istio_tracing.result["match"]}"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
This fix addresses the race condition when Istio tracing rule takes a while on cluster creation.
```
null_resource.istio_tracing: Error running command 'kubectl patch -n istio-system --request-timeout 5s rule stackdriver-tracing-rule -p '{"spec":{"match":"context.protocol == \"http\" || context.protocol == \"grpc\""}}' --type merge': exit status 1. Output: Error from server (NotFound): rules.config.istio.io "stackdriver-tracing-rule" not found
```