### PR TITLE
GPII-4111: Add additional locust output on failure

### DIFF
--- a/gcp/modules/locust/tasks/flowmanager.py
+++ b/gcp/modules/locust/tasks/flowmanager.py
@@ -1,4 +1,4 @@
-from locust import HttpLocust, TaskSet, task
+from locust import HttpLocust, TaskSet, task, events
 import random
 
 class FlowmanagerTasks(TaskSet):
@@ -20,3 +20,16 @@ class FlowmanagerWarmer(HttpLocust):
   task_set = FlowmanagerTasks
   min_wait = 1000
   max_wait = 3000
+
+
+def on_failure(request_type, name, response_time, exception, **kwargs):
+    print("Request: %s %s" % (request_type, name))
+    if exception.request is not None:
+        print("URL: %s" % (exception.request.url))
+    print("Exception: %s" % (exception))
+    if exception.response is not None:
+        print("Code: %s" % (exception.response.status_code))
+        print("Headers: %s" % (exception.response.headers))
+        print("Content: %s" % (exception.response.content))
+
+events.request_failure += on_failure

--- a/gcp/modules/locust/tasks/preferences.py
+++ b/gcp/modules/locust/tasks/preferences.py
@@ -1,4 +1,4 @@
-from locust import HttpLocust, TaskSet, task
+from locust import HttpLocust, TaskSet, task, events
 import random
 
 class PreferencesTasks(TaskSet):
@@ -14,3 +14,16 @@ class PreferencesWarmer(HttpLocust):
   task_set = PreferencesTasks
   min_wait = 1000
   max_wait = 3000
+
+
+def on_failure(request_type, name, response_time, exception, **kwargs):
+    print("Request: %s %s" % (request_type, name))
+    if exception.request is not None:
+        print("URL: %s" % (exception.request.url))
+    print("Exception: %s" % (exception))
+    if exception.response is not None:
+        print("Code: %s" % (exception.response.status_code))
+        print("Headers: %s" % (exception.response.headers))
+        print("Content: %s" % (exception.response.content))
+
+events.request_failure += on_failure


### PR DESCRIPTION
This PR adds additional debug output to locust workers in case of errors. Related to work on debugging 404 errors [GPII-4111](https://issues.gpii.net/browse/GPII-4111).

At the moment it's very difficult do debug errors with limited output Locust provides - for example Locust does not show headers for failed requests (without headers it's difficult to determine whether the failure is coming from Envoy).

This PR adds additional output to locust workers in case of failures.

Example of output added to worker logs:

```yaml
Request: GET /preferences/omar
URL: http://preferences.gpii.svc.cluster.local/preferences/omar
Exception: 503 Server Error: Service Unavailable for url: http://preferences.gpii.svc.cluster.loca
Code: 503
Headers: {'content-length': '91', 'content-type': 'text/plain', 'date': 'Tue, 24 Sep 2019 15:57:35 GMT', 'server': 'envoy'}
Content: b'upstream connect error or disconnect/reset before headers. reset reason: connection failure'
```