### PR TITLE
GPII-4141: Fix (again) bigquery api still being enabled error

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -52,7 +52,6 @@ variable "ci_dev_project_regex" {
 variable "service_apis" {
   default = [
     "bigquery-json.googleapis.com",
-    "bigquery.googleapis.com",
     "bigquerystorage.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudbilling.googleapis.com",


### PR DESCRIPTION
Seems like Google rolled `bigquery.googleapis.com` as the new name for `bigquery-json.googleapis.com`, that’s when we got the first error with BQ/BinAuth (#510, #511, [GPII-4141](https://issues.gpii.net/browse/GPII-4141)), and now, because it was causing a lot of issues, they rolled it back. And that's why we're seeing:

```
Error: Error applying plan:

1 error occurred:
    * google_project_services.project: 1 error occurred:
    * google_project_services.project: Error updating services: googleapi: Error 503: The service(s) ["bigquery.googleapis.com"] are still being enabled for project gpii2test-gcp-stg. This isn't a real API error, this is just eventual consistency.
```

This PR removes `bigquery.googleapis.com` and should fix the issue (at least until Google decides to roll it out again or smth.).

See relevant https://github.com/terraform-providers/terraform-provider-google/issues/4590.