### PR TITLE
GPII-4110: Bump exekube version to 0.9.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.5-google_gpii.0
+  - image: gpii/exekube:0.9.6-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.5-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.6-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.5-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.6-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.5-google_gpii.0
+    image: gpii/exekube:0.9.6-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.5-google_gpii.0
+    image: gpii/exekube:0.9.6-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}


### PR DESCRIPTION
This PR fixes [GPII-4110](https://issues.gpii.net/browse/GPII-4110).

This PR:
- Bumps exekube image version, this image adds new Istio GKE GCR registry to whitelist, see https://github.com/gpii-ops/exekube/pull/69 for details

This PR depends on https://github.com/gpii-ops/exekube/pull/69.

The https://github.com/gpii-ops/exekube/pull/69 also has to be merged for the CircleCI checks to work.