### PR TITLE
[GPII-4090]: Destroy disabled KMS key versions during secrets key rotation

### DIFF
--- a/shared/rakefiles/secrets.rb
+++ b/shared/rakefiles/secrets.rb
@@ -372,8 +372,8 @@ class Secrets
 
     key_versions.each do |version|
       version_id = get_crypto_key_version(version["name"])
-      if version["state"] == "ENABLED" or versions_to_keep > 0
-        puts "[secret-mgmt] Skipping version #{version_id}, because need to keep #{versions_to_keep} most recent versions!"
+      if versions_to_keep > 0
+        puts "[secret-mgmt] Skipping version #{version_id}, because need to keep #{versions_to_keep} most recent disabled versions!"
         versions_to_keep = versions_to_keep - 1
         next
       end

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -53,6 +53,9 @@ task :rotate_secrets_key, [:encryption_key] => [:configure, :configure_secrets] 
   rotate_secrets = true
   @secrets.set_secrets(rotate_secrets)
   @secrets.disable_non_primary_key_versions(args[:encryption_key], new_version_id)
+
+  versions_to_keep = 10
+  @secrets.destroy_disabled_non_primary_key_versions(args[:encryption_key], versions_to_keep)
 end
 
 # This is an EXPERIMENTAL helper for moving between regions, but it is not very smart and it


### PR DESCRIPTION
This PR improves secret key rotation task to destroy disabled KMS key versions, so Google won't charge us for them.
Destruction operations is irreversible, so it keeps 10 most recent disabled key versions in case we may need them.