### PR TITLE
GPII-3850: Use new 0.9.10 exekube image - fix additional missing bin-auth rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.9-google_gpii.0
+  - image: gpii/exekube:0.9.10-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.9-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.10-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.9-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.10-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.9-google_gpii.0
+    image: gpii/exekube:0.9.10-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.9-google_gpii.0
+    image: gpii/exekube:0.9.10-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}


### PR DESCRIPTION
This PR adds missing `gke.grc.io/istio/prometheus/*` rule to the Bin-auth whitelisted images and
fixes the additional error observed in [GPII-3850](https://issues.gpii.net/browse/GPII-3850).

```
pods "promsd-76f8d4cff8-6jmsv" is forbidden: image policy webhook backend denied one or more images: Denied by default admission rule. Overridden by evaluation mode. Denied by default admission rule. Overridden by evaluation mode
```

This PR depends on https://github.com/gpii-ops/exekube/pull/73.

**Changes:**
- Bump Exekube version to 0.9.10 - adds `gke.grc.io/istio/prometheus/*` to whitelisted registries

**Deployment:**
This is a no-downtime deployment.

**Testing:**
This change has been tested in the dev cluster.

_Note: the tests are only expected to pass once the https://github.com/gpii-ops/exekube/pull/73 is merged._