### PR TITLE
Revert "[GPII-4205]: Upgrade k8s-snapshots to latest"

### DIFF
--- a/shared/charts/k8s-snapshots/README.md
+++ b/shared/charts/k8s-snapshots/README.md
@@ -46,7 +46,7 @@ deletes the release.
 
 ## Configuration
 
-The following table lists the configurable parameters of the k8s-snapshots
+The following table lists the configurable parameters of the gpii-dataloader
 chart and their default values.
 
 | Parameter          | Description                                                       | Default                    |

--- a/shared/charts/k8s-snapshots/templates/deployment.yaml
+++ b/shared/charts/k8s-snapshots/templates/deployment.yaml
@@ -10,10 +10,6 @@ spec:
       labels:
         app: {{ template "k8s-snapshots.name" . }}
       annotations:
-        # This annotation is needed to allow traffic to metadata.google.internal
-        # until Istio's issue with FQDNs in ServiceEntries is not resolved:
-        # https://github.com/istio/istio/issues/14404
-        traffic.sidecar.istio.io/excludeOutboundIPRanges: "169.254.169.254/32"
         {{ if .Values.serviceAccount }}accounts.google.com/service-account: {{ .Values.serviceAccount }}{{ end }}
         {{ if .Values.scopes }}accounts.google.com/scopes: {{ .Values.scopes }}{{ end }}
     spec:
@@ -22,10 +18,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-          - name: CLOUD_PROVIDER
-            value: "google"
-          - name: GCLOUD_CREDENTIALS_FILE
-            value: ""
         {{- if .Values.useClaimName }}
           - name: USE_CLAIM_NAME
             value: "true"

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -96,7 +96,7 @@ flowmanager:
 k8s_snapshots:
   upstream:
     repository: elsdoerfer/k8s-snapshots
-    tag: latest
+    tag: v2.0
   generated:
     repository: gcr.io/gpii-common-prd/elsdoerfer__k8s-snapshots
     sha: sha256:5c9a27ae0a37e0d4d0a6cb2d89e6b859af7a01ef9d9864b647fb4927e11c741e


### PR DESCRIPTION
Team noticed random spikes in amount of snapshots across multiple environments after upgrade.
This PR reverts gpii-ops/gpii-infra#531.
