### PR TITLE
GPII-4102: Block egress traffic

### DIFF
--- a/gcp/modules/gpii-istio/main.tf
+++ b/gcp/modules/gpii-istio/main.tf
@@ -8,6 +8,7 @@ resource "kubernetes_namespace" "gpii" {
 
     labels {
       istio-injection = "enabled"
+      name            = "gpii"
     }
   }
 }

--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -5,9 +5,57 @@ resource "kubernetes_network_policy" "deny-default" {
   }
 
   spec {
-    pod_selector = {}
+    pod_selector {}
 
-    policy_types = ["Ingress"]
+    policy_types = ["Ingress", "Egress"]
+
+    egress {
+      # Allow egress traffic to Istio control plane
+      to {
+        namespace_selector {
+          match_labels = {
+            k8s-app = "istio"
+          }
+        }
+      }
+
+      # Allow egress traffic within namespace
+      to {
+        namespace_selector {
+          match_labels = {
+            name = "gpii"
+          }
+        }
+      }
+
+      # Allow egress traffic to dns
+      to {
+        namespace_selector {
+          match_labels = {
+            name = "kube-system"
+          }
+        }
+        pod_selector {
+          match_labels = {
+            k8s-app = "kube-dns"
+          }
+        }
+      }
+    }
+
+    egress {
+      # Allow egress traffic Compute Metadata
+      to {
+        ip_block {
+          cidr = "10.16.0.0/20"
+        }
+      }
+      ports {
+        port     = "8181"
+        protocol = "TCP"
+      }
+    }
+
   }
 }
 

--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -66,24 +66,24 @@ resource "kubernetes_network_policy" "allow-promsd-to-istio" {
   }
 
   spec {
-    pod_selector = {}
+    pod_selector {}
 
-    ingress = {
-      from = {
-        namespace_selector = {
-          match_labels {
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
             k8s-app = "istio"
           }
         }
 
-        pod_selector = {
-          match_labels {
+        pod_selector {
+          match_labels = {
             app = "promsd"
           }
         }
       }
 
-      ports = {
+      ports {
         port     = "http-envoy-prom"
         protocol = "TCP"
       }

--- a/gcp/modules/gpii-istio/network_policy.tf
+++ b/gcp/modules/gpii-istio/network_policy.tf
@@ -35,6 +35,7 @@ resource "kubernetes_network_policy" "deny-default" {
             name = "kube-system"
           }
         }
+
         pod_selector {
           match_labels = {
             k8s-app = "kube-dns"
@@ -50,12 +51,12 @@ resource "kubernetes_network_policy" "deny-default" {
           cidr = "10.16.0.0/20"
         }
       }
+
       ports {
         port     = "8181"
         protocol = "TCP"
       }
     }
-
   }
 }
 


### PR DESCRIPTION
This PR adds network policies to block egress external traffic unless it's going via the egress gateway, it's part of work on controlling egress traffic - [GPII-4102](https://issues.gpii.net/browse/GPII-4102). This will effectively bring us back to the state before GKE Istio 1.1, when any egress traffic was denied by default.

**PR Changes:**
- Block egress traffic from `gpii` namespace - egress traffic is blocked by default, there are several exceptions:
  - Egress to Istio control plane is allowed - this is required for traffic routed via Egress gateway and other Istio traffic to istio control plane
  - Egress traffic within `gpii` namespace is allowed (traffic is already controlled by ingress rules on corresponding services)
  - Egress traffic to Kube DNS service is allowed
  - Egress traffic to GCP metadata is allowed on port 8181

**Deployment:**
This is a non-disruptive deploy. (All the traffic is already routed via Egress gateway).

**Testing:**
- I've confirmed traffic is truly routed via Egress gateway and all other traffic blocked after applying blocking Network Policies.