### PR TITLE
[GPII-4205]: Use k8s-snapshots:0.2.1-gpii.0

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -103,7 +103,7 @@ flowmanager:
     tag: 20191122122513-d141625
 k8s_snapshots:
   upstream:
-    repository: gpii-ops/k8s-snapshots
+    repository: gpii/k8s-snapshots
     tag: 0.2.1-gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/elsdoerfer__k8s-snapshots

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -103,8 +103,8 @@ flowmanager:
     tag: 20191122122513-d141625
 k8s_snapshots:
   upstream:
-    repository: elsdoerfer/k8s-snapshots
-    tag: v2.0
+    repository: gpii-ops/k8s-snapshots
+    tag: 0.2.1-gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/elsdoerfer__k8s-snapshots
     sha: sha256:06ceb13d357ef689cd4ecfa17d20f6cd7874554c6da4dfad7bd56cd005e4e452


### PR DESCRIPTION
My [previous attempt](https://github.com/gpii-ops/gpii-infra/pull/531) to solve `k8s-snapshots` security issues was [not very successful](https://github.com/gpii-ops/gpii-infra/pull/555).

New image is a better solution: https://github.com/gpii-ops/k8s-snapshots/pull/1

In progress, because I need some time to test it in my dev cluster.