### PR TITLE
GPII-4046: Allow promsd to Envoy sidecars

### DIFF
--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -5,7 +5,41 @@ resource "kubernetes_network_policy" "deny-default" {
   }
 
   spec {
-    pod_selector {}
+    pod_selector = {}
+
+    policy_types = ["Ingress"]
+  }
+}
+
+resource "kubernetes_network_policy" "allow-promsd-to-istio" {
+  metadata {
+    name      = "allow-promsd-to-istio"
+    namespace = "${kubernetes_namespace.gpii.metadata.0.name}"
+  }
+
+  spec {
+    pod_selector = {}
+
+    ingress = {
+      from = {
+        namespace_selector = {
+          match_labels {
+            k8s-app = "istio"
+          }
+        }
+
+        pod_selector = {
+          match_labels {
+            app = "promsd"
+          }
+        }
+      }
+
+      ports = {
+        port     = "http-envoy-prom"
+        protocol = "TCP"
+      }
+    }
 
     policy_types = ["Ingress"]
   }


### PR DESCRIPTION
Part of [GPII-4046](https://issues.gpii.net/browse/GPII-4046). Traffic between Istio's Prometheus (`promsd`) and Istio sidecars in GPII is being blocked and it prevents Prometheus from scraping metrics from sidecar containers. It is due to missing network policies.

This PR adds a rule to allow metric scraping traffic from Prometheus (`app: promsd`) to any pod in GPII namespace, on port `9090` (`http-envoy-prom`).