### PR TITLE
[GPII-4151]: Add SCC tasks

### DIFF
--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -34,3 +34,8 @@ desc "[ONLY ADMIN] Display added or removed assets in target projects (comma sep
 task :display_scc_assets_changed, [:projects, :compare_duration] => [:set_vars] do |taskname, args|
   sh "#{@exekube_cmd} rake display_scc_assets_changed['#{args[:projects]}','#{args[:compare_duration]}']"
 end
+
+desc "[ONLY ADMIN] Display SCC findings"
+task :display_scc_findings => [:set_vars] do
+  sh "#{@exekube_cmd} rake display_scc_findings"
+end

--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -29,3 +29,8 @@ task :set_billing_org_perms => [:set_vars] do
   # Go to the https://console.cloud.google.com/billing/ to see the permissions granted.
   sh "#{@exekube_cmd} rake set_billing_org_perms"
 end
+
+desc "[ONLY ADMIN] Display added or removed assets in target projects (comma separated) for the compare duration in seconds"
+task :display_scc_assets_changed, [:projects, :compare_duration] => [:set_vars] do |taskname, args|
+  sh "#{@exekube_cmd} rake display_scc_assets_changed['#{args[:projects]}','#{args[:compare_duration]}']"
+end

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -340,4 +340,10 @@ task :display_scc_assets_changed, [:projects, :compare_duration] do |taskname, a
     --format json | jq '.[] | select(.stateChange == \"REMOVED\" or .stateChange == \"ADDED\")'
   "
 end
+
+# This task displays added or removed assets in target projects (comma separated) for the compare duration in seconds
+task :display_scc_findings do
+  sh "gcloud alpha scc findings list #{ENV["ORGANIZATION_ID"]} --filter 'state = \"ACTIVE\"'"
+end
+
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -301,4 +301,43 @@ task :couchdb_ui => [:configure, :configure_secrets, :set_secrets] do
   sh "/rakefiles/scripts/couchdb_ui.sh"
 end
 
+# This task displays added or removed assets in target projects (comma separated) for the compare duration in seconds
+task :display_scc_assets_changed, [:projects, :compare_duration] do |taskname, args|
+  unless args[:projects]
+    # In case projects list is empty, we are interested in assets from:
+    projects = [
+      360407405272, # 360407405272 – gpii-gcp-prd
+      180717459583 # 180717459583 - gpii-common-prd
+    ]
+  else
+    projects = args[:projects].split(",")
+  end
+
+  unless args[:compare_duration]
+    # Default comparison duration is 7 days
+    compare_duration = "604800s"
+  else
+    compare_duration = "#{args[:compare_duration]}s"
+  end
+
+  projects_filter = ["("]
+  projects.each do |project_id|
+    projects_filter << " OR " if projects_filter.length > 1
+    projects_filter << "security_center_properties.resource_project = \"//cloudresourcemanager.googleapis.com/projects/"
+    projects_filter << project_id
+    projects_filter << "\""
+  end
+  projects_filter << ")"
+  projects_filter = projects_filter.join
+
+  sh "gcloud alpha scc assets list #{ENV["ORGANIZATION_ID"]} \
+    --filter ' \
+      #{projects_filter} \
+      AND NOT security_center_properties.resource_type = \"google.compute.snapshot\" \
+      AND NOT security_center_properties.resource_type = \"google.cloud.kms.cryptokeyversion\" \
+    ' \
+    --compare-duration #{compare_duration} \
+    --format json | jq '.[] | select(.stateChange == \"REMOVED\" or .stateChange == \"ADDED\")'
+  "
+end
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -341,7 +341,7 @@ task :display_scc_assets_changed, [:projects, :compare_duration] do |taskname, a
   "
 end
 
-# This task displays added or removed assets in target projects (comma separated) for the compare duration in seconds
+# This task displays scc findings for the target organization
 task :display_scc_findings do
   sh "gcloud alpha scc findings list #{ENV["ORGANIZATION_ID"]} --filter 'state = \"ACTIVE\"'"
 end


### PR DESCRIPTION
This PR:
* Adds `:display_scc_findings` task to display active findings.
* Adds parametrized `:display_scc_assets_changed` task that by default displays added or removed assets for `gpii-gcp-prd`, `gpii-common-prd` using 1 week as comparison duration and excludes noisy assets like KMS keys and Snapshots from the output.

Downsides: SCC commands are in alfa state, so we may probably face similar field naming changes or other issues that we've been recently facing using UI.