### PR TITLE
[GPII-4211]: Override NS records created by google_dns_managed_zone to set proper TTL

### DIFF
--- a/common/modules/gcp-dns/main.tf
+++ b/common/modules/gcp-dns/main.tf
@@ -38,7 +38,7 @@ resource "google_dns_managed_zone" "root_zone" {
 # Override NS record created by google_dns_managed_zone
 # to set proper TTL
 resource "google_dns_record_set" "root_zone" {
-  name         = "${google_dns_managed_zone.root_zone.dns_name}."
+  name         = "${google_dns_managed_zone.root_zone.dns_name}"
   managed_zone = "${google_dns_managed_zone.root_zone.name}"
   type         = "NS"
   ttl          = 3600
@@ -86,7 +86,7 @@ resource "google_dns_managed_zone" "main" {
 # Override NS record created by google_dns_managed_zone
 # to set proper TTL
 resource "google_dns_record_set" "main" {
-  name         = "${google_dns_managed_zone.main.dns_name}."
+  name         = "${google_dns_managed_zone.main.dns_name}"
   managed_zone = "${google_dns_managed_zone.main.name}"
   type         = "NS"
   ttl          = 3600

--- a/common/modules/gcp-dns/main.tf
+++ b/common/modules/gcp-dns/main.tf
@@ -28,7 +28,7 @@ provider "google" {
 resource "google_dns_managed_zone" "root_zone" {
   name        = "${replace(var.organization_domain, ".", "-")}"
   dns_name    = "${var.organization_domain}."
-  description = "root ${var.organization_domain} DNS zone"
+  description = "Root ${var.organization_domain} DNS zone"
 
   lifecycle {
     prevent_destroy = "true"
@@ -76,7 +76,7 @@ resource "google_dns_record_set" "ns_main" {
 resource "google_dns_managed_zone" "main" {
   name        = "gcp-${replace(var.organization_domain, ".", "-")}"
   dns_name    = "gcp.${var.organization_domain}."
-  description = "gcp DNS zone"
+  description = "Main GCP part DNS zone"
 
   lifecycle {
     prevent_destroy = "true"

--- a/common/modules/gcp-dns/main.tf
+++ b/common/modules/gcp-dns/main.tf
@@ -35,6 +35,18 @@ resource "google_dns_managed_zone" "root_zone" {
   }
 }
 
+# Override NS record created by google_dns_managed_zone
+# to set proper TTL
+resource "google_dns_record_set" "root_zone" {
+  name         = "${google_dns_managed_zone.root_zone.dns_name}."
+  managed_zone = "${google_dns_managed_zone.root_zone.name}"
+  type         = "NS"
+  ttl          = 3600
+  project      = "${var.project_id}"
+  rrdatas      = ["${google_dns_managed_zone.root_zone.name_servers}"]
+  depends_on   = ["google_dns_managed_zone.root_zone"]
+}
+
 # Only needed to create the NS registry of test.gpii.net in gpii.net zone
 data "google_dns_managed_zone" "test_gpii_net" {
   count   = "${replace(var.organization_domain, "/^gpii.net/", "") == "" ? 1 : 0}"
@@ -69,6 +81,18 @@ resource "google_dns_managed_zone" "main" {
   lifecycle {
     prevent_destroy = "true"
   }
+}
+
+# Override NS record created by google_dns_managed_zone
+# to set proper TTL
+resource "google_dns_record_set" "main" {
+  name         = "${google_dns_managed_zone.main.dns_name}."
+  managed_zone = "${google_dns_managed_zone.main.name}"
+  type         = "NS"
+  ttl          = 3600
+  project      = "${var.project_id}"
+  rrdatas      = ["${google_dns_managed_zone.main.name_servers}"]
+  depends_on   = ["google_dns_managed_zone.main"]
 }
 
 output "gcp_name_servers" {

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -544,6 +544,18 @@ resource "google_dns_managed_zone" "project" {
   ]
 }
 
+# Override NS record created by google_dns_managed_zone
+# to set proper TTL
+resource "google_dns_record_set" "project" {
+  name         = "${local.dnsname}."
+  managed_zone = "${google_dns_managed_zone.project.name}"
+  type         = "NS"
+  ttl          = 3600
+  project      = "${google_project.project.project_id}"
+  rrdatas      = ["${google_dns_managed_zone.project.name_servers}"]
+  depends_on   = ["google_dns_managed_zone.project"]
+}
+
 # Set the NS records in the parent zone of the parent project if the
 # project_name has the pattern ${env}-${user}
 resource "google_dns_record_set" "ns" {


### PR DESCRIPTION
This PR adds record sets to override all NS records created by `google_dns_managed_zone` primitives to set the proper TTL (3600) instead of default one (21600).

It is impossible to set TTL for the records created by `google_dns_managed_zone`:
https://github.com/terraform-providers/terraform-provider-google/issues/5280
 
However, as it turns out, TF does not care about DNS records, created by `google_dns_managed_zone`  – as long as the zone entity is unchanged, other records can be modified without causing a conflict.

I tested this running common part only for my project – deployment should be seamless. 