### PR TITLE
[GPII-4194]: Set missing org-level permissions for common support account

### DIFF
--- a/shared/rakefiles/xk_infra.rake
+++ b/shared/rakefiles/xk_infra.rake
@@ -141,11 +141,13 @@ task :set_org_perms => [@gcp_creds_file] do
         --role #{role}"
     end
   end
-  # Enforce org-level roles for cloud-admin, common SA, and Eugene's account
+  # Enforce org-level roles for cloud-admin, common SA
+  # Eugene's and Serpan's (common support) accounts
   members = {
     "group:cloud-admin@raisingthefloor.org" => cloud_admin_org_roles,
     "serviceAccount:projectowner@#{ENV["TF_VAR_project_id"]}.iam.gserviceaccount.com" => common_sa_org_roles,
-    "user:eugene@raisingthefloor.org" => ["roles/billing.admin"]
+    "user:eugene@raisingthefloor.org" => ["roles/billing.admin"],
+    "user:serpan@raisingthefloor.org" => ["roles/resourcemanager.organizationViewer"]
   }
   members.each do |member, expected_roles|
     existing_roles = %x{


### PR DESCRIPTION
This PR modifies common infra task that enforces org-level permissions to set missing Organization Viewer role for our common support account.

From the [Role-based Support documentation](https://cloud.google.com/support/docs/role-based-support):
`To access support cases for your organization's support account, a user must have the ability to view the organization. This means that Support Account Administrators and all support users must have the Organization Viewer role assigned at the organization level.`