### PR TITLE
GPII-4229: Disable k8s alerts till resolved

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/alert_k8s_snapshots_couchdb.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_k8s_snapshots_couchdb.tf
@@ -34,7 +34,7 @@ resource "google_monitoring_alert_policy" "k8s_snapshots_couchdb" {
 
   notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]
   user_labels           = {}
-  enabled               = "true"
+  enabled               = "false"
 
   depends_on = ["google_logging_metric.disks_createsnapshot", "google_logging_metric.k8s_snapshots_couchdb_snapshot_created"]
 }

--- a/gcp/modules/gcp-stackdriver-monitoring/alert_k8s_snapshots_errors.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_k8s_snapshots_errors.tf
@@ -29,7 +29,7 @@ resource "google_monitoring_alert_policy" "k8s_snapshots_errors" {
 
   notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]
   user_labels           = {}
-  enabled               = "true"
+  enabled               = "false"
 
   depends_on = ["google_logging_metric.k8s_snapshots_error"]
 }


### PR DESCRIPTION
This PR disables K8s snapshots alerts till [GPII-4229](https://issues.gpii.net/browse/GPII-4229) is resolved.