### PR TITLE
GPII-4046: Network monitoring - Kiali

### DIFF
--- a/gcp/live/dev/k8s/kiali/terraform.tfvars
+++ b/gcp/live/dev/k8s/kiali/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kiali"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/prd/k8s/kiali/terraform.tfvars
+++ b/gcp/live/prd/k8s/kiali/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kiali"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/stg/k8s/kiali/terraform.tfvars
+++ b/gcp/live/stg/k8s/kiali/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kiali"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/modules/kiali/main.tf
+++ b/gcp/modules/kiali/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "secrets_dir" {}
+variable "charts_dir" {}
+
+module "prometheus" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name      = "prometheus"
+  release_namespace = "istio-system"
+  release_values    = ""
+
+  chart_name = "${var.charts_dir}/istio-prometheus"
+}
+
+module "kiali" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name      = "kiali"
+  release_namespace = "istio-system"
+  release_values    = ""
+
+  chart_name = "${var.charts_dir}/istio-kiali"
+}

--- a/gcp/modules/kiali/main.tf
+++ b/gcp/modules/kiali/main.tf
@@ -4,6 +4,8 @@ terraform {
 
 variable "secrets_dir" {}
 variable "charts_dir" {}
+variable "kiali_repository" {}
+variable "kiali_tag" {}
 
 module "prometheus" {
   source           = "/exekube-modules/helm-release"
@@ -17,14 +19,24 @@ module "prometheus" {
   chart_name = "${var.charts_dir}/istio-prometheus"
 }
 
+data "template_file" "release_values" {
+  template = "${file("${path.module}/templates/values.yaml.tpl")}"
+
+  vars = {
+    kiali_repository = "${var.kiali_repository}"
+    kiali_tag        = "${var.kiali_tag}"
+  }
+}
+
 module "kiali" {
   source           = "/exekube-modules/helm-release"
   tiller_namespace = "kube-system"
   client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
 
-  release_name      = "kiali"
-  release_namespace = "istio-system"
-  release_values    = ""
+  release_name            = "kiali"
+  release_namespace       = "istio-system"
+  release_values          = ""
+  release_values_rendered = "${data.template_file.release_values.rendered}"
 
   chart_name = "${var.charts_dir}/istio-kiali"
 }

--- a/gcp/modules/kiali/templates/values.yaml.tpl
+++ b/gcp/modules/kiali/templates/values.yaml.tpl
@@ -1,0 +1,2 @@
+image: ${kiali_repository}
+tag: ${kiali_tag}

--- a/shared/charts/istio-kiali/Chart.yaml
+++ b/shared/charts/istio-kiali/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
+name: kiali
+version: 1.5.0
+appVersion: 1.5.0
+tillerVersion: ">=2.7.2"

--- a/shared/charts/istio-kiali/templates/_helpers.tpl
+++ b/shared/charts/istio-kiali/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kiali.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kiali.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kiali.chart" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/shared/charts/istio-kiali/templates/clusterrole.yaml
+++ b/shared/charts/istio-kiali/templates/clusterrole.yaml
@@ -1,0 +1,284 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["config.istio.io"]
+  resources:
+  - adapters
+  - apikeys
+  - bypasses
+  - authorizations
+  - checknothings
+  - circonuses
+  - cloudwatches
+  - deniers
+  - dogstatsds
+  - edges
+  - fluentds
+  - handlers
+  - instances
+  - kubernetesenvs
+  - kuberneteses
+  - listcheckers
+  - listentries
+  - logentries
+  - memquotas
+  - metrics
+  - noops
+  - opas
+  - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
+  - rbacs
+  - redisquotas
+  - reportnothings
+  - rules
+  - signalfxs
+  - solarwindses
+  - stackdrivers
+  - statsds
+  - stdios
+  - templates
+  - tracespans
+  - zipkins
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["networking.istio.io"]
+  resources:
+  - destinationrules
+  - gateways
+  - serviceentries
+  - sidecars
+  - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - meshpolicies
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["rbac.istio.io"]
+  resources:
+  - clusterrbacconfigs
+  - rbacconfigs
+  - servicerolebindings
+  - serviceroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["security.istio.io"]
+  resources:
+    - authorizationpolicies
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali-viewer
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["config.istio.io"]
+  resources:
+  - adapters
+  - apikeys
+  - bypasses
+  - authorizations
+  - checknothings
+  - circonuses
+  - cloudwatches
+  - deniers
+  - dogstatsds
+  - edges
+  - fluentds
+  - handlers
+  - instances
+  - kubernetesenvs
+  - kuberneteses
+  - listcheckers
+  - listentries
+  - logentries
+  - memquotas
+  - metrics
+  - noops
+  - opas
+  - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
+  - rbacs
+  - redisquotas
+  - reportnothings
+  - rules
+  - signalfxs
+  - solarwindses
+  - stackdrivers
+  - statsds
+  - stdios
+  - templates
+  - tracespans
+  - zipkins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["networking.istio.io"]
+  resources:
+  - destinationrules
+  - gateways
+  - serviceentries
+  - sidecars
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - meshpolicies
+  - policies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["rbac.istio.io"]
+  resources:
+  - clusterrbacconfigs
+  - rbacconfigs
+  - servicerolebindings
+  - serviceroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["security.istio.io"]
+  resources:
+    - authorizationpolicies
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list

--- a/shared/charts/istio-kiali/templates/clusterrolebinding.yaml
+++ b/shared/charts/istio-kiali/templates/clusterrolebinding.yaml
@@ -1,0 +1,37 @@
+{{- if not .Values.dashboard.viewOnlyMode }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-kiali-admin-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ .Release.Namespace }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-kiali-viewer-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali-viewer
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/shared/charts/istio-kiali/templates/config-handler.yaml
+++ b/shared/charts/istio-kiali/templates/config-handler.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: handler
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledAdapter: prometheus
+  params:
+    metricsExpirationPolicy:
+      metricsExpiryDuration: "{{ .Values.adapters.prometheus.metricsExpiryDuration }}"
+    metrics:
+    - name: requests_total
+      instance_name: requestcount.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - request_protocol
+      - response_code
+      - response_flags
+      - permissive_response_code
+      - permissive_response_policyid
+      - connection_security_policy
+    - name: request_duration_seconds
+      instance_name: requestduration.instance.{{ .Release.Namespace }}
+      kind: DISTRIBUTION
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - request_protocol
+      - response_code
+      - response_flags
+      - permissive_response_code
+      - permissive_response_policyid
+      - connection_security_policy
+      buckets:
+        explicit_buckets:
+          bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+    - name: request_bytes
+      instance_name: requestsize.instance.{{ .Release.Namespace }}
+      kind: DISTRIBUTION
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - request_protocol
+      - response_code
+      - response_flags
+      - permissive_response_code
+      - permissive_response_policyid
+      - connection_security_policy
+      buckets:
+        exponentialBuckets:
+          numFiniteBuckets: 8
+          scale: 1
+          growthFactor: 10
+    - name: response_bytes
+      instance_name: responsesize.instance.{{ .Release.Namespace }}
+      kind: DISTRIBUTION
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - request_protocol
+      - response_code
+      - response_flags
+      - permissive_response_code
+      - permissive_response_policyid
+      - connection_security_policy
+      buckets:
+        exponentialBuckets:
+          numFiniteBuckets: 8
+          scale: 1
+          growthFactor: 10
+    - name: tcp_sent_bytes_total
+      instance_name: tcpbytesent.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags
+    - name: tcp_received_bytes_total
+      instance_name: tcpbytereceived.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags
+    - name: tcp_connections_opened_total
+      instance_name: tcpconnectionsopened.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags
+    - name: tcp_connections_closed_total
+      instance_name: tcpconnectionsclosed.instance.{{ .Release.Namespace }}
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_security_policy
+      - response_flags

--- a/shared/charts/istio-kiali/templates/config-instances.yaml
+++ b/shared/charts/istio-kiali/templates/config-instances.yaml
@@ -1,0 +1,280 @@
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: requestcount
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | request.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: requestduration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.duration | "0ms"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | request.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: requestsize
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: request.size | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | request.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: responsesize
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.size | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | request.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      request_protocol: api.protocol | context.protocol | "unknown"
+      response_code: response.code | 200
+      response_flags: context.proxy_error_code | "-"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpbytesent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.sent.bytes | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpbytereceived
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.received.bytes | 0
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpconnectionsopened
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: tcpconnectionsclosed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_principal: source.principal | "unknown"
+      source_app: source.labels["app"] | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_app: destination.labels["app"] | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      response_flags: context.proxy_error_code | "-"
+    monitored_resource_type: '"UNSPECIFIED"'

--- a/shared/charts/istio-kiali/templates/config-rules.yaml
+++ b/shared/charts/istio-kiali/templates/config-rules.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promhttp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
+  actions:
+  - handler: prometheus
+    instances:
+    - requestcount
+    - requestduration
+    - requestsize
+    - responsesize
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  match: context.protocol == "tcp"
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpbytesent
+    - tcpbytereceived
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionopen
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsopened
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionclosed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsclosed

--- a/shared/charts/istio-kiali/templates/configmap.yaml
+++ b/shared/charts/istio-kiali/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  config.yaml: |
+    istio_namespace: {{ .Release.Namespace }}
+    auth:
+      strategy: {{ .Values.dashboard.auth.strategy }}
+    server:
+      port: 20001
+{{- if .Values.contextPath }}
+      web_root: {{ .Values.contextPath }}
+{{- end }}
+    external_services:
+      tracing:
+        url: {{ .Values.dashboard.jaegerURL }}
+      grafana:
+        url: {{ .Values.dashboard.grafanaURL }}
+      prometheus:
+        url: {{ .Values.prometheusAddr }}
+{{- if .Values.security.enabled }}
+    identity:
+      cert_file: {{ .Values.security.cert_file }}
+      private_key_file: {{ .Values.security.private_key_file }}
+{{- end}}

--- a/shared/charts/istio-kiali/templates/demosecret.yaml
+++ b/shared/charts/istio-kiali/templates/demosecret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.createDemoSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.dashboard.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  username: YWRtaW4=   # admin
+  passphrase: YWRtaW4= # admin
+{{- end }}

--- a/shared/charts/istio-kiali/templates/deployment.yaml
+++ b/shared/charts/istio-kiali/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kiali
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: kiali
+  template:
+    metadata:
+      name: kiali
+      labels:
+        app: kiali
+        chart: {{ template "kiali.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        kiali.io/runtimes: go,kiali
+    spec:
+      serviceAccountName: kiali-service-account
+      containers:
+      - image: "{{ .Values.hub }}/{{ .Values.image }}:{{ .Values.tag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        - "-v"
+        - "3"
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.contextPath }}/healthz
+            port: 20001
+            scheme:  {{ if .Values.security.enabled }} 'HTTPS' {{ else }} 'HTTP' {{ end }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.contextPath }}/healthz
+            port: 20001
+            scheme:  {{ if .Values.security.enabled }} 'HTTPS' {{ else }} 'HTTP' {{ end }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+        resources:
+{{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: istio.kiali-service-account
+{{- if not .Values.security.enabled }}
+          optional: true
+{{- end }}
+      - name: kiali-secret
+        secret:
+          secretName: {{ .Values.dashboard.secretName }}
+          optional: true

--- a/shared/charts/istio-kiali/templates/deployment.yaml
+++ b/shared/charts/istio-kiali/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: kiali-service-account
       containers:
-      - image: "{{ .Values.hub }}/{{ .Values.image }}:{{ .Values.tag }}"
+      - image: "{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: kiali
         command:

--- a/shared/charts/istio-kiali/templates/ingress.yaml
+++ b/shared/charts/istio-kiali/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: kiali
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+{{- if .Values.ingress.hosts }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ if $.Values.contextPath }} {{ $.Values.contextPath }} {{ else }} / {{ end }}
+            backend:
+              serviceName: kiali
+              servicePort: 20001
+    {{- end -}}
+{{- else }}
+    - http:
+        paths:
+          - path: {{ if .Values.contextPath }} {{ .Values.contextPath }} {{ else }} / {{ end }}
+            backend:
+              serviceName: kiali
+              servicePort: 20001
+{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/shared/charts/istio-kiali/templates/service.yaml
+++ b/shared/charts/istio-kiali/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - name: http-kiali
+    protocol: TCP
+    port: 20001
+  selector:
+    app: kiali

--- a/shared/charts/istio-kiali/templates/serviceaccount.yaml
+++ b/shared/charts/istio-kiali/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiali-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/shared/charts/istio-kiali/values.yaml
+++ b/shared/charts/istio-kiali/values.yaml
@@ -3,8 +3,7 @@
 #
 enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
 replicaCount: 1
-hub: quay.io/kiali
-image: kiali
+image: quay.io/kiali/kiali
 imagePullPolicy: IfNotPresent
 tag: v1.5.0
 contextPath: /kiali # The root context path to access the Kiali UI.

--- a/shared/charts/istio-kiali/values.yaml
+++ b/shared/charts/istio-kiali/values.yaml
@@ -1,0 +1,71 @@
+#
+# addon kiali
+#
+enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
+replicaCount: 1
+hub: quay.io/kiali
+image: kiali
+imagePullPolicy: IfNotPresent
+tag: v1.5.0
+contextPath: /kiali # The root context path to access the Kiali UI.
+nodeSelector: {}
+tolerations: []
+
+# Specify the pod anti-affinity that allows you to constrain which nodes
+# your pod is eligible to be scheduled based on labels on pods that are
+# already running on the node rather than based on labels on nodes.
+# There are currently two types of anti-affinity:
+#    "requiredDuringSchedulingIgnoredDuringExecution"
+#    "preferredDuringSchedulingIgnoredDuringExecution"
+# which denote "hard" vs. "soft" requirements, you can define your values
+# in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+# correspondingly.
+# For example:
+# podAntiAffinityLabelSelector:
+# - key: security
+#   operator: In
+#   values: S1,S2
+#   topologyKey: "kubernetes.io/hostname"
+# This pod anti-affinity rule says that the pod requires not to be scheduled
+# onto a node if that node is already running a pod with label having key
+# "security" and value "S1".
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
+
+ingress:
+  enabled: false
+  ## Used to create an Ingress record.
+  hosts:
+    - kiali.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: kiali-tls
+    #   hosts:
+    #     - kiali.local
+
+dashboard:
+  auth:
+    strategy: anonymous # Can be anonymous, login, or openshift
+  secretName: kiali # You must create a secret with this name - one is not provided out-of-box.
+  viewOnlyMode: true # Bind the service account to a role with only read access
+prometheusAddr: http://prometheus.istio-system:9090
+
+# When true, a secret will be created with a default username and password. Useful for demos.
+createDemoSecret: false
+
+security:
+  enabled: false
+  cert_file: /kiali-cert/cert-chain.pem
+  private_key_file: /kiali-cert/key.pem
+
+resources:
+  requests:
+    cpu: 10m
+
+adapters:
+  prometheus:
+    enabled: true
+    metricsExpiryDuration: 10m

--- a/shared/charts/istio-prometheus/Chart.yaml
+++ b/shared/charts/istio-prometheus/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: prometheus
+version: 1.1.0
+appVersion: 2.8.0
+tillerVersion: ">=2.7.2"

--- a/shared/charts/istio-prometheus/templates/_helpers.tpl
+++ b/shared/charts/istio-prometheus/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus.chart" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/shared/charts/istio-prometheus/templates/clusterrole.yaml
+++ b/shared/charts/istio-prometheus/templates/clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-{{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  - nodes/proxy
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/shared/charts/istio-prometheus/templates/clusterrolebindings.yaml
+++ b/shared/charts/istio-prometheus/templates/clusterrolebindings.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-{{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: {{ .Release.Namespace }}

--- a/shared/charts/istio-prometheus/templates/configmap.yaml
+++ b/shared/charts/istio-prometheus/templates/configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: {{ .Values.scrapeInterval }}
+    scrape_configs:
+
+    - job_name: 'istio-mesh'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - {{ .Release.Namespace }}
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-telemetry;prometheus

--- a/shared/charts/istio-prometheus/templates/deployment.yaml
+++ b/shared/charts/istio-prometheus/templates/deployment.yaml
@@ -1,0 +1,69 @@
+# TODO: the original template has service account, roles, etc
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        chart: {{ template "prometheus.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: "{{ .Values.hub }}/{{ .Values.image }}:{{ .Values.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            - '--storage.tsdb.retention={{ .Values.retention }}'
+            - '--config.file=/etc/prometheus/prometheus.yml'
+          ports:
+            - containerPort: 9090
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+          resources:
+{{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 12 }}
+{{- end }}
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/prometheus
+          - mountPath: /etc/istio-certs
+            name: istio-certs
+      volumes:
+      - name: config-volume
+        configMap:
+          name: prometheus
+      - name: istio-certs
+        secret:
+          defaultMode: 420
+{{- if not .Values.security.enabled }}
+          optional: true
+{{- end }}
+          secretName: istio.default
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+      {{- end }}

--- a/shared/charts/istio-prometheus/templates/ingress.yaml
+++ b/shared/charts/istio-prometheus/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+{{- if .Values.ingress.hosts }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ if $.Values.contextPath }} {{ $.Values.contextPath }} {{ else }} / {{ end }}
+            backend:
+              serviceName: prometheus
+              servicePort: 9090
+    {{- end -}}
+{{- else }}
+    - http:
+        paths:
+          - path: {{ if .Values.contextPath }} {{ .Values.contextPath }} {{ else }} / {{ end }}
+            backend:
+              serviceName: prometheus
+              servicePort: 9090
+{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/shared/charts/istio-prometheus/templates/service.yaml
+++ b/shared/charts/istio-prometheus/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - name: http-prometheus
+    protocol: TCP
+    port: 9090
+
+{{- if .Values.service.nodePort.enabled }}
+# Using separate ingress for nodeport, to avoid conflict with pilot e2e test configs.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-nodeport
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: NodePort
+  ports:
+  - port: 9090
+    nodePort: {{ .Values.service.nodePort.port }}
+    name: http-prometheus
+  selector:
+    app: prometheus
+{{- end }}

--- a/shared/charts/istio-prometheus/templates/serviceaccount.yaml
+++ b/shared/charts/istio-prometheus/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    chart: {{ template "prometheus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/shared/charts/istio-prometheus/values.yaml
+++ b/shared/charts/istio-prometheus/values.yaml
@@ -3,10 +3,10 @@
 #
 enabled: true
 replicaCount: 1
-hub: docker.io/prom
+hub: gcr.io/gke-release/istio/prometheus
 image: prometheus
 imagePullPolicy: IfNotPresent
-tag: v2.12.0
+tag: v2.4.3
 retention: 6h
 nodeSelector: {}
 tolerations: []

--- a/shared/charts/istio-prometheus/values.yaml
+++ b/shared/charts/istio-prometheus/values.yaml
@@ -1,0 +1,66 @@
+#
+# addon prometheus configuration
+#
+enabled: true
+replicaCount: 1
+hub: docker.io/prom
+image: prometheus
+imagePullPolicy: IfNotPresent
+tag: v2.12.0
+retention: 6h
+nodeSelector: {}
+tolerations: []
+
+# Specify the pod anti-affinity that allows you to constrain which nodes
+# your pod is eligible to be scheduled based on labels on pods that are
+# already running on the node rather than based on labels on nodes.
+# There are currently two types of anti-affinity:
+#    "requiredDuringSchedulingIgnoredDuringExecution"
+#    "preferredDuringSchedulingIgnoredDuringExecution"
+# which denote "hard" vs. "soft" requirements, you can define your values
+# in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+# correspondingly.
+# For example:
+# podAntiAffinityLabelSelector:
+# - key: security
+#   operator: In
+#   values: S1,S2
+#   topologyKey: "kubernetes.io/hostname"
+# This pod anti-affinity rule says that the pod requires not to be scheduled
+# onto a node if that node is already running a pod with label having key
+# "security" and value "S1".
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
+
+# Controls the frequency of prometheus scraping
+scrapeInterval: 15s
+
+contextPath: /prometheus
+
+ingress:
+  enabled: false
+  ## Used to create an Ingress record.
+  hosts:
+    - prometheus.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: prometheus-tls
+    #   hosts:
+    #     - prometheus.local
+
+service:
+  annotations: {}
+  nodePort:
+    enabled: false
+    port: 32090
+
+security:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 10m
+

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -355,4 +355,9 @@ task :couchdb_ui => [:set_vars] do
   sh "docker-compose run --rm -p 35984:35984 xk rake couchdb_ui"
 end
 
+desc "Kiali - access network monitoring dashboard"
+task :kiali_ui => [:set_vars] do
+  sh "docker-compose run --rm -p 20001:20001 xk rake kiali_ui"
+end
+
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/scripts/kiali_ui.sh
+++ b/shared/rakefiles/scripts/kiali_ui.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+# This script starts prot-forwarding to Kiali UI
+# and prints a link to access 
+
+set -emou pipefail
+LC_CTYPE=C
+
+# Enable debug output if $DEBUG is set to true
+[ "${DEBUG:=false}" = 'true' ] && set -x
+
+# Get script name
+THIS_SCRIPT="$(basename "${0}")"
+
+# Optional
+KIALI_SVC_PORT=${KIALI_SVC_PORT:='20001'}
+KIALI_LOCAL_FWD_PORT=${KIALI_LOCAL_FWD_PORT:='20001'}
+KIALI_NAMESPACE=${KIALI_NAMESPACE:='istio-system'}
+KIALI_SVC_NAME=${KIALI_SVC_NAME:='kiali'}
+REQUIRED_BINARIES=${REQUIRED_BINARIES:="kubectl"}
+
+# Check if we have all the dependencies
+for BIN in ${REQUIRED_BINARIES}; do
+  if [ ! -x "$(command -v "${BIN}")" ]
+  then
+    echo "${THIS_SCRIPT}: Required dependency ${BIN} not found in path"
+    exit 1
+  fi
+done
+
+# Start port forwarding
+echo "${THIS_SCRIPT}: Starting port-forwarding"
+kubectl port-forward "service/${KIALI_SVC_NAME}" -n "${KIALI_NAMESPACE}" \
+  --address=0.0.0.0 "${KIALI_LOCAL_FWD_PORT}:${KIALI_SVC_PORT}" >/dev/null &
+KUBECTL_PID="${!}"
+
+echo "${THIS_SCRIPT}:"
+echo "${THIS_SCRIPT}: Kiali port is now being forwarded to your local machine, port ${KIALI_LOCAL_FWD_PORT}."
+echo "${THIS_SCRIPT}:"
+echo "${THIS_SCRIPT}: You can access Kiali Web UI at:"
+echo "${THIS_SCRIPT}: http://localhost:${KIALI_LOCAL_FWD_PORT}/"
+echo "${THIS_SCRIPT}:"
+echo "${THIS_SCRIPT}: You can close this terminal and port-forwarding by pressing ENTER (new line)."
+echo "${THIS_SCRIPT}:"
+
+# idle waiting for abort from user
+read -r
+
+# Stop port-forwarding
+echo "${THIS_SCRIPT}: Stopping port-forwarding"
+kill "${KUBECTL_PID}"
+
+echo "${THIS_SCRIPT}: Done"

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -346,4 +346,9 @@ task :display_scc_findings do
   sh "gcloud alpha scc findings list #{ENV["ORGANIZATION_ID"]} --filter 'state = \"ACTIVE\"'"
 end
 
+# This task forwards Kiali port
+task :kiali_ui => [:configure] do
+  sh "/rakefiles/scripts/kiali_ui.sh"
+end
+
 # vim: et ts=2 sw=2:

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -125,3 +125,11 @@ service_account_assigner:
     repository: gcr.io/gpii-common-prd/gpii__service-account-assigner
     sha: sha256:5c6d9ed84af21d85a71af9e991c4e8adadcc7ccd792ce0472ea2a0378a27f8ca
     tag: 0.0.3-gpii.0
+kiali:
+  upstream:
+    repository: quay.io/kiali/kiali
+    tag: v1.5.0
+  generated:
+    repository: quay.io/kiali/kiali
+    sha: placeholder
+    tag: v1.5.0


### PR DESCRIPTION
This PR deploys Kiali UI to address FERPA Network Mapping requirement - [GPII-4046](https://issues.gpii.net/browse/GPII-4046).

**This PR:**
- Adds Istio Prometheus chart
- Adds Istio Kiali chart
  _(Both charts are slightly modified official Istio subcharts. Main changes - convert subcharts to standalone charts, clean up unused resources, add all `handler`, `instance` and `rule` resources to collect required metrics)_
- Adds Kiali Terraform module
- Deploys Kiali with Prometheus across all environments
- Adds `kiali_ui` rake task to easily setup port-forwarding to Kiali UI

Kiali UI is configured as read-only and its permissions are limited to read-only operations via Kubernetes RBAC. Dedicated Prometheus instance is required, as the instanced deployed with GKE Istio (`promsd`) collects metrics in a different format compared to upstream Istio/Prometheus and expected by Kiali. It's not possible to add the metrics, as it's not possible to modify Prometheus config (it's managed by GKE add-on manager and any changes are overwritten).

**Usage:**
Run `rake kiali_ui` and open printed link - http://localhost:20001/.
```
$ rake kiali_ui                                                                                                                                                       (network-monitoring|…) 0
docker-compose run --rm -p 20001:20001 xk rake kiali_ui
gcloud config set project $TF_VAR_project_id
Updated property [core/project].
/rakefiles/scripts/kiali_ui.sh
kiali_ui.sh: Starting port-forwarding
kiali_ui.sh:
kiali_ui.sh: Kiali port is now being forwarded to your local machine, port 20001.
kiali_ui.sh:
kiali_ui.sh: You can access Kiali Web UI at:
kiali_ui.sh: http://localhost:20001/
kiali_ui.sh:
kiali_ui.sh: You can close this terminal and port-forwarding by pressing ENTER (new line).
kiali_ui.sh:

kiali_ui.sh: Stopping port-forwarding
kiali_ui.sh: Done
```

**Deployment & Testing:**
This is a no-downtime change. Tested in dev - both upgrading existing and deploying new environment from scratch.