### PR TITLE
GPII-4141: Enable bigquerystorage API to fix bin-auth error

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -53,6 +53,7 @@ variable "service_apis" {
   default = [
     "bigquery-json.googleapis.com",
     "bigquery.googleapis.com",
+    "bigquerystorage.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
Looks like we need `bigquerystorage.googleapis.com` too:

```
The service bigquerystorage.googleapis.com is depended on by the following active services: binaryauthorization.googleapis.com,resourceviews.googleapis.com,replicapoolupdater.googleapis.com,container.googleapis.com,bigquery-json.googleapis.com,replicapool.googleapis.com
```

This should fix CI error with Binary Auth API being disabled - [GPII-4141](https://issues.gpii.net/browse/GPII-4141):