### PR TITLE
[GPII-4205]: Upgrade k8s-snapshots to latest

### DIFF
--- a/shared/charts/k8s-snapshots/README.md
+++ b/shared/charts/k8s-snapshots/README.md
@@ -46,7 +46,7 @@ deletes the release.
 
 ## Configuration
 
-The following table lists the configurable parameters of the gpii-dataloader
+The following table lists the configurable parameters of the k8s-snapshots
 chart and their default values.
 
 | Parameter          | Description                                                       | Default                    |

--- a/shared/charts/k8s-snapshots/templates/deployment.yaml
+++ b/shared/charts/k8s-snapshots/templates/deployment.yaml
@@ -10,6 +10,10 @@ spec:
       labels:
         app: {{ template "k8s-snapshots.name" . }}
       annotations:
+        # This annotation is needed to allow traffic to metadata.google.internal
+        # until Istio's issue with FQDNs in ServiceEntries is not resolved:
+        # https://github.com/istio/istio/issues/14404
+        traffic.sidecar.istio.io/excludeOutboundIPRanges: "169.254.169.254/32"
         {{ if .Values.serviceAccount }}accounts.google.com/service-account: {{ .Values.serviceAccount }}{{ end }}
         {{ if .Values.scopes }}accounts.google.com/scopes: {{ .Values.scopes }}{{ end }}
     spec:
@@ -18,6 +22,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+          - name: CLOUD_PROVIDER
+            value: "google"
+          - name: GCLOUD_CREDENTIALS_FILE
+            value: ""
         {{- if .Values.useClaimName }}
           - name: USE_CLAIM_NAME
             value: "true"

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -96,7 +96,7 @@ flowmanager:
 k8s_snapshots:
   upstream:
     repository: elsdoerfer/k8s-snapshots
-    tag: v2.0
+    tag: latest
   generated:
     repository: gcr.io/gpii-common-prd/elsdoerfer__k8s-snapshots
     sha: sha256:06ceb13d357ef689cd4ecfa17d20f6cd7874554c6da4dfad7bd56cd005e4e452


### PR DESCRIPTION
This PR switches `k8s-snapshots` to use latest image that is [free from critical vulnerabilities](https://console.cloud.google.com/gcr/images/gpii-gcp-dev-natarajaya/GLOBAL/k8s-snapshots@sha256:5c9a27ae0a37e0d4d0a6cb2d89e6b859af7a01ef9d9864b647fb4927e11c741e/details?tab=vulnz&project=gpii-gcp-dev-natarajaya&authuser=1&organizationId=247149361674), and fixes its chart to work properly with the new version.

I have tested this with my dev cluster and have not found any side effects, but using latest build seems like a bad idea anyway. Initially I wanted to pin it down to specific SHA, but looks like our version-updater [can only work with tags](https://github.com/gpii-ops/gpii-version-updater/blob/master/sync_images.rb#L41-L47) :(

Should we push to our docker registry, add a tag and let version-updater to pick up from there?