### PR TITLE
GPII-4221: Automate CouchDB Backup Restore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.7-google_gpii.0
+  - image: gpii/exekube:0.9.8-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.7-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.8-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.7-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.8-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.7-google_gpii.0
+    image: gpii/exekube:0.9.8-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -562,8 +562,8 @@ another point in the past. This operation is disruptive and requires bringing
 entire CouchDB cluster down.
 
 Ops team performs backup restoration test on `gpii-gcp-stg` cluster monthly, to
-make sure that automated backups are being created as expected and can be used
-to restore functional and consistent DB.
+make sure that automated backups are being created as expected, can be used to
+restore functional and consistent DB and that this documentation is correct.
 
 This operation requires admin permissions on the project, use `rake
 grant_project_admin`.
@@ -581,6 +581,9 @@ order, starting from node `0`).
 ```
 rake 'couchdb_backup_restore[snapshot-0 snapshot-1 snapshot-2]'
 ```
+
+To make sure that all systems are functional, run smoke tests using the `rake
+test_*` tasks.
 
 ### Manual processes: Users' data and client credentials
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -555,38 +555,32 @@ In this scenario we rely on CouchDB ability to recover from loss of one or more 
    * You can check DB status on recovered node with `kubectl exec --namespace gpii -it couchdb-couchdb-N -c couchdb -- curl -s http://$TF_VAR_couchdb_admin_username:$TF_VAR_couchdb_admin_password@127.0.0.1:5984/gpii/`, where N is node index.
 1. To make sure that all systems are functional, run smoke tests with `rake test_preferences_read` and then `rake test_flowmanager`.
 
-### Data corruption on all replicas of CouchDB cluster
+### Restoring Entire CouchDB Cluster from Snapshots
 
-There may be a situation, when we want to roll back entire DB data set to another point in the past. Current solution is disruptive, requires bringing entire CouchDB cluster down and some manual actions (we'll most likely automate this in future).
+There may be a situation, when we want to roll back entire DB data set to
+another point in the past. This operation is disruptive and requires bringing
+entire CouchDB cluster down.
 
-Ops team must perform backup restoration test using this scenario on `gpii-gcp-stg` cluster monthly, to make sure that:
-* Automated backups are being created as expected.
-* Existing backups can be used to restore functional and consistent DB.
-* Restoration guide (this scenario) is accurate.
+Ops team performs backup restoration test on `gpii-gcp-stg` cluster monthly, to
+make sure that automated backups are being created as expected and can be used
+to restore functional and consistent DB.
 
-Here are the steps:
+This operation requires admin permissions on the project, use `rake
+grant_project_admin`.
 
-1. Grant yourself admin permissions in the project you are working on with `rake grant_project_admin`.
-1. Get current number of CouchDB stateful set replicas N with `kubectl --namespace gpii get statefulset couchdb-couchdb -o json | jq ".status.replicas"`.
-1. Collect CouchDB disk names from PVCs with `kubectl --namespace gpii get pvc -l app=couchdb -o json | jq -r .items[].spec.volumeName`.
-1. Choose a snapshot set that you want to restore, make sure that snapshots are present for all disks that are currently in use by CouchDB cluster.
-   * In case of a backup restoration test, pick latest snapshot set available: you can do this with `for i in {0..N}; do gcloud compute snapshots list --sort-by=~creationTimestamp,STATUS --limit=1 --format="value[separator=';'](name,status)" --filter="name~'pv-database-storage-couchdb-couchdb-$i-*'" | cut -f1 -d\; ; done`
-1. Scale `flowmanager` and `preferences` deployments to 0 replicas with `kubectl --namespace gpii scale deployment preferences --replicas=0` and `kubectl --namespace gpii scale deployment flowmanager --replicas=0` to stop the flow of traffic to CouchDB. This will give you time to verify that DB restoration is successful before allowing the DB to receive traffic again. **WARNING! This will prevent flowmanager and preferences services from processing customer requests!**
-1. Scale CouchDB stateful set to 0 replicas with `kubectl --namespace gpii scale statefulset couchdb-couchdb --replicas=0`. This will cause K8s to terminate all CouchDB pods, all PDs that were mounted into them will be released.
-1. Destroy `k8s-snapshots` module with `rake destroy_module["k8s/kube-system/k8s-snapshots"]` to prevent new snapshots from being created while you working with disks.
-1. Open Google Cloud console, go to "Compute Engine" -> "Disks".
-1. Now, repeat for every CouchDB disk name you collected:
-   * Save disk name, type, size, zone and description.
-   * Pick proper snapshot.
-   * Delete PD.
-   * Create new PD from snapshot with the same name, type, size, zone and description.
-1. Scale CouchDB stateful set back to number of replicas it used to have before with `kubectl --namespace gpii scale statefulset couchdb-couchdb --replicas=N`
-1. Database is now restored to the state at the time of target snapshot.
-   * You can check the status of all nodes with `for i in {0..N-1}; do kubectl exec --namespace gpii -it couchdb-couchdb-$i -c couchdb -- curl -s http://$TF_VAR_secret_couchdb_admin_username:$TF_VAR_secret_couchdb_admin_password@127.0.0.1:5984/_up; done`, where N is a number of CouchDB replicas.
-   * You can also check CouchDB membership status with `kubectl exec --namespace gpii -it couchdb-couchdb-0 -c couchdb -- curl -s http://$TF_VAR_secret_couchdb_admin_username:$TF_VAR_secret_couchdb_admin_password@127.0.0.1:5984/_membership | jq`.
-1. Once DB state is verified and you sure that everything went as desired, you can scale `preferences` and `flowmanager` deployments back as well. From this point system functionality for the customer is fully restored.
-1. Deploy `k8s-snapshots` module to resume regular snapshot process with `rake deploy_module["k8s/kube-system/k8s-snapshots"]`.
-1. To make sure that all systems are functional, run smoke tests with `rake test_preferences_read` and then `rake test_flowmanager`.
+Restoring from the latest set of snapshots (mainly used when performing monthly
+exercise):
+
+```
+rake 'couchdb_backup_restore'
+```
+
+Restoring from a specific set of snapshots (the snapshots have to be listed in
+order, starting from node `0`).
+
+```
+rake 'couchdb_backup_restore[snapshot-0 snapshot-1 snapshot-2]'
+```
 
 ### Manual processes: Users' data and client credentials
 

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.7-google_gpii.0
+    image: gpii/exekube:0.9.8-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -366,4 +366,8 @@ task :kiali_ui => [:set_vars] do
   sh "docker-compose run --rm -p 20001:20001 xk rake kiali_ui"
 end
 
+desc "CouchDB - restore from backup"
+task :couchdb_backup_restore, [:snapshots] => [:set_vars] do |taskname, args|
+  sh "#{@exekube_cmd} rake couchdb_backup_restore['#{args[:snapshots]}']"
+end
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/scripts/couchdb_backup_restore.sh
+++ b/shared/rakefiles/scripts/couchdb_backup_restore.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env sh
+
+# This script restores CouchDB disks from set of snapshots.
+# By default latest set of available snapshots will be used,
+# alternatively snapshots names can be passed via 
+# COUCHDB_SOURCE_SNAPSHOTS variable
+
+set -emou pipefail
+LC_CTYPE=C
+
+# Enable debug output if $DEBUG is set to true
+[ "${DEBUG:=false}" = 'true' ] && set -x
+# DEBUG set messes up kubectl output
+unset DEBUG
+
+# Get script name
+THIS_SCRIPT="$(basename "${0}")"
+
+# Optional
+COUCHDB_SOURCE_SNAPSHOTS=${COUCHDB_SOURCE_SNAPSHOTS:=''}
+COUCHDB_NAMESPACE=${COUCHDB_NAMESPACE:='gpii'}
+COUCHDB_STATEFULSET_NAME=${COUCHDB_STATEFULSET_NAME:='couchdb-couchdb'}
+COUCHDB_SNAPSHOT_PREFIX=${COUCHDB_SNAPSHOT_PREFIX:='pv-database-storage-couchdb-couchdb'}
+COUCHDB_PVC_FILTER=${COUCHDB_PVC_FILTER:='app=couchdb'}
+COUCHDB_POD_FILTER=${COUCHDB_POD_FILTER:='app=couchdb'}
+DEPLOYMENTS_NAMES=${DEPLOYMENTS_NAMES:='preferences flowmanager'}
+DEPLOYMENTS_NAMESPACE=${DEPLOYMENTS_NAMESPACE:='gpii'}
+K8S_SNAPSHOTS_NAMESPACE=${K8S_SNAPSHOTS_NAMESPACE:='kube-system'}
+K8S_SNAPSHOTS_DEPLOYMENT_NAME=${K8S_SNAPSHOTS_DEPLOYMENT_NAME:='k8s-snapshots'}
+REQUIRED_BINARIES=${REQUIRED_BINARIES:='kubectl gcloud jq awk'}
+MAX_RETRIES=${MAX_RETRIES:='30'}
+SLEEP=${SLEEP:='10'}
+PRINT_PREFIX=${PRINT_PREFIX="${THIS_SCRIPT}: "}
+
+# Check if we have colors available, it looks good
+check_colors(){
+  if command -v tput > /dev/null; then
+    COLORS="$(tput colors)"
+    if [ -n "${COLORS}" ] && [ "${COLORS}" -ge 8 ]; then
+      GREEN="$(tput setaf 2)"
+      RED="$(tput setaf 1)"
+      YELLOW="$(tput setaf 3)"
+      NOCOL="$(tput sgr0)"
+    fi
+  else
+    GREEN=''
+    RED=''
+    YELLOW=''
+    NOCOL=''
+  fi
+}
+
+# Print message
+print() {
+  echo "${YELLOW}${PRINT_PREFIX}${NOCOL}$*"
+}
+
+# Print error and exit
+fail() {
+  print "${RED}ERROR: $*${NOCOL}"
+  exit 1
+}
+
+# Print section header
+print_header() {
+  print
+  print "## ${GREEN}$*${NOCOL}"
+}
+
+# Check if we have all the dependencies
+verify_binaries() {
+  for bin in ${REQUIRED_BINARIES}; do
+    [ -x "$(command -v "${bin}")" ] || fail "Required dependency ${bin} not found in path"
+  done
+}
+
+# Scale resource of kind $1 and name $2 in namespace $3 to given number of replicas $4
+scale_and_wait() {
+  kind=${1:?'Resource Kind must be set'}
+  name=${2:?'Resource Name must be set'}
+  namespace=${3:?'Resource Namespace must be set'}
+  replicas=${4:?'Number of replicas must be set'}
+
+  print "Scaling ${kind} ${namespace}/${name} to ${replicas} replicas"
+  kubectl -n "${namespace}" scale "${kind}/${name}" --replicas="${replicas}"
+
+  # Wait for given number of repicas
+  retries=0
+  ready='false'
+  if [ "${replicas}" -gt 0 ]; then
+    while [ "${retries}" -lt "${MAX_RETRIES}" ] && [ "${ready}" != 'true' ]; do
+      [ "$(kubectl -n "${namespace}" get "${kind}" "${name}" -o jsonpath='{.status.readyReplicas}')" = "${replicas}" ] && ready='true'
+      [ "${ready}" != 'true' ] && printf '.' && sleep "${SLEEP}"
+      retries=$((retries + 1))
+    done
+    # shellcheck disable=SC2015
+    [ "${ready}" = 'true' ] && printf '\n' || fail "Time-out while waiting for ${kind}/${name}" 
+  fi
+}
+
+# Reads names of Couchdb snapshots
+read_latest_couchdb_snapshots() {
+  snapshots=''
+  for i in $(seq 0 "$((COUCHDB_REPLICAS-1))"); do
+    snapshots="${snapshots} $(gcloud compute snapshots list --sort-by='~creationTimestamp' --limit=1 --format='json' \
+                   --filter="name~'${COUCHDB_SNAPSHOT_PREFIX}-${i}-*'" \
+                   | jq -re '.[0].name')"
+  done
+  COUCHDB_SOURCE_SNAPSHOTS="$(echo "${snapshots}" | awk '{$1=$1};1')"
+}
+
+# Check that snapshots are available
+check_snapshots() {
+  for s in ${COUCHDB_SOURCE_SNAPSHOTS}; do
+    gcloud compute snapshots describe "${s}" > /dev/null
+  done
+}
+
+# Restores volumes from snapshots
+restore_disks() {
+  i=1
+
+  for volume in ${COUCHDB_PVS}; do
+    print "Restoring volume ${volume}"
+    pv_info="$(kubectl get pv "${volume}" -o json)"
+    disk_name="$(printf '%s' "${pv_info}" | jq -er '.spec.gcePersistentDisk.pdName')"
+    disk_zone="$(printf '%s' "${pv_info}" | jq -er '.metadata.labels."failure-domain.beta.kubernetes.io/zone"')"
+    disk_info="$(gcloud compute disks describe "${disk_name}" --zone "${disk_zone}" --format json)"
+    disk_size="$(printf '%s' "${disk_info}" | jq -er '.sizeGb')"
+    disk_desc="$(printf '%s' "${disk_info}" | jq -er '.description')"
+    disk_type="$(printf '%s' "${disk_info}" | jq -er '.type | split("/")[-1]')"
+
+    snapshot="$(echo "${COUCHDB_SOURCE_SNAPSHOTS}" | cut -f"${i}" -d' ')"
+    i=$((i + 1))
+
+    print "- Deleting disk ${disk_name}"
+    gcloud compute disks delete "${disk_name}" --zone "${disk_zone}" --quiet
+   
+    print "- Creating disk ${disk_name} (${disk_zone}, ${disk_size} GB, ${disk_type})"
+    print "  from snapshot ${snapshot}"
+    gcloud compute disks create "${disk_name}" --zone "${disk_zone}" \
+                                  --description="${disk_desc}" \
+                                  --size "${disk_size}GB" \
+                                  --type "${disk_type}" \
+                                  --source-snapshot "${snapshot}"
+
+  done 
+}
+
+# Check CouchDB Cluster health
+check_couchdb_health() {
+  # Wait until each node has OK status
+  for i in $(seq 0 "$((COUCHDB_REPLICAS-1))"); do
+    print "Waiting for ${COUCHDB_STATEFULSET_NAME}-${i}"
+    retries=0
+    status='false'
+    
+    while [ "${retries}" -lt "${MAX_RETRIES}" ] && [ "${status}" != 'ok' ]; do
+
+      # shellcheck disable=SC2016
+      status="$(kubectl exec -n "${COUCHDB_NAMESPACE}" -it "${COUCHDB_STATEFULSET_NAME}-${i}" -c couchdb -- \
+        sh -c 'curl -s http://$COUCHDB_USER:$COUCHDB_PASSWORD@127.0.0.1:5984/_up' | jq -re '.status')"
+      [ "${status}" != 'ok' ] && printf '.' && sleep "${SLEEP}"
+      
+      retries=$((retries + 1))
+    done
+    # shellcheck disable=SC2015
+    [ "${status}" = 'ok' ] && printf '\n' || fail "Time-out while waiting for ${COUCHDB_STATEFULSET_NAME}-${i}" 
+  done
+
+  # Wait until all the nodes are listed as cluster_nodes 
+  print "Checking membership status"
+  retries=0
+  nodes=0
+  while [ "${retries}" -lt "${MAX_RETRIES}" ] && [ "${nodes}" != "${COUCHDB_REPLICAS}" ]; do
+
+    # shellcheck disable=SC2016
+    nodes="$(kubectl exec -n "${COUCHDB_NAMESPACE}" -it "${COUCHDB_STATEFULSET_NAME}-0" -c couchdb -- \
+      sh -c 'curl -s http://$COUCHDB_USER:$COUCHDB_PASSWORD@127.0.0.1:5984/_membership' | jq -re '.cluster_nodes | length')"
+    [ "${nodes}" != "${COUCHDB_REPLICAS}" ] && printf '.' && sleep "${SLEEP}"
+
+    retries=$((retries + 1))
+  done
+  # shellcheck disable=SC2015
+  [ "${nodes}" = "${COUCHDB_REPLICAS}" ] && printf '\n' || fail "Time-out while waiting for CouchDB membership" 
+}
+
+
+# Init helper functions
+check_colors
+
+# Check prerequisites
+print_header "Checking prerequisites"
+verify_binaries
+
+# Read num of Couch replicas
+print_header "Reading current set of replicas"
+COUCHDB_REPLICAS="$(kubectl -n "${COUCHDB_NAMESPACE}" get statefulset "${COUCHDB_STATEFULSET_NAME}" -o jsonpath='{.status.replicas}')"
+
+# If not supplied read set of latest snapshots
+if [ "${COUCHDB_SOURCE_SNAPSHOTS}" = '' ]; then
+  print_header "Reading latest set of snapshots"
+  read_latest_couchdb_snapshots
+fi
+
+# Check that number of snaphsots matches number of replicas
+[ "$(echo "${COUCHDB_SOURCE_SNAPSHOTS}" | wc -w | awk '{$1=$1};1')" = "${COUCHDB_REPLICAS}" ] \
+  || fail "Number of CouchDB snapshots (${COUCHDB_SOURCE_SNAPSHOTS}) does not match number of replicas (${COUCHDB_REPLICAS})"
+print "Snapshots to restore from: ${COUCHDB_SOURCE_SNAPSHOTS}"
+
+# Check snapshots
+print_header "Checking snapshots availability"
+check_snapshots
+
+# Scale services to 0
+print_header "Scaling down services"
+for d in $DEPLOYMENTS_NAMES; do
+  scale_and_wait deployment "${d}" "${DEPLOYMENTS_NAMESPACE}" 0
+done
+
+# Read names of current Couch volumes
+print_header "Reading CouchDB volume names"
+COUCHDB_PVS="$(kubectl -n "${COUCHDB_NAMESPACE}" get pvc -l "${COUCHDB_PVC_FILTER}" \
+                 --sort-by '.metadata.name' -o json | jq -re '.items[].spec.volumeName')"
+
+# Scale CouchDB to 0
+print_header "Scaling down CouchDB"
+scale_and_wait statefulset "${COUCHDB_STATEFULSET_NAME}" "${COUCHDB_NAMESPACE}" 0
+
+# Wait for pods to disappear
+print "Waiting for all pods to terminate"
+kubectl wait pods -l="${COUCHDB_POD_FILTER}" -n "${COUCHDB_NAMESPACE}" --for=delete --timeout="$((MAX_RETRIES * SLEEP))s"
+
+# Scale K8s snapshots to 0
+print_header "Scaling down k8s-snapshots"
+scale_and_wait deployment "${K8S_SNAPSHOTS_DEPLOYMENT_NAME}" "${K8S_SNAPSHOTS_NAMESPACE}" 0
+
+print_header "Restoring disks"
+# Restore individual CouchDB disks
+restore_disks
+
+# Scale CouchDB back
+print_header "Scaling up CouchDB"
+scale_and_wait statefulset "${COUCHDB_STATEFULSET_NAME}" "${COUCHDB_NAMESPACE}" "${COUCHDB_REPLICAS}"
+
+# Check CouchDB Health
+print_header "Checking CouchDB health"
+check_couchdb_health
+
+# Scale services back
+print_header "Scaling up services"
+for d in $DEPLOYMENTS_NAMES; do
+  scale_and_wait deployment "${d}" "${DEPLOYMENTS_NAMESPACE}" 3
+done
+
+# Scale K8s snapshots back
+print_header "Scaling up k8s-snapshots"
+scale_and_wait deployment "${K8S_SNAPSHOTS_DEPLOYMENT_NAME}" "${K8S_SNAPSHOTS_NAMESPACE}" 1
+
+print_header "Done"

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -371,4 +371,10 @@ task :kiali_ui => [:configure] do
   sh "/rakefiles/scripts/kiali_ui.sh"
 end
 
+# This task restores CouchDB disks from snapshots
+task :couchdb_backup_restore, [:snapshots] => [:configure, :configure_secrets, :set_secrets] do |taskname, args|
+  ENV["COUCHDB_SOURCE_SNAPSHOTS"] = args[:snapshots] unless args[:snapshots].nil?
+  sh "/rakefiles/scripts/couchdb_backup_restore.sh"
+end
+
 # vim: et ts=2 sw=2:


### PR DESCRIPTION
This PR adds a script to automate restore of CouchDB cluster from snapshots ([GPII-4221](https://issues.gpii.net/browse/GPII-4221)).

This PR depends on https://github.com/gpii-ops/exekube/pull/71.

**PR Changes introduced:**
- Add CouchDB Backup restore script.
  The script does the following main steps (in-order):
  - (optional) Reads latest set of snapshots
  - Checks snapshots availability
  - Scales down services (flowmanager & preferences)
  - Reads CouchDB volume names
  - Scales down CouchDB
  - Scales down k8s-snapshots
  - Deletes and restores individual volumes from snapshots
  - Scales up CouchDB
  - Checks CouchDB health (both individual nodes and overall cluster membership)
  - Scales up services
  - Scales up k8s-snapshots
- Add CouchDB Backup restore rake task
- Add documentation for CouchDB Restore Backup task
- Bump exekube to 0.9.8

**Deployment:**
This is a non-disruptive deploy.

**Testing:**
Testing has been done both in `dev` and `stg` environments, and both with the latest set of snapshots being detected automatically and custom list of snapshots supplied.

_Note: The CircleCI tests will fail until the Exekube PR is merged._