### PR TITLE
[GPII-4159] Add locust configs simulating default morphic behaviors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ shared/charts/locust/tasks/*
 tags
 vendor/
 __pycache__
+*.pyc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -235,6 +235,8 @@ gcp-stg:
     - rake
     - rake test_preferences_read
     - rake test_flowmanager
+    - rake test_morphic_write
+    - rake test_morphic_read
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/stg
@@ -304,6 +306,8 @@ gcp-prd:
     - rake
     - rake test_preferences_read RAKE_REALLY_DESTROY_IN_PRD=true
     - rake test_flowmanager RAKE_REALLY_DESTROY_IN_PRD=true
+    - rake test_morphic_write RAKE_REALLY_DESTROY_IN_PRD=true
+    - rake test_morphic_read RAKE_REALLY_DESTROY_IN_PRD=true
   after_script:
     # Clean up even if something failed.
     - cd gcp/live/prd

--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -168,8 +168,9 @@ resource "null_resource" "couchdb_finish_cluster" {
         if [ "$STATUS" != '"Cluster is already finished"' ]; then
           sleep 10
         else
+          echo "Trying to create ${var.release_namespace} DB..."
           curl -s -X PUT $COUCHDB_URL/${var.release_namespace} || true
-
+          echo "Trying to load default morphic credentials into ${var.release_namespace} DB..."
           echo '${data.template_file.morphic_credentials.rendered}' | curl -s -d @- \
             -H "Content-type: application/json" \
             -X POST $COUCHDB_URL/${var.release_namespace}/_bulk_docs || true

--- a/gcp/modules/couchdb/morphic_credentials.json
+++ b/gcp/modules/couchdb/morphic_credentials.json
@@ -1,0 +1,29 @@
+{
+  "docs": [
+    {
+      "_id": "locustCredential",
+      "type": "clientCredential",
+      "schemaVersion": "0.2",
+      "clientId": "locust",
+      "oauth2ClientId": "${morphic_client_id}",
+      "oauth2ClientSecret": "${morphic_client_secret}",
+      "allowedIPBlocks": null,
+      "allowedPrefsToWrite": null,
+      "isCreateGpiiKeyAllowed": true,
+      "isCreatePrefsSafeAllowed": true,
+      "revoked": false,
+      "revokedReason": null,
+      "timestampCreated": "${timestamp}",
+      "timestampRevoked": null
+    },
+    {
+      "_id": "locust",
+      "type": "gpiiAppInstallationClient",
+      "schemaVersion": "0.2",
+      "name": "Locust",
+      "computerType": "public",
+      "timestampCreated": "${timestamp}",
+      "timestampUpdated": null
+    }
+  ]
+}

--- a/gcp/modules/couchdb/secrets.yaml
+++ b/gcp/modules/couchdb/secrets.yaml
@@ -2,4 +2,6 @@ secrets:
   - secret_couchdb_admin_username
   - secret_couchdb_admin_password
   - secret_couchdb_auth_cookie
+  - uuid_morphic_client_id
+  - uuid_morphic_client_secret
 encryption_key: default

--- a/gcp/modules/locust/main.tf
+++ b/gcp/modules/locust/main.tf
@@ -11,6 +11,9 @@ variable "nonce" {}
 variable "locust_repository" {}
 variable "locust_tag" {}
 
+variable "uuid_morphic_client_id" {}
+variable "uuid_morphic_client_secret" {}
+
 resource "null_resource" "locust_copy_tasks" {
   triggers = {
     nonce = "${var.nonce}"
@@ -31,11 +34,13 @@ data "template_file" "locust_values" {
   template = "${file("values.yaml")}"
 
   vars {
-    locust_repository = "${var.locust_repository}"
-    locust_tag        = "${var.locust_tag}"
-    locust_workers    = "${var.locust_workers}"
-    target_host       = "${var.locust_target_host}"
-    locust_script     = "${var.locust_script}"
+    locust_repository     = "${var.locust_repository}"
+    locust_tag            = "${var.locust_tag}"
+    locust_workers        = "${var.locust_workers}"
+    target_host           = "${var.locust_target_host}"
+    locust_script         = "${var.locust_script}"
+    morphic_client_id     = "${var.uuid_morphic_client_id}"
+    morphic_client_secret = "${var.uuid_morphic_client_secret}"
   }
 }
 

--- a/gcp/modules/locust/tasks/common.py
+++ b/gcp/modules/locust/tasks/common.py
@@ -1,0 +1,42 @@
+import os
+from random import randint
+
+class MorphicCommon:
+    settings_gets = [
+      "%7B%22solutions%22%3A%5B%7B%22id%22%3A%22com.microsoft.windows.desktopBackground%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.desktopBackgroundColor%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mirrorScreen%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.cursors%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.colorFilters%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.filterKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.highContrast%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.audioDescription%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.notificationDuration%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.language%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.toggleKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.underlineMenuShortcuts%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.shortcutWarningMessage%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.shortcutWarningSound%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.magnifier%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseSettings%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.mouseTrailing%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.narrator%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.nightScreen%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.soundSentry%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.onscreenKeyboard%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenDPI%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.screenResolution%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.stickyKeys%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.touchPadSettings%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.typingEnhancement%22%7D%2C%7B%22id%22%3A%22com.microsoft.windows.volumeControl%22%7D%2C%7B%22id%22%3A%22net.gpii.test.speechControl%22%7D%2C%7B%22id%22%3A%22net.gpii.explode%22%7D%2C%7B%22id%22%3A%22net.gpii.uioPlus%22%7D%2C%7B%22id%22%3A%22trace.easyOne.communicator.windows%22%7D%2C%7B%22id%22%3A%22trace.easyOne.sudan.windows%22%7D%2C%7B%22id%22%3A%22webinsight.webAnywhere.windows%22%7D%2C%7B%22id%22%3A%22com.microsoft.office%22%7D%5D%2C%22OS%22%3A%7B%22id%22%3A%22win32%22%2C%22version%22%3A%2210.0.18362%22%7D%7D"
+    ]
+
+    settings_puts = [
+      {
+          "contexts": {
+              "gpii-default": {
+                  "preferences": {
+                      "http://registry.gpii.net/common/DPIScale": 2
+                  }
+              }
+          }
+      }
+    ]
+
+    def __init__(self):
+        self.username = "locust" + str(randint(1,10000))
+
+        client_id = os.getenv('LOCUST_CLIENT_ID')
+        if not client_id:
+            client_id = '05388544-a7af-4377-a18a-b29ce68211c5'
+        self.client_id = client_id
+
+        client_secret = os.getenv('LOCUST_CLIENT_SECRET')
+        if not client_secret:
+            client_secret = '19d93ac9-d274-499e-b85d-13c5ceda188e'
+        self.client_secret = client_secret
+
+def on_failure(request_type, name, response_time, response_length, exception, **kwargs):
+    print("Request: %s %s" % (request_type, name))
+    if exception.request is not None:
+        print("URL: %s" % (exception.request.url))
+    print("Exception: %s" % (exception))
+    if exception.response is not None:
+        print("Code: %s" % (exception.response.status_code))
+        print("Headers: %s" % (exception.response.headers))
+        print("Content: %s" % (exception.response.content))

--- a/gcp/modules/locust/tasks/common.py
+++ b/gcp/modules/locust/tasks/common.py
@@ -15,18 +15,32 @@ class MorphicCommon:
                   }
               }
           }
+      },
+      {
+          "contexts": {
+              "gpii-default": {
+                  "preferences": {
+                      "http://registry.gpii.net/common/DPIScale": 2,
+                      "http://registry.gpii.net/common/highContrastTheme": "white-black",
+                      "http://registry.gpii.net/applications/com.microsoft.windows.colorFilters": {
+                          "FilterType": 4
+                      },
+                      "http://registry.gpii.net/common/volume": 0.713
+                  }
+              }
+          }
       }
     ]
 
     def __init__(self):
         self.username = "locust" + str(randint(1,10000))
 
-        client_id = os.getenv('LOCUST_CLIENT_ID')
+        client_id = os.getenv('MORPHIC_CLIENT_ID')
         if not client_id:
             client_id = '05388544-a7af-4377-a18a-b29ce68211c5'
         self.client_id = client_id
 
-        client_secret = os.getenv('LOCUST_CLIENT_SECRET')
+        client_secret = os.getenv('MORPHIC_CLIENT_SECRET')
         if not client_secret:
             client_secret = '19d93ac9-d274-499e-b85d-13c5ceda188e'
         self.client_secret = client_secret

--- a/gcp/modules/locust/tasks/flowmanager.py
+++ b/gcp/modules/locust/tasks/flowmanager.py
@@ -1,7 +1,7 @@
 from locust import HttpLocust, TaskSet, task, events
 import random
 
-import on_failure
+from common import on_failure
 events.request_failure += on_failure
 
 class FlowmanagerTasks(TaskSet):

--- a/gcp/modules/locust/tasks/morphic_read.py
+++ b/gcp/modules/locust/tasks/morphic_read.py
@@ -1,0 +1,39 @@
+import json, random
+
+from locust import HttpLocust, TaskSequence, seq_task, events
+from common import MorphicCommon, on_failure
+
+events.request_failure += on_failure
+
+class MorphicReadTasks(TaskSequence):
+
+    def on_start(self):
+      self.common = MorphicCommon()
+
+    @seq_task(1)
+    def post_access_token(self):
+      response = self.client.post(
+        "/access_token",
+        {
+          "grant_type": "password",
+          "password": "dummy",
+          "client_id": self.common.client_id,
+          "client_secret": self.common.client_secret,
+          "username": self.common.username
+        }
+      )
+      self.access_token = json.loads(response.text)['access_token']
+
+    @seq_task(2)
+    def get_settings(self):
+      self.client.get(
+          "/" + self.common.username + "/settings/" + random.choice(self.common.settings_gets),
+          name = "/settings",
+          headers = {"Authorization": "Bearer " + self.access_token}
+      )
+
+
+class FlowmanagerWarmer(HttpLocust):
+  task_set = MorphicReadTasks
+  min_wait = 500
+  max_wait = 1000

--- a/gcp/modules/locust/tasks/morphic_write.py
+++ b/gcp/modules/locust/tasks/morphic_write.py
@@ -1,0 +1,44 @@
+import json, random
+
+from locust import HttpLocust, TaskSequence, seq_task, events
+from common import MorphicCommon, on_failure
+
+events.request_failure += on_failure
+
+class MorphicWriteTasks(TaskSequence):
+
+    def on_start(self):
+      self.common = MorphicCommon()
+
+    @seq_task(1)
+    def post_access_token(self):
+      response = self.client.post(
+        "/access_token",
+        {
+          "grant_type": "password",
+          "password": "dummy",
+          "client_id": self.common.client_id,
+          "client_secret": self.common.client_secret,
+          "username": self.common.username
+        }
+      )
+      self.access_token = json.loads(response.text)['access_token']
+
+    @seq_task(2)
+    def put_settings(self):
+      payload = random.choice(self.common.settings_puts)
+      self.client.put(
+          "/" + self.common.username + "/settings",
+          name = "/settings",
+          headers = {
+            "Authorization": "Bearer " + self.access_token,
+            "Content-Type": "application/json",
+          },
+          json = payload
+      )
+
+
+class FlowmanagerWarmer(HttpLocust):
+  task_set = MorphicWriteTasks
+  min_wait = 500
+  max_wait = 1000

--- a/gcp/modules/locust/tasks/on_failure.py
+++ b/gcp/modules/locust/tasks/on_failure.py
@@ -1,9 +1,0 @@
-def on_failure(request_type, name, response_time, exception, **kwargs):
-    print("Request: %s %s" % (request_type, name))
-    if exception.request is not None:
-        print("URL: %s" % (exception.request.url))
-    print("Exception: %s" % (exception))
-    if exception.response is not None:
-        print("Code: %s" % (exception.response.status_code))
-        print("Headers: %s" % (exception.response.headers))
-        print("Content: %s" % (exception.response.content))

--- a/gcp/modules/locust/tasks/preferences_read.py
+++ b/gcp/modules/locust/tasks/preferences_read.py
@@ -1,7 +1,7 @@
 from locust import HttpLocust, TaskSet, task, events
 import random
 
-import on_failure
+from common import on_failure
 events.request_failure += on_failure
 
 class PreferencesReadTasks(TaskSet):

--- a/gcp/modules/locust/tasks/preferences_write.py
+++ b/gcp/modules/locust/tasks/preferences_write.py
@@ -5,7 +5,7 @@ import json
 import time
 import string
 
-import on_failure
+from common import on_failure
 events.request_failure += on_failure
 
 def generate_random_username():

--- a/gcp/modules/locust/values.yaml
+++ b/gcp/modules/locust/values.yaml
@@ -14,3 +14,7 @@ worker:
 service:
   type: ClusterIP
   name: http-master-web
+
+morphic:
+  client_id: ${morphic_client_id}
+  client_secret: ${morphic_client_secret}

--- a/shared/charts/locust/Chart.yaml
+++ b/shared/charts/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.7.5
 maintainers:
   - name: so0k

--- a/shared/charts/locust/templates/_helpers.tpl
+++ b/shared/charts/locust/templates/_helpers.tpl
@@ -37,3 +37,14 @@ Get DNS from target-host
 {{- $match := index .Values.master.config "target-host" | toString | regexFind "//.*[^:]" -}}
 {{- $match | trimAll "/" -}}
 {{- end -}}
+
+{{/*
+Create a random string if the supplied key does not exist
+*/}}
+{{- define "locust.defaultsecret" -}}
+{{- if . -}}
+{{- . | b64enc | quote -}}
+{{- else -}}
+{{- randAlphaNum 20 | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/shared/charts/locust/templates/secrets.yaml
+++ b/shared/charts/locust/templates/secrets.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.morphic }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "locust.fullname" . }}
+  labels:
+    app: {{ template "locust.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  morphic_client_id: {{ template "locust.defaultsecret" .Values.morphic.client_id }}
+  morphic_client_secret: {{ template "locust.defaultsecret" .Values.morphic.client_secret }}
+{{- end }}

--- a/shared/charts/locust/templates/worker-deploy.yaml
+++ b/shared/charts/locust/templates/worker-deploy.yaml
@@ -45,6 +45,18 @@ spec:
           value: "{{ .Values.service.internalPort }}"
         - name: TARGET_HOST
           value: {{ index .Values.master.config "target-host" | quote }}
+        {{- if .Values.morphic }}
+        - name: MORPHIC_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "locust.fullname" . }}
+              key: morphic_client_id
+        - name: MORPHIC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "locust.fullname" . }}
+              key: morphic_client_secret
+        {{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
       restartPolicy: Always

--- a/shared/charts/locust/values.yaml
+++ b/shared/charts/locust/values.yaml
@@ -41,3 +41,7 @@ worker:
   target:
     labels:
     namespace: gpii
+
+# morphic:
+#   client_id:
+#   client_secret:

--- a/shared/rakefiles/ci.rake
+++ b/shared/rakefiles/ci.rake
@@ -56,6 +56,8 @@ task :destroy_hard_and_deploy_ci => [:set_vars_ci] do
     Rake::Task["test_preferences_read"].invoke
     Rake::Task["test_preferences_write"].invoke
     Rake::Task["test_flowmanager"].invoke
+    Rake::Task["test_morphic_write"].invoke
+    Rake::Task["test_morphic_read"].invoke
     Rake::Task["display_cluster_state"].invoke
     Rake::Task["destroy_hard"].reenable
     Rake::Task["destroy_hard"].invoke

--- a/shared/rakefiles/entrypoint.rake
+++ b/shared/rakefiles/entrypoint.rake
@@ -95,6 +95,8 @@ task :display_cluster_info => [:set_vars] do
   puts
   puts "Run `rake test_preferences_read` to execute Locust read tests for Preferences."
   puts "Run `rake test_preferences_write` to execute Locust write tests for Preferences."
+  puts "Run `rake test_morphic_read` to execute Locust tests for Flowmanager simulating morphic read load."
+  puts "Run `rake test_morphic_write` to execute Locust tests for Flowmanager simulating morphic write load."
   puts "Run `rake test_flowmanager` to execute Locust tests for Flowmanager."
   puts
   puts "Run `rake destroy` to delete all the expensive resources created by the deployment."

--- a/shared/rakefiles/secrets.rb
+++ b/shared/rakefiles/secrets.rb
@@ -78,9 +78,9 @@ class Secrets
         collected_secrets[encryption_key] = module_secrets['secrets']
       end
       module_secrets['secrets'].each do |secret_name|
-        if !(secret_name.start_with?("secret_") || secret_name.start_with?("key_"))
+        if !(secret_name.start_with?("secret_") || secret_name.start_with?("key_") || secret_name.start_with?("uuid_"))
           raise "ERROR: Can not use secret with name '#{secret_name}' for module '#{module_name}'!\n \
-            Secret name must start with 'secret_' or 'key_'!"
+            Secret name must start with 'secret_', 'key_' or 'uuid_'!"
         elsif secrets_to_modules.include? secret_name
           raise "ERROR: Can not use secret with name '#{secret_name}' for module '#{module_name}'!\n \
             Secret '#{secret_name}' is already in use by module '#{secrets_to_modules[secret_name]}'!"
@@ -172,6 +172,8 @@ class Secrets
         if secret_name.start_with?("key_")
           key = OpenSSL::Cipher::AES256.new.encrypt.random_key
           secret_value = Base64.strict_encode64(key)
+        elsif secret_name.start_with?("uuid_")
+          secret_value = SecureRandom.uuid
         else
           secret_value = SecureRandom.hex
         end

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -58,4 +58,38 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed] do
   Rake::Task[:test].invoke
 end
 
+desc "[TEST] Run Locust swarm simulating typical morphic client preferences read load"
+task :test_morphic_read => [:set_vars, :check_destroy_allowed] do
+  ENV["TF_VAR_locust_target_host"] = "https://flowmanager.#{ENV["TF_VAR_domain_name"]}"
+  ENV["TF_VAR_locust_target_app"] = "morphic_read"
+  ENV["TF_VAR_locust_script"] = "morphic_read.py"
+  ENV["TF_VAR_locust_users"] = "5"
+  ENV["TF_VAR_locust_hatch_rate"] = "5"
+  ENV["TF_VAR_locust_desired_total_rps"] = "3"
+  ENV["TF_VAR_locust_desired_median_response_time"] = "500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+
+  Rake::Task[:set_compose_env].reenable
+  Rake::Task[:set_compose_env].invoke
+  Rake::Task[:test].reenable
+  Rake::Task[:test].invoke
+end
+
+desc "[TEST] Run Locust swarm simulating typical morphic client preferences write load"
+task :test_morphic_write => [:set_vars, :check_destroy_allowed] do
+  ENV["TF_VAR_locust_target_host"] = "https://flowmanager.#{ENV["TF_VAR_domain_name"]}"
+  ENV["TF_VAR_locust_target_app"] = "morphic_write"
+  ENV["TF_VAR_locust_script"] = "morphic_write.py"
+  ENV["TF_VAR_locust_users"] = "5"
+  ENV["TF_VAR_locust_hatch_rate"] = "5"
+  ENV["TF_VAR_locust_desired_total_rps"] = "3"
+  ENV["TF_VAR_locust_desired_median_response_time"] = "500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+
+  Rake::Task[:set_compose_env].reenable
+  Rake::Task[:set_compose_env].invoke
+  Rake::Task[:test].reenable
+  Rake::Task[:test].invoke
+end
+
 # vim: et ts=2 sw=2:

--- a/shared/rakefiles/tests/spec/secrets_spec.rb
+++ b/shared/rakefiles/tests/spec/secrets_spec.rb
@@ -71,9 +71,10 @@ describe Secrets do
     fake_project_id = "fakeorg-fakecloud-fakeenv-fakeuser"
     fake_infra_region = "mars-north1"
     secrets = Secrets.new(fake_project_id, fake_infra_region)
-    secrets.populate_secrets(["secret_foo", "key_bar"])
+    secrets.populate_secrets(["secret_foo", "key_bar", "uuid_baz"])
 
     expect(ENV["TF_VAR_secret_foo"].length).to be(32)
+    expect(ENV["TF_VAR_uuid_baz"].length).to be(36)
 
     expect {
       decipher = OpenSSL::Cipher::AES.new(256, :CBC)


### PR DESCRIPTION
This PR:
* Adds new locust configs to simulate default morphic behaviors.
* Adds functionality to generate uuids to secrets module.
* Fixes secrets rspecs.
* Adds functionality to generate and load morphic credentials for locust to couchdb module.
* Patches locust chart to set morphic env variables for worker deployment.
* Updates CI configs to include new load tests.

After some consideration I decided to not worry about post-test cleanup for now: generated access tokens will expire and got collected by flush tokens job, and few extra thousands prefsets will be reused by locust and it is fine to leave them in DB for static environments.

I tested entire CI workflow in my dev cluster, and have not found any issues.