### PR TITLE
GPII-4270: Upgrade to 1.13.11-gke.15 - fixes Istio CVEs

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -78,7 +78,10 @@ module "gke_cluster" {
   project_id         = "${var.project_id}"
   serviceaccount_key = "${var.serviceaccount_key}"
 
-  kubernetes_version = "${data.external.gke_version_assert.result.version}"
+  # This is temporary till 1.13.11-gke.15 or newer is released as default
+  # fixes security vulnerabilities https://istio.io/news/security/istio-security-2019-007/
+  # kubernetes_version = "${data.external.gke_version_assert.result.version}"
+  kubernetes_version = "1.13.11-gke.15"
 
   region = "${var.infra_region}"
 


### PR DESCRIPTION
This PR upgrades GKE clusters to `1.13.11-gke.15`. This version includes Istio `1.1.17` which fixes known security issues, see https://istio.io/news/security/istio-security-2019-007/ for details. ([GPII-3850](https://issues.gpii.net/browse/GPII-3850)).

The fixed GKE version should be removed, once the `1.13.11-gke.15` or newer becomes default (comment added in the code).

**Changes:**
- Bump GKE to fixed version to `1.13.11-gke.15` -  includes Istio `1.1.17`

**Deployment:**
This is a no-downtime deployment.

**Testing:**
This change has been tested in dev cluster.