### PR TITLE
[GPII-3965] Remove lbm module dependency on common-stg

### DIFF
--- a/common/live/stg/infra/stackdriver/monitoring/terraform.tfvars
+++ b/common/live/stg/infra/stackdriver/monitoring/terraform.tfvars
@@ -4,12 +4,6 @@ terragrunt = {
     source = "/project/modules//gcp-stackdriver"
   }
 
-  dependencies {
-    paths = [
-      "../lbm"
-    ]
-  }
-
   include = {
     path = "${find_in_parent_folders()}"
   }


### PR DESCRIPTION
This PR remove the dependency of LBM module in common-stg and unlocks the pipeline.