### PR TITLE
[GPII-4238] The mail notification channel of the devs clusters is alerts+dev

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/main.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/main.tf
@@ -25,6 +25,11 @@ variable "domain_name" {}
 variable "serviceaccount_key" {}
 variable "env" {}
 
+variable "use_auth_user_email" {
+  default = false
+}
+
+variable "auth_user_email" {}
 variable "secret_slack_auth_token" {}
 
 resource "null_resource" "destroy_old_stackdriver_resources" {

--- a/gcp/modules/gcp-stackdriver-monitoring/notification_email.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/notification_email.tf
@@ -5,7 +5,7 @@ resource "google_monitoring_notification_channel" "email" {
   type         = "email"
 
   labels = {
-    email_address = "${var.notification_email}"
+    email_address = "${(var.use_auth_user_email && var.auth_user_email != "") ? var.auth_user_email : var.notification_email}"
   }
 
   user_labels = {}


### PR DESCRIPTION
This PR use the old code that left behind the alerts upgrade.