### PR TITLE
[GPII-3946]: Add exekube image to version-updater config

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -5,6 +5,14 @@
 # See the README for details on how to modify which images are used or to add
 # components.
 ---
+exekube:
+  upstream:
+    # The following comment is needed, so exekube version checker script
+    # can properly process this file as well, since it mentions image in different format:
+    #
+    # gpii/exekube:0.9.11-google_gpii.0
+    repository: gpii/exekube
+    tag: 0.9.11-google_gpii.0
 cert_manager:
   upstream:
     repository: quay.io/jetstack/cert-manager-controller


### PR DESCRIPTION
This PR adds exekube to versions file, so version-updater can upload it to GCR, where it will be scanned for vulnerabilities.

I tried to fix exekube version checker script to work properly with version-updater image format, but it turns out that find is pretty bad with multiline regex, hence the workaround with the comment.