### PR TITLE
[GPII-3241] Reduce alert noise

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/alert_couchdb_prometheus_exporter_exports_metric.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_couchdb_prometheus_exporter_exports_metric.tf
@@ -5,7 +5,7 @@ resource "google_monitoring_alert_policy" "couchdb_prometheus_exporter_exports_m
   conditions {
     condition_absent {
       filter   = "metric.type=\"custom.googleapis.com/couchdb/httpd_node_up\" resource.type=\"gke_container\""
-      duration = "300s"
+      duration = "${(var.env == "prd" || var.env == "stg") ? "300" : "600"}s"
 
       aggregations {
         alignment_period     = "60s"

--- a/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_uptime.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_uptime.tf
@@ -7,7 +7,7 @@ resource "google_monitoring_alert_policy" "flowmanager_uptime" {
       filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.label.host=\"flowmanager.${var.domain_name}\" AND resource.type=\"uptime_url\""
       comparison      = "COMPARISON_GT"
       threshold_value = 1.0
-      duration        = "300s"
+      duration        = "${(var.env == "prd" || var.env == "stg") ? "300" : "600"}s"
 
       aggregations {
         alignment_period     = "1200s"


### PR DESCRIPTION
Increase the time to wait for condition only in ephemeral clusters for the alerts:

- Pod `couchdb-prometheus-exporter` exports a metric 
- Uptime check on `flowmanager.alfredo.dev.gcp.gpii.net` is green


