### PR TITLE
GPII-4046: Add missing dependency on helm-initializer

### DIFF
--- a/gcp/live/dev/k8s/kiali/terraform.tfvars
+++ b/gcp/live/dev/k8s/kiali/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer",
     ]
   }
 

--- a/gcp/live/prd/k8s/kiali/terraform.tfvars
+++ b/gcp/live/prd/k8s/kiali/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer",
     ]
   }
 

--- a/gcp/live/stg/k8s/kiali/terraform.tfvars
+++ b/gcp/live/stg/k8s/kiali/terraform.tfvars
@@ -7,6 +7,7 @@ terragrunt = {
   dependencies {
     paths = [
       "../cluster",
+      "../kube-system/helm-initializer",
     ]
   }
 


### PR DESCRIPTION
Looks like I missed dependency on `helm-initializer` and didn't catch this during testing (this creates a race condition between helm-init and Kiali) as part of the work on [GPII-4046](https://issues.gpii.net/browse/GPII-4046).

This PR adds the missing dependency on `helm-initializer`.