### PR TITLE
Add missing configure dependency for SCC tasks

### DIFF
--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -302,7 +302,7 @@ task :couchdb_ui => [:configure, :configure_secrets, :set_secrets] do
 end
 
 # This task displays added or removed assets in target projects (comma separated) for the compare duration in seconds
-task :display_scc_assets_changed, [:projects, :compare_duration] do |taskname, args|
+task :display_scc_assets_changed, [:projects, :compare_duration] => [:configure] do |taskname, args|
   unless args[:projects]
     # In case projects list is empty, we are interested in assets from:
     projects = [
@@ -342,7 +342,7 @@ task :display_scc_assets_changed, [:projects, :compare_duration] do |taskname, a
 end
 
 # This task displays scc findings for the target organization
-task :display_scc_findings do
+task :display_scc_findings => [:configure] do
   sh "gcloud alpha scc findings list #{ENV["ORGANIZATION_ID"]} --filter 'state = \"ACTIVE\"'"
 end
 


### PR DESCRIPTION
Recently added `display_scc_*` tasks are missing dependency on `configure`, and will fail when called without authentication previously done by another task.

This PR adds the missing dependency.

**Steps to reproduce:**
- run `rake clobber` do discard temporary volumes
- run `rake display_scc_findings`

The task will fail with auth error:
```console
$ RAKE_REALLY_RUN_IN_PRD=true rake display_scc_findings
docker-compose run --rm xk rake display_scc_findings
Creating volume "gpii-common-prd-stepan-secrets" with default driver
Creating volume "gpii-common-prd-stepan-helm" with default driver
Creating volume "gpii-common-prd-stepan-gcloud" with default driver
Creating volume "gpii-common-prd-stepan-kube" with default driver
gcloud alpha scc findings list 247149361674 --filter 'state = "ACTIVE"'
ERROR: (gcloud.alpha.scc.findings.list) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials, or if you have already logged in with a
different account:

  $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
rake aborted!
...
```