### PR TITLE
GPII-4102: Add Istio Egress Gateway

### DIFF
--- a/gcp/modules/istio-gke-helper/main.tf
+++ b/gcp/modules/istio-gke-helper/main.tf
@@ -22,3 +22,15 @@ module "istio-gke-helper" {
 
   chart_name = "${var.charts_dir}/istio-gke-helper"
 }
+
+module "istio-gateways" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name      = "istio-gateways"
+  release_namespace = "istio-system"
+  release_values    = ""
+
+  chart_name = "${var.charts_dir}/istio-gateways"
+}

--- a/shared/charts/istio-gateways/Chart.yaml
+++ b/shared/charts/istio-gateways/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+name: gateways
+version: 1.1.0
+appVersion: 1.1.0
+tillerVersion: ">=2.7.2"
+description: Helm chart for deploying Istio gateways
+keywords:
+  - istio
+  - ingressgateway
+  - egressgateway
+  - gateways
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/shared/charts/istio-gateways/templates/_affinity.tpl
+++ b/shared/charts/istio-gateways/templates/_affinity.tpl
@@ -1,0 +1,93 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "gatewaynodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "gatewayNodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "gatewayNodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "gatewayNodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .root.Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key | quote }}
+          {{- end }}
+        {{- end }}
+        {{- $nodeSelector := default .root.Values.defaultNodeSelector .nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val | quote }}
+        {{- end }}
+{{- end }}
+
+{{- define "gatewayNodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .root.Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "gatewaypodAntiAffinity" }}
+{{- if or .podAntiAffinityLabelSelector .podAntiAffinityTermLabelSelector}}
+  podAntiAffinity:
+    {{- if .podAntiAffinityLabelSelector }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "gatewaypodAntiAffinityRequiredDuringScheduling" . }}
+    {{- end }}
+    {{- if .podAntiAffinityTermLabelSelector }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "gatewaypodAntiAffinityPreferredDuringScheduling" . }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "gatewaypodAntiAffinityRequiredDuringScheduling" }}
+    {{- range $index, $item := .podAntiAffinityLabelSelector }}
+    - labelSelector:
+        matchExpressions:
+        - key: {{ $item.key }}
+          operator: {{ $item.operator }}
+          {{- if $item.values }}
+          values:
+          {{- $vals := split "," $item.values }}
+          {{- range $i, $v := $vals }}
+          - {{ $v | quote }}
+          {{- end }}
+          {{- end }}
+      topologyKey: {{ $item.topologyKey }}
+    {{- end }}
+{{- end }}
+
+{{- define "gatewaypodAntiAffinityPreferredDuringScheduling" }}
+    {{- range $index, $item := .podAntiAffinityTermLabelSelector }}
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: {{ $item.key }}
+            operator: {{ $item.operator }}
+            {{- if $item.values }}
+            values:
+            {{- $vals := split "," $item.values }}
+            {{- range $i, $v := $vals }}
+            - {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+        topologyKey: {{ $item.topologyKey }}
+      weight: 100
+    {{- end }}
+{{- end }}

--- a/shared/charts/istio-gateways/templates/_helpers.tpl
+++ b/shared/charts/istio-gateways/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gateway.chart" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/shared/charts/istio-gateways/templates/_podDisruptionBudget.tpl
+++ b/shared/charts/istio-gateways/templates/_podDisruptionBudget.tpl
@@ -1,0 +1,3 @@
+{{- define "podDisruptionBudget.spec" }}
+  minAvailable: 1
+{{- end }}

--- a/shared/charts/istio-gateways/templates/deployment.yaml
+++ b/shared/charts/istio-gateways/templates/deployment.yaml
@@ -1,0 +1,244 @@
+{{- range $key, $spec := .Values.gateways }}
+{{- if ne $key "enabled" }}
+{{- if $spec.enabled }}
+
+{{- $labels := merge (dict "release" $.Release.Name "chart" (include "gateway.chart" $) "heritage" $.Release.Service) $spec.labels }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $key }}
+  namespace: {{ $spec.namespace | default $.Release.Namespace }}
+  labels:
+{{ $labels | toYaml | indent 4 }}
+spec:
+{{- if not $spec.autoscaleEnabled }}
+{{- if $spec.replicaCount }}
+  replicas: {{ $spec.replicaCount }}
+{{- else }}
+  replicas: 1
+{{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- range $key, $val := $spec.labels }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ $spec.rollingMaxSurge }}
+      maxUnavailable: {{ $spec.rollingMaxUnavailable }}
+  template:
+    metadata:
+      labels:
+{{ $labels | toYaml | indent 8 }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+{{- if $spec.podAnnotations }}
+{{ toYaml $spec.podAnnotations | indent 8 }}
+{{ end }}
+    spec:
+      serviceAccountName: {{ $key }}-service-account
+      containers:
+        - name: istio-proxy
+{{- if contains "/" $.Values.proxy.image }}
+          image: "{{ $.Values.proxy.image }}"
+{{- else }}
+          image: "{{ $.Values.hub }}/{{ $.Values.proxy.image }}:{{ $.Values.tag }}"
+{{- end }}
+          imagePullPolicy: {{ $.Values.imagePullPolicy }}
+          ports:
+            {{- range $key, $val := $spec.ports }}
+            - containerPort: {{ $val.port }}
+            {{- end }}
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
+          args:
+          - proxy
+          - router
+          - --domain
+          - $(POD_NAMESPACE).svc.{{ $.Values.proxy.clusterDomain }}
+        {{- if $.Values.proxy.logLevel }}
+          - --proxyLogLevel={{ $.Values.proxy.logLevel }}
+        {{- end}}
+        {{- if $.Values.proxy.componentLogLevel }}
+          - --proxyComponentLogLevel={{ $.Values.proxy.componentLogLevel }}
+        {{- end}}
+        {{- if $.Values.logging.level }}
+          - --log_output_level={{ $.Values.logging.level }}
+        {{- end}}
+          - --drainDuration
+          - '45s' #drailnDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - {{ $key }}
+        {{- if eq $.Values.proxy.tracer "zipkin" }}
+          - --zipkinAddress
+          {{- if $.Values.tracer.zipkin.address }}
+          - {{ $.Values.tracer.zipkin.address }}
+          {{- else if $.Values.istioNamespace }}
+          - zipkin.{{ $.Values.istioNamespace }}:9411
+          {{- else }}
+          - zipkin:9411
+          {{- end }}
+        {{- end }}
+        {{- if $.Values.proxy.envoyMetricsService.enabled }}
+          - --envoyMetricsService
+          {{- with  $.Values.proxy.envoyMetricsService }}
+          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tlsSettings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcpKeepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
+          {{- end }}
+        {{- end}}
+        {{- if $.Values.proxy.envoyAccessLogService.enabled }}
+          - --envoyAccessLogService
+          {{- with  $.Values.proxy.envoyAccessLogService }}
+          - '{"address":"{{ .host }}:{{.port }}"{{ if .tlsSettings }},"tlsSettings":{{ .tlsSettings | toJson }}{{- end }}{{ if .tcpKeepalive }},"tcpKeepalive":{{ .tcpKeepalive | toJson }}{{- end }}}'
+          {{- end }}
+        {{- end }}
+          - --proxyAdminPort
+          - "15000"
+          - --statusPort
+          - "15020"
+        {{- if $.Values.controlPlaneSecurityEnabled }}
+          - --controlPlaneAuthPolicy
+          - MUTUAL_TLS
+          - --discoveryAddress
+          {{- if $.Values.istioNamespace }}
+          - istio-pilot.{{ $.Values.istioNamespace }}:15011
+          {{- else }}
+          - istio-pilot:15011
+          {{- end }}
+        {{- else }}
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          {{- if $.Values.istioNamespace }}
+          - istio-pilot.{{ $.Values.istioNamespace }}:15010
+          {{- else }}
+          - istio-pilot:15010
+          {{- end }}
+          {{- if $spec.applicationPorts }}
+          - --applicationPorts
+          - "{{ $spec.applicationPorts }}"
+          {{- end }}
+        {{- end }}
+        {{- if $.Values.trustDomain }}
+          - --trust-domain={{ $.Values.trustDomain }}
+        {{- end }}
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+{{- if $spec.resources }}
+{{ toYaml $spec.resources | indent 12 }}
+{{- end }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: ISTIO_META_CONFIG_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: ISTIO_METAJSON_LABELS
+            value: |
+              {{ $labels | toJson}}
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: {{ $key }}
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps/v1/namespaces/{{ $spec.namespace | default $.Release.Namespace }}/deployments/{{ $key }}
+          {{- if eq $.Values.proxy.tracer "stackdriver" }}
+          - name: STACKDRIVER_TRACING_ENABLED
+            value: "true"
+          - name: STACKDRIVER_TRACING_DEBUG
+            value: "{{ $.Values.tracer.stackdriver.debug }}"
+          - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
+            value: "{{ $.Values.tracer.stackdriver.maxNumberOfAnnotations }}"
+          - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
+            value: "{{ $.Values.tracer.stackdriver.maxNumberOfAttributes }}"
+          - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
+            value: "{{ $.Values.tracer.stackdriver.maxNumberOfMessageEvents }}"
+          {{- end }}
+          {{- if $spec.env }}
+          {{- range $key, $val := $spec.env }}
+          - name: {{ $key }}
+            value: {{ $val }}
+          {{- end }}
+          {{- end }}
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          {{- range $spec.secretVolumes }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath | quote }}
+            readOnly: true
+          {{- end }}
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.{{ $key }}-service-account
+          optional: true
+      {{- range $spec.secretVolumes }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName | quote }}
+          optional: true
+      {{- end }}
+      {{- range $spec.configVolumes }}
+      - name: {{ .name }}
+        configMap:
+          name: {{ .configMapName | quote }}
+          optional: true
+      {{- end }}
+      affinity:
+      {{- include "gatewaynodeaffinity" (dict "root" $ "nodeSelector" $spec.nodeSelector) | indent 6 }}
+      {{- include "gatewaypodAntiAffinity" (dict "podAntiAffinityLabelSelector" $spec.podAntiAffinityLabelSelector "podAntiAffinityTermLabelSelector" $spec.podAntiAffinityTermLabelSelector) | indent 6 }}
+      {{- if $spec.tolerations }}
+      tolerations:
+{{ toYaml $spec.tolerations | indent 6 }}
+      {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/shared/charts/istio-gateways/templates/service.yaml
+++ b/shared/charts/istio-gateways/templates/service.yaml
@@ -1,0 +1,51 @@
+{{- range $key, $spec := .Values.gateways }}
+{{- if ne $key "enabled" }}
+{{- if $spec.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $key }}
+  namespace: {{ $spec.namespace | default $.Release.Namespace }}
+  annotations:
+    {{- range $key, $val := $spec.serviceAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    chart: {{ template "gateway.chart" $ }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
+spec:
+{{- if $spec.loadBalancerIP }}
+  loadBalancerIP: "{{ $spec.loadBalancerIP }}"
+{{- end }}
+{{- if $spec.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml $spec.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if $spec.externalTrafficPolicy }}
+  externalTrafficPolicy: {{$spec.externalTrafficPolicy }}
+{{- end }}
+{{- if $spec.externalIPs }}
+  externalIPs:
+{{ toYaml $spec.externalIPs | indent 4 }}
+{{- end }}
+  type: {{ .type }}
+  selector:
+    release: {{ $.Release.Name }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
+  ports:
+    {{- range $key, $val := $spec.ports }}
+    -
+      {{- range $pkey, $pval := $val }}
+      {{ $pkey}}: {{ $pval }}
+      {{- end }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/shared/charts/istio-gateways/templates/serviceaccount.yaml
+++ b/shared/charts/istio-gateways/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- range $key, $spec := .Values.gateways }}
+{{- if ne $key "enabled" }}
+{{- if $spec.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $key }}-service-account
+  namespace: {{ $spec.namespace | default $.Release.Namespace }}
+  labels:
+    app: {{ $spec.labels.app }}
+    chart: {{ template "gateway.chart" $ }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/shared/charts/istio-gateways/values.yaml
+++ b/shared/charts/istio-gateways/values.yaml
@@ -1,0 +1,116 @@
+#
+# Gateways Configuration
+# By default (if enabled) a pair of Ingress and Egress Gateways will be created for the mesh.
+# You can add more gateways in addition to the defaults but make sure those are uniquely named
+# and that NodePorts are not conflicting.
+# Disable specifc gateway by setting the `enabled` to false.
+#
+enabled: true
+
+gateways:
+  istio-egressgateway:
+    enabled: true
+    labels:
+      app: istio-egressgateway
+      istio: egressgateway
+    autoscaleEnabled: true
+    autoscaleMin: 2
+    autoscaleMax: 5
+    # specify replicaCount when autoscaleEnabled: false
+    # replicaCount: 1
+    rollingMaxSurge: 100%
+    rollingMaxUnavailable: 25%
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 2000m
+        memory: 1024Mi
+    cpu:
+      targetAverageUtilization: 80
+    serviceAnnotations: {}
+    podAnnotations: {}
+    type: ClusterIP #change to NodePort or LoadBalancer if need be
+    ports:
+    - port: 80
+      name: http2
+    - port: 443
+      name: https
+      # This is the port where sni routing happens
+    - port: 15443
+      targetPort: 15443
+      name: tls
+    secretVolumes:
+    - name: egressgateway-certs
+      secretName: istio-egressgateway-certs
+      mountPath: /etc/istio/egressgateway-certs
+    - name: egressgateway-ca-certs
+      secretName: istio-egressgateway-ca-certs
+      mountPath: /etc/istio/egressgateway-ca-certs
+    #### Advanced options ########
+    env:
+      # Set this to "external" if and only if you want the egress gateway to
+      # act as a transparent SNI gateway that routes mTLS/TLS traffic to
+      # external services defined using service entries, where the service
+      # entry has resolution set to DNS, has one or more endpoints with
+      # network field set to "external". By default its set to "" so that
+      # the egress gateway sees the same set of endpoints as the sidecars
+      # preserving backward compatibility
+      # ISTIO_META_REQUESTED_NETWORK_VIEW: ""
+      # A gateway with this mode ensures that pilot generates an additional
+      # set of clusters for internal services but without Istio mTLS, to
+      # enable cross cluster routing.
+      ISTIO_META_ROUTER_MODE: "sni-dnat"
+    nodeSelector: {}
+    tolerations: []
+    # Specify the pod anti-affinity that allows you to constrain which nodes
+    # your pod is eligible to be scheduled based on labels on pods that are
+    # already running on the node rather than based on labels on nodes.
+    # There are currently two types of anti-affinity:
+    #    "requiredDuringSchedulingIgnoredDuringExecution"
+    #    "preferredDuringSchedulingIgnoredDuringExecution"
+    # which denote "hard" vs. "soft" requirements, you can define your values
+    # in "podAntiAffinityLabelSelector" and "podAntiAffinityTermLabelSelector"
+    # correspondingly.
+    # For example:
+    # podAntiAffinityLabelSelector:
+    # - key: security
+    #   operator: In
+    #   values: S1,S2
+    #   topologyKey: "kubernetes.io/hostname"
+    # This pod anti-affinity rule says that the pod requires not to be scheduled
+    # onto a node if that node is already running a pod with label having key
+    # "security" and value "S1".
+    podAntiAffinityLabelSelector: []
+    podAntiAffinityTermLabelSelector: []
+
+# Values from Global originally
+logging:
+  level: default:info
+
+proxy:
+  tracer: zipkin
+  envoyMetricsService:
+    enabled: false
+  envoyAccessLogService:
+    enabled: false
+  clusterDomain: cluster.local
+
+  image: gke.gcr.io/istio/proxyv2:1.1.13-gke.0
+
+tracer:
+  zipkin:
+    placeholder: placeholder
+
+controlPlaneSecurityEnabled: true
+
+defaultPodDisruptionBudget:
+  enabled: true
+
+arch:
+  amd64: 2
+  s390x: 2
+  ppc64le: 2
+
+defaultNodeSelector: {}


### PR DESCRIPTION
This PR deploys Istio Egress gateway as part of work on controlling egress traffic - [GPII-4102](https://issues.gpii.net/browse/GPII-4102). Egress gateway used to be deployed as part of the GKE istio add-on by default prior to 1.1 (with all egress traffic blocked).

The PR does not affect the current flow of egress traffic in any way, not blocks any traffic, this will be handled in separate PRs.

**PR Changes:**
- Add Istio gateways chart - the chart is based on official Istio charts, but refactored to work as a standalone chart (vs. original subchart) and with some bits of not relevant functionality removed from templates
- Deploy an instance of Istio Egress gateway

**Deployment:**
This is a non-disruptive deploy.

**Testing:**
I've tested that the Egress gateways is correctly deployed and running in a dev environment.