### PR TITLE
GPII-4280: Fix bigquery api error

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -51,7 +51,7 @@ variable "ci_dev_project_regex" {
 
 variable "service_apis" {
   default = [
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "bigquerystorage.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudbilling.googleapis.com",


### PR DESCRIPTION
This PR fixes error observed in CI:
```
Error: Error applying plan:
1386 1 error occurred:
1387 	* google_project_services.project: 1 error occurred:
1388 	* google_project_services.project: Error updating services: googleapi: Error 503: The service(s) ["bigquery-json.googleapis.com"] are still being enabled for project gpii2test-gcp-prd. This isn't a real API error, this is just eventual consistency.
```

This issue is caused By Google's rename of `bigquery-json.googleapis.com` to `bigquery.googleapis.com`  - see https://cloud.google.com/bigquery/docs/release-notes#October_23_2019 for details.