### PR TITLE
GPII-4141: Fix disabled BinAuth API error

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -52,6 +52,7 @@ variable "ci_dev_project_regex" {
 variable "service_apis" {
   default = [
     "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
This should fix CI error with Binary Auth API being disabled - [GPII-4141](https://issues.gpii.net/browse/GPII-4141):

```
* google_binary_authorization_policy.policy: Error creating Policy: googleapi: Error 403: Binary Authorization API has not been used in project 224490750817 before or it is disabled. Enable it by visiting https://console.cloud.google.com/apis/api/binaryauthorization.googleapis.com/overview?project=224490750817 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
```

Seems like Binary Authorization now requires `bigquery.googleapis.com` API to be enabled.

I found out about this based on CI run - https://gitlab.com/gpii-ops/gpii-infra/-/jobs/303619443 - and following `gcloud` message when trying to disable bigquery API: `ERROR: (gcloud.services.disable) FAILED_PRECONDITION: The service bigquery.googleapis.com is depended on by the following active services: binaryauthorization.googleapis.com,resourceviews.googleapis.com,r
eplicapoolupdater.googleapis.com,container.googleapis.com,bigquery-json.googleapis.com,replicapool.googleapis.com; Please specify disable_dependent_services=true if you want to proceed with disabling all
services.`