### PR TITLE
[GPII-4068]: Improve CouchDB rollouts with lifecycle hooks, second try 

### DIFF
--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -43,6 +43,10 @@ couchdbConfig:
   httpd:
     WWW-Authenticate: "Basic realm=\"CouchDB\""
 
+lifecycle:
+  preStop:
+    sleep_seconds: 15
+
 resources:
   requests:
     cpu: ${requests_cpu}

--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.3.0
+version: 1.4.0
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/README.md
+++ b/shared/charts/couchdb/README.md
@@ -102,29 +102,33 @@ CouchDB chart and their default values:
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
-|           Parameter             |                Default                 |
-|---------------------------------|----------------------------------------|
-| `adminUsername`                 | admin                                  |
-| `adminPassword`                 | auto-generated                         |
-| `cookieAuthSecret`              | auto-generated                         |
-| `helperImage.repository`        | kocolosk/couchdb-statefulset-assembler |
-| `helperImage.tag`               | 1.1.0                                  |
-| `helperImage.pullPolicy`        | IfNotPresent                           |
-| `initImage.repository`          | busybox                                |
-| `initImage.tag`                 | latest                                 |
-| `image.repository`              | couchdb                                |
-| `image.tag`                     | 2.2.0                                  |
-| `image.pullPolicy`              | IfNotPresent                           |
-| `ingress.enabled`               | false                                  |
-| `ingress.hosts`                 | chart-example.local                    |
-| `ingress.annotations`           |                                        |
-| `ingress.tls`                   |                                        |
-| `persistentVolume.accessModes`  | ReadWriteOnce                          |
-| `persistentVolume.storageClass` | Default for the Kube cluster           |
-| `persistentVolume.provisioner`  | Default for the Kube cluster           |
-| `podManagementPolicy`           | Parallel                               |
-| `affinity`                      |                                        |
-| `resources`                     |                                        |
-| `service.enabled`               | true                                   |
-| `service.type`                  | ClusterIP                              |
-| `service.externalPort`          | 5984                                   |
+|           Parameter              |                Default                 |
+|----------------------------------|----------------------------------------|
+| `adminUsername`                  | admin                                  |
+| `adminPassword`                  | auto-generated                         |
+| `cookieAuthSecret`               | auto-generated                         |
+| `helperImage.repository`         | kocolosk/couchdb-statefulset-assembler |
+| `helperImage.tag`                | 1.1.0                                  |
+| `helperImage.pullPolicy`         | IfNotPresent                           |
+| `initImage.repository`           | busybox                                |
+| `initImage.tag`                  | latest                                 |
+| `image.repository`               | couchdb                                |
+| `image.tag`                      | 2.2.0                                  |
+| `image.pullPolicy`               | IfNotPresent                           |
+| `ingress.enabled`                | false                                  |
+| `ingress.hosts`                  | chart-example.local                    |
+| `ingress.annotations`            |                                        |
+| `ingress.tls`                    |                                        |
+| `persistentVolume.accessModes`   | ReadWriteOnce                          |
+| `persistentVolume.storageClass`  | Default for the Kube cluster           |
+| `persistentVolume.provisioner`   | Default for the Kube cluster           |
+| `podManagementPolicy`            | Parallel                               |
+| `affinity`                       |                                        |
+| `resources`                      |                                        |
+| `service.enabled`                | true                                   |
+| `service.type`                   | ClusterIP                              |
+| `service.externalPort`           | 5984                                   |
+| `virtual_service.enabled`        | false                                  |
+| `virtual_service.timeout`        | 2s                                     |
+| `virtual_service.attempts`       | 1                                      |
+| `lifecycle.preStop.sleep_seconds`| 15                                     |

--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -85,6 +85,21 @@ spec:
               path: /_up
               port: 5984
 {{- end }}
+          lifecycle:
+{{- if .Values.lifecycle.preStop }}
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    curl -X PUT \
+                         -H "Content-type: application/json" \
+                         -d "\"true\"" \
+                         -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} \
+                      http://localhost:5984/_node/couchdb@${HOSTNAME}.{{ template "couchdb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/_config/couchdb/maintenance_mode \
+                      && sleep {{ .Values.lifecycle.preStop.sleep_seconds }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/shared/charts/couchdb/templates/virtual_service.yaml
+++ b/shared/charts/couchdb/templates/virtual_service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.virtual_service.enabled -}}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ template "couchdb.name" . }}-vs
+spec:
+  hosts:
+  - {{ template "couchdb.svcname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: {{ template "couchdb.svcname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    timeout: {{ .Values.virtual_service.timeout }}
+    retries:
+      attempts: {{ .Values.virtual_service.attempts }}
+      perTryTimeout: {{ .Values.virtual_service.timeout }}
+{{- end -}}

--- a/shared/charts/couchdb/values.yaml
+++ b/shared/charts/couchdb/values.yaml
@@ -87,6 +87,19 @@ service:
   type: ClusterIP
   externalPort: 5984
 
+## Istio's virtual service to control the flow of ingress traffic
+virtual_service:
+  enabled: false
+#  attempts: 1
+#  timeout: 2s
+
+## To allow pods to handle existing connections gracefully on termination
+## lifecycle hook can be used to enable maintenance mode to fail readiness check
+## before terminating the pod.
+lifecycle:
+#  preStop:
+#    sleep_seconds: 15
+
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed
 ## from outside the Kubernetes cluster.


### PR DESCRIPTION
Original PR (https://github.com/gpii-ops/gpii-infra/pull/489) got reverted because of the unrelated issue with Istio connection pooling that is being addressed in https://github.com/gpii-ops/gpii-infra/pull/507.