### PR TITLE
GPII-3850: Use new 0.9.9. exekube image - fix missing bin-auth whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.8-google_gpii.0
+  - image: gpii/exekube:0.9.9-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.8-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.9-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.8-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.9-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.8-google_gpii.0
+    image: gpii/exekube:0.9.9-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.8-google_gpii.0
+    image: gpii/exekube:0.9.9-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}


### PR DESCRIPTION
This PR adds missing `gke.grc.io` rule to the Bin-auth whitelisted images patterns and fixes one of the errors observed in [GPII-3850](https://issues.gpii.net/browse/GPII-3850).

```
Failed:
Create pod
kube-proxy-gke-k8s-cluster-terraform-20190319173-571935b8-99sf failed to be created
```

This PR depends on https://github.com/gpii-ops/exekube/pull/72.

**Changes:**
- Bump Exekube version to 0.9.9 - adds `gke.grc.io` to whitelisted registries

**Deployment:**
This is a no-downtime deployment.

**Testing:**
This change has been tested in dev cluster.

_Note: the tests are only expected to pass once the https://github.com/gpii-ops/exekube/pull/72 is merged._