### PR TITLE
[GPII-3836]: Enable secrets bucket versioning for stg, prd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.6-google_gpii.0
+  - image: gpii/exekube:0.9.7-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.6-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.7-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.6-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.7-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.6-google_gpii.0
+    image: gpii/exekube:0.9.7-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.6-google_gpii.0
+    image: gpii/exekube:0.9.7-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/live/prd/secret-mgmt/terraform.tfvars
+++ b/gcp/live/prd/secret-mgmt/terraform.tfvars
@@ -12,3 +12,4 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+bucket_versioning_enabled = true

--- a/gcp/live/prd/secret-mgmt/terraform.tfvars
+++ b/gcp/live/prd/secret-mgmt/terraform.tfvars
@@ -11,5 +11,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-
-bucket_versioning_enabled = true

--- a/gcp/live/stg/secret-mgmt/terraform.tfvars
+++ b/gcp/live/stg/secret-mgmt/terraform.tfvars
@@ -12,3 +12,4 @@ terragrunt = {
 
 # ↓ Module configuration (empty means all default)
 
+bucket_versioning_enabled = true

--- a/gcp/live/stg/secret-mgmt/terraform.tfvars
+++ b/gcp/live/stg/secret-mgmt/terraform.tfvars
@@ -11,5 +11,3 @@ terragrunt = {
 }
 
 # ↓ Module configuration (empty means all default)
-
-bucket_versioning_enabled = true

--- a/gcp/modules/gcp-secret-mgmt/main.tf
+++ b/gcp/modules/gcp-secret-mgmt/main.tf
@@ -13,7 +13,7 @@ variable "encryption_keys" {
 variable "infra_region" {}
 
 variable "bucket_versioning_enabled" {
-  default = false
+  default = true
 }
 
 module "gcp-secret-mgmt" {

--- a/gcp/modules/gcp-secret-mgmt/main.tf
+++ b/gcp/modules/gcp-secret-mgmt/main.tf
@@ -12,16 +12,21 @@ variable "encryption_keys" {
 
 variable "infra_region" {}
 
+variable "bucket_versioning_enabled" {
+  default = false
+}
+
 module "gcp-secret-mgmt" {
   source = "/exekube-modules/gcp-secret-mgmt"
 
-  project_id         = "${var.project_id}"
-  serviceaccount_key = "${var.serviceaccount_key}"
-  encryption_keys    = "${var.encryption_keys}"
-  storage_location   = "${var.infra_region}"
-  keyring_name       = "${var.keyring_name}"
-  keyring_location   = "${var.infra_region}"
-  apply_audit_config = false
+  project_id                = "${var.project_id}"
+  serviceaccount_key        = "${var.serviceaccount_key}"
+  encryption_keys           = "${var.encryption_keys}"
+  storage_location          = "${var.infra_region}"
+  keyring_name              = "${var.keyring_name}"
+  keyring_location          = "${var.infra_region}"
+  apply_audit_config        = false
+  bucket_versioning_enabled = "${var.bucket_versioning_enabled}"
 }
 
 # Re-export variable. See https://www.terraform.io/docs/providers/terraform/d/remote_state.html#root-outputs-only


### PR DESCRIPTION
This PR enables secrets bucket versioning for staging and production environments and should be merged after https://github.com/gpii-ops/exekube/pull/70.

Deployment does not require any special treatment.