### PR TITLE
[GPII-4224]: Exclude Google-managed SA keys from :display_scc_assets_changed output

### DIFF
--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -330,11 +330,13 @@ task :display_scc_assets_changed, [:projects, :compare_duration] => [:configure]
   projects_filter << ")"
   projects_filter = projects_filter.join
 
+  # Default filter excludes snapshots, KMS key versions, and system managed SA keys
   sh "gcloud alpha scc assets list #{ENV["ORGANIZATION_ID"]} \
     --filter ' \
       #{projects_filter} \
       AND NOT security_center_properties.resource_type = \"google.compute.snapshot\" \
       AND NOT security_center_properties.resource_type = \"google.cloud.kms.cryptokeyversion\" \
+      AND NOT resource_properties.keyType = \"SYSTEM_MANAGED\" \
     ' \
     --compare-duration #{compare_duration} \
     --format json \


### PR DESCRIPTION
This PR contains fix suggested by Google Support that excludes Google-managed SA keys from assets changed.
Unfortunately, `gcloud` filter does not work properly when I mix SCC attributes and resource properties, so I had to filter them with `jq` instead.