### PR TITLE
[GPII-4158]: Fix conflicting IAM entities

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -443,13 +443,21 @@ data "google_iam_policy" "combined" {
     ]
   }
 
-  # This permission should be removed once the ticket is closed.
+  # Permissions below should be removed once the ticket is closed.
   # More info: https://issues.gpii.net/browse/GPII-4158
   binding {
     role = "roles/bigquery.admin"
 
     members = [
       "${local.service_accounts}",
+    ]
+  }
+
+  binding {
+    role = "roles/bigquery.dataEditor"
+
+    members = [
+      "serviceAccount:cloud-logs@system.gserviceaccount.com",
     ]
   }
 

--- a/gcp/modules/gcp-stackdriver-export/gpii_key.tf
+++ b/gcp/modules/gcp-stackdriver-export/gpii_key.tf
@@ -18,11 +18,4 @@ resource "google_logging_project_sink" "gpii_key" {
   name        = "gpii-key"
   destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.gpii_key.dataset_id}"
   filter      = "textPayload:\"gpiiKey: '\" AND resource.type=\"k8s_container\" AND (resource.labels.container_name=\"preferences\" OR resource.labels.container_name=\"flowmanager\")"
-
-  unique_writer_identity = true
-}
-
-resource "google_project_iam_member" "gpii_key" {
-  member = "${google_logging_project_sink.gpii_key.writer_identity}"
-  role   = "roles/bigquery.dataEditor"
 }


### PR DESCRIPTION
This PR fixes a conflict between authoritative `google_project_iam_policy` of the common code and unique writer IAM member of the Stackdriver BigQuery logging sink.

I haven't found a way to resolve this conflict without introducing unnecessary cohesion between common code and GCP part, but considering temporary nature of the these resources, I think we can sacrifice `unique_writer_identity` of the sink and grant required permissions to Stackdriver Logging agent instead.