### PR TITLE
GPII-4085: Add new Istio GCR registry to whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.4-google_gpii.0
+  - image: gpii/exekube:0.9.5-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.4-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.5-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.4-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.5-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.4-google_gpii.0
+    image: gpii/exekube:0.9.5-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.4-google_gpii.0
+    image: gpii/exekube:0.9.5-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/modules/istio/hpa.tf
+++ b/gcp/modules/istio/hpa.tf
@@ -8,7 +8,11 @@ resource "kubernetes_horizontal_pod_autoscaler" "istio-egressgateway" {
     namespace = "istio-system"
 
     labels = {
-      k8s-app = "istio"
+      k8s-app  = "istio"
+      app      = "egressgateway"
+      chart    = "gateways"
+      heritage = "Tiller"
+      release  = "istio"
     }
   }
 
@@ -32,7 +36,11 @@ resource "kubernetes_horizontal_pod_autoscaler" "istio-ingressgateway" {
     namespace = "istio-system"
 
     labels = {
-      k8s-app = "istio"
+      k8s-app  = "istio"
+      app      = "ingressgateway"
+      chart    = "gateways"
+      heritage = "Tiller"
+      release  = "istio"
     }
   }
 
@@ -56,7 +64,11 @@ resource "kubernetes_horizontal_pod_autoscaler" "istio-pilot" {
     namespace = "istio-system"
 
     labels = {
-      k8s-app = "istio"
+      k8s-app  = "istio"
+      app      = "pilot"
+      chart    = "pilot"
+      heritage = "Tiller"
+      release  = "istio"
     }
   }
 
@@ -80,7 +92,11 @@ resource "kubernetes_horizontal_pod_autoscaler" "istio-policy" {
     namespace = "istio-system"
 
     labels = {
-      k8s-app = "istio"
+      k8s-app  = "istio"
+      app      = "mixer"
+      chart    = "mixer"
+      heritage = "Tiller"
+      release  = "istio"
     }
   }
 
@@ -104,7 +120,11 @@ resource "kubernetes_horizontal_pod_autoscaler" "istio-telemetry" {
     namespace = "istio-system"
 
     labels = {
-      k8s-app = "istio"
+      k8s-app  = "istio"
+      app      = "mixer"
+      chart    = "mixer"
+      heritage = "Tiller"
+      release  = "istio"
     }
   }
 


### PR DESCRIPTION
This PR is part of [GPII-4085](https://issues.gpii.net/browse/GPII-4085).

This PR:
- Bumps exekube image version, this image adds new Istio GKE GCR registry to whitelist, see https://github.com/gpii-ops/exekube/pull/68 for details
- Aligns tags for HPAs to ones used by GKE post 1.1 upgrade

This PR depends on https://github.com/gpii-ops/exekube/pull/68.