### PR TITLE
[GPII-4220] Alerts not received in Slack

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/notification_alerts_slack.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/notification_alerts_slack.tf
@@ -2,7 +2,7 @@ resource "google_monitoring_notification_channel" "alerts_slack" {
   depends_on   = ["null_resource.destroy_old_stackdriver_resources"]
   count        = "${(var.env == "prd" || var.env == "stg") ? 1 : 0}"
   type         = "slack"
-  display_name = "Alerts #${var.env} Slack"
+  display_name = "#alerts-${var.env}"
 
   labels = {
     channel_name = "#alerts-${var.env}"


### PR DESCRIPTION
It seems that the `display_name` is translated to the `Channel name` of the alert. After changing this in one alert in stg, new messages appeared in the channel.