### PR TITLE
GPII-4262: Deploy revised validation endpoints.

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -80,27 +80,27 @@ couchdb:
 dataloader:
   upstream:
     repository: gpii/universal
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
     sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
 flushtokens:
   upstream:
     repository: gpii/universal
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
     sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
 flowmanager:
   upstream:
     repository: gpii/universal
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
     sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
 k8s_snapshots:
   upstream:
     repository: gpii/k8s-snapshots
@@ -120,11 +120,11 @@ locust:
 preferences:
   upstream:
     repository: gpii/universal
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
   generated:
     repository: gcr.io/gpii-common-prd/gpii__universal
     sha: sha256:1d10740602c8585ba5477631150b6b06a7ea4cfceb6423083955e5fb45b2af88
-    tag: 20190809170605-f8485e9
+    tag: 20191211142940-0af24fa
 service_account_assigner:
   upstream:
     repository: gpii/service-account-assigner


### PR DESCRIPTION
See [GPII-4262](https://issues.gpii.net/browse/GPII-4262) for more details, including verification procedures.

My idea is that this would be deployed on Monday, December 16th, 2019.  I will comment with performance tests and QA results shortly.