### PR TITLE
[GPII-4158]: Export preferences and flowmanager logs containing GPII keys to BigQuery

### DIFF
--- a/gcp/modules/gcp-stackdriver-export/gpii_key.tf
+++ b/gcp/modules/gcp-stackdriver-export/gpii_key.tf
@@ -1,3 +1,7 @@
+# The resources below are temporary and needed so we can collect
+# and analyze some data about individual GPII keys usage.
+# More info: https://issues.gpii.net/browse/GPII-4158
+
 provider "google" {
   project     = "${var.project_id}"
   credentials = "${var.serviceaccount_key}"

--- a/gcp/modules/gcp-stackdriver-export/gpii_key.tf
+++ b/gcp/modules/gcp-stackdriver-export/gpii_key.tf
@@ -1,0 +1,22 @@
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
+resource "google_bigquery_dataset" "this" {
+  dataset_id = "exported_logs_with_gpii_key"
+  location   = "US"
+}
+
+resource "google_logging_project_sink" "this" {
+  name        = "gpii-key"
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.this.dataset_id}"
+  filter      = "textPayload:\"gpiiKey: '\" AND resource.type=\"k8s_container\" AND (resource.labels.container_name=\"preferences\" OR resource.labels.container_name=\"flowmanager\")"
+
+  unique_writer_identity = true
+}
+
+resource "google_project_iam_member" "this" {
+  member  = "${google_logging_project_sink.this.writer_identity}"
+  role    = "roles/bigquery.dataEditor"
+}

--- a/gcp/modules/gcp-stackdriver-export/gpii_key.tf
+++ b/gcp/modules/gcp-stackdriver-export/gpii_key.tf
@@ -3,20 +3,20 @@ provider "google" {
   credentials = "${var.serviceaccount_key}"
 }
 
-resource "google_bigquery_dataset" "this" {
+resource "google_bigquery_dataset" "gpii_key" {
   dataset_id = "exported_logs_with_gpii_key"
   location   = "US"
 }
 
-resource "google_logging_project_sink" "this" {
+resource "google_logging_project_sink" "gpii_key" {
   name        = "gpii-key"
-  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.this.dataset_id}"
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.gpii_key.dataset_id}"
   filter      = "textPayload:\"gpiiKey: '\" AND resource.type=\"k8s_container\" AND (resource.labels.container_name=\"preferences\" OR resource.labels.container_name=\"flowmanager\")"
 
   unique_writer_identity = true
 }
 
-resource "google_project_iam_member" "this" {
-  member = "${google_logging_project_sink.this.writer_identity}"
+resource "google_project_iam_member" "gpii_key" {
+  member = "${google_logging_project_sink.gpii_key.writer_identity}"
   role   = "roles/bigquery.dataEditor"
 }

--- a/gcp/modules/gcp-stackdriver-export/gpii_key.tf
+++ b/gcp/modules/gcp-stackdriver-export/gpii_key.tf
@@ -17,6 +17,6 @@ resource "google_logging_project_sink" "this" {
 }
 
 resource "google_project_iam_member" "this" {
-  member  = "${google_logging_project_sink.this.writer_identity}"
-  role    = "roles/bigquery.dataEditor"
+  member = "${google_logging_project_sink.this.writer_identity}"
+  role   = "roles/bigquery.dataEditor"
 }


### PR DESCRIPTION
This PR adds BigQuery dataset and configures Stackdriver logging sink to export preferences and flowmanager container logs containing GPII keys. Entire thing is temporary and only needed so I can collect and analyze data regarding individual key usage.

Exekube's `gcp-stackdriver-export` module does not support BigQuery exports – I tried to fix this, but now abandoned this idea, because supporting both GS and BigQuery sinks requires module refactoring that probably does not worth the effort atm.