### PR TITLE
GPII-4119: Upgrade GKE to 1.13

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -24,7 +24,7 @@ variable "node_count" {
 }
 
 variable "expected_gke_version_prefix" {
-  default = "1."
+  default = "1.13"
 }
 
 variable "infra_region" {}
@@ -78,9 +78,7 @@ module "gke_cluster" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
 
-  # kubernetes_version = "${data.external.gke_version_assert.result.version}"
-  # this is temporary till version below or newer is released as default
-  kubernetes_version = "1.12.9-gke.15"
+  kubernetes_version = "${data.external.gke_version_assert.result.version}"
 
   region = "${var.infra_region}"
 


### PR DESCRIPTION
This PR reenables automatic "follow the default version" behavior and effectively upgrades GKE Masters and control plane to `1.13.10-gke.0`. [GPII-4119](https://issues.gpii.net/browse/GPII-4119).

Nodes are not upgraded immediately but will be upgraded in the next maintenance window. I have also tested cluster functionality after triggering the node upgrade manually and everything seems good.

I hoped to upgrade directly to `1.13.11-gke.3` which should contain a fix for [CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226) and Istio` 1.1.16`, and was supposed to be released between October 8 and October 12. Unfortunately, it's still not available across all regions.