### PR TITLE
GPII-3718: add credentials to Google provider

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -2,6 +2,11 @@ terraform {
   backend "gcs" {}
 }
 
+provider "google" {
+  project     = "${var.project_id}"
+  credentials = "${var.serviceaccount_key}"
+}
+
 variable "env" {}
 variable "project_id" {}
 variable "serviceaccount_key" {}


### PR DESCRIPTION
Hot fix to solve this issue:
```
 Error: Error running plan: 1 error occurred:
	* provider.google: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```
https://gitlab.com/gpii-ops/gpii-infra/-/jobs/410504806