### PR TITLE
[GPII-3946]: Use exekube from GCR registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gpii/exekube:0.9.11-google_gpii.0
+  - image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gpii/exekube:0.9.11-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gpii/exekube:0.9.11-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.11-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gpii/exekube:0.9.11-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/shared/rakefiles/scripts/check_exekube_versions.sh
+++ b/shared/rakefiles/scripts/check_exekube_versions.sh
@@ -3,7 +3,7 @@
 # This script verifies that only one version of exekube is being used across the project
 
 EXCLUDE_DIRS=".git"
-IMAGE_REGEX="gpii/exekube:\d+\.\d+\.\d+-google_gpii\.\d+"
+IMAGE_REGEX="gcr.io/gpii-common-prd/gpii__exekube:\d+\.\d+\.\d+-google_gpii\.\d+"
 
 images=$(find . \( -name "$EXCLUDE_DIRS" -prune \) -o -type f -exec grep -h -o -E "$IMAGE_REGEX" {} \; | sort -u)
 images_count=$(echo "$images" | wc -l | awk '{ print $1 }')


### PR DESCRIPTION
This PR updates all components in the project to use exekube image from GCR and fixes exekube version checker script.