### PR TITLE
[GPII-3681]: Leftovers and fixes for ephemeral environments

### DIFF
--- a/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
@@ -43,7 +43,7 @@ resource "google_monitoring_alert_policy" "ssl_cert_check" {
       }
 
       display_name = "Flowmanager TLS cert metric is absent"
-    }
+    },
   ]
 
   notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]

--- a/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
@@ -2,57 +2,49 @@ resource "google_monitoring_alert_policy" "ssl_cert_check" {
   display_name = "Flowmanager TLS cert is valid"
   combiner     = "OR"
 
-  conditions {
-    condition_threshold {
-      filter          = "metric.type=\"custom.googleapis.com/ssl-cert-check/certificate_days_left\" AND resource.type=\"global\" AND metric.labels.name=\"flowmanager.${var.domain_name}:443\""
-      comparison      = "COMPARISON_LT"
-      threshold_value = 28.0
-      duration        = "0s"
+  conditions = [
+    {
+      condition_threshold {
+        filter          = "metric.type=\"custom.googleapis.com/ssl-cert-check/certificate_days_left\" AND resource.type=\"global\" AND metric.labels.name=\"flowmanager.${var.domain_name}:443\""
+        comparison      = "COMPARISON_LT"
+        threshold_value = 28.0
+        duration        = "0s"
 
-      aggregations {
-        alignment_period     = "600s"
-        per_series_aligner   = "ALIGN_MEAN"
-        cross_series_reducer = "REDUCE_MIN"
+        aggregations {
+          alignment_period     = "600s"
+          per_series_aligner   = "ALIGN_MEAN"
+          cross_series_reducer = "REDUCE_MIN"
 
-        group_by_fields = [
-          "metric.labels.name",
-        ]
+          group_by_fields = [
+            "metric.labels.name",
+          ]
+        }
+
+        denominator_filter       = ""
+        denominator_aggregations = []
       }
 
-      denominator_filter       = ""
-      denominator_aggregations = []
-    }
+      display_name = "Flowmanager TLS cert is about to expire"
+    },
+    {
+      condition_absent {
+        filter   = "metric.type=\"custom.googleapis.com/ssl-cert-check/certificate_days_left\" AND resource.type=\"global\" AND metric.labels.name=\"flowmanager.${var.domain_name}:443\""
+        duration = "86400s"
 
-    display_name = "Flowmanager TLS cert is about to expire"
-  }
+        aggregations {
+          alignment_period     = "600s"
+          per_series_aligner   = "ALIGN_MEAN"
+          cross_series_reducer = "REDUCE_MIN"
 
-  notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]
-  user_labels           = {}
-  enabled               = "true"
-}
-
-resource "google_monitoring_alert_policy" "ssl_cert_check_absense" {
-  display_name = "Flowmanager TLS cert metric is present"
-  combiner     = "OR"
-
-  conditions {
-    condition_absent {
-      filter   = "metric.type=\"custom.googleapis.com/ssl-cert-check/certificate_days_left\" AND resource.type=\"global\" AND metric.labels.name=\"flowmanager.${var.domain_name}:443\""
-      duration = "86400s"
-
-      aggregations {
-        alignment_period     = "600s"
-        per_series_aligner   = "ALIGN_MEAN"
-        cross_series_reducer = "REDUCE_MIN"
-
-        group_by_fields = [
-          "metric.labels.name",
-        ]
+          group_by_fields = [
+            "metric.labels.name",
+          ]
+        }
       }
-    }
 
-    display_name = "Flowmanager TLS cert metric is absent"
-  }
+      display_name = "Flowmanager TLS cert metric is absent"
+    }
+  ]
 
   notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]
   user_labels           = {}

--- a/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
+++ b/gcp/modules/gcp-stackdriver-monitoring/alert_flowmanager_ssl_cert_check.tf
@@ -49,4 +49,5 @@ resource "google_monitoring_alert_policy" "ssl_cert_check" {
   notification_channels = ["${google_monitoring_notification_channel.email.name}", "${google_monitoring_notification_channel.alerts_slack.*.name}"]
   user_labels           = {}
   enabled               = "true"
+  count                 = "${(var.env == "prd" || var.env == "stg") ? 1 : 0}"
 }


### PR DESCRIPTION
This PR:
* Contains change that combines multiple conditions into single alert policy that I though was already committed to #548 
* Prevents TF from creating `ssl-cert-check` alert policy for ephemeral envs: Stackdriver is [not happy](https://gitlab.com/gpii-ops/gpii-infra/-/jobs/360834150) when we try to create alert policy based on custom metric that is not yet exists. This fix is needed to unblock the pipeline, I'll work on permanent solution later.