### PR TITLE
[GPII-4158]: Add missing permission to projectowner SA

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -443,6 +443,16 @@ data "google_iam_policy" "combined" {
     ]
   }
 
+  # This permission should be removed once the ticket is closed.
+  # More info: https://issues.gpii.net/browse/GPII-4158
+  binding {
+    role = "roles/bigquery.admin"
+
+    members = [
+      "${local.service_accounts}",
+    ]
+  }
+
   audit_config {
     service = "allServices"
 


### PR DESCRIPTION
Discrepancy between dev workflow and CI with everything related to common part is a bit annoying...