### PR TITLE
GPII-4282: Upgrade certmerge-operator image

### DIFF
--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -24,7 +24,7 @@ cert_manager:
 certmerge_operator:
   upstream:
     repository: gpii/certmerge-operator
-    tag: 0.0.3-gpii.0
+    tag: 0.0.3-gpii.1
   generated:
     repository: gcr.io/gpii-common-prd/gpii__certmerge-operator
     sha: sha256:0b794c687b07b078b6f10d451c81c2fb83bd3c93cf7540fe863910fac1a6d101


### PR DESCRIPTION
This PR upgrades `certmerge-operator` image.

Depends on https://github.com/gpii-ops/docker-image-certmerge-operator/pull/2.

**Changes introduced:**
- There are no functional changes introduced in this PR, the `certmerge-operator` itself and image have been updated, see details in https://github.com/gpii-ops/docker-image-certmerge-operator/pull/2 and https://github.com/gpii-ops/certmerge-operator/pull/1.

**Testing:**
The change has been tested in a dev environment.