### PR TITLE
[GPII-4159]: Relax locust thresholds

### DIFF
--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -17,7 +17,7 @@ task :test_preferences_read => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_target_app"] = "preferences"
   ENV["TF_VAR_locust_script"] = "preferences_read.py"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "3000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -32,7 +32,7 @@ task :test_preferences_write => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_script"] = "preferences_write.py"
   ENV["TF_VAR_locust_desired_total_rps"] = "10"
   ENV["TF_VAR_locust_desired_median_response_time"] = "2000"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "3000"
   ENV["TF_VAR_locust_users"] = "25"
   ENV["TF_VAR_locust_hatch_rate"] = "5"
 
@@ -50,7 +50,7 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_users"] = "15"
   ENV["TF_VAR_locust_desired_total_rps"] = "5"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "3000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -67,7 +67,7 @@ task :test_morphic_read => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_hatch_rate"] = "5"
   ENV["TF_VAR_locust_desired_total_rps"] = "3"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "3000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -84,7 +84,7 @@ task :test_morphic_write => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_hatch_rate"] = "5"
   ENV["TF_VAR_locust_desired_total_rps"] = "3"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "3000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke

--- a/shared/rakefiles/test.rake
+++ b/shared/rakefiles/test.rake
@@ -16,8 +16,8 @@ task :test_preferences_read => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_target_host"] = "http://preferences.gpii.svc.cluster.local"
   ENV["TF_VAR_locust_target_app"] = "preferences"
   ENV["TF_VAR_locust_script"] = "preferences_read.py"
-  ENV["TF_VAR_locust_desired_median_response_time"] = "300"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+  ENV["TF_VAR_locust_desired_median_response_time"] = "500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -50,7 +50,7 @@ task :test_flowmanager => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_users"] = "15"
   ENV["TF_VAR_locust_desired_total_rps"] = "5"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -67,7 +67,7 @@ task :test_morphic_read => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_hatch_rate"] = "5"
   ENV["TF_VAR_locust_desired_total_rps"] = "3"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke
@@ -84,7 +84,7 @@ task :test_morphic_write => [:set_vars, :check_destroy_allowed] do
   ENV["TF_VAR_locust_hatch_rate"] = "5"
   ENV["TF_VAR_locust_desired_total_rps"] = "3"
   ENV["TF_VAR_locust_desired_median_response_time"] = "500"
-  ENV["TF_VAR_locust_desired_max_response_time"] = "1500"
+  ENV["TF_VAR_locust_desired_max_response_time"] = "5000"
 
   Rake::Task[:set_compose_env].reenable
   Rake::Task[:set_compose_env].invoke


### PR DESCRIPTION
This PR relaxes median / max response time thresholds for all load tests.

There is often a single outlier that causes pipeline failure. I was hesitating to maybe use 95th or 99th percentile as a threshold instead, but ended up just increasing max response time. Since we review Locust stats in Stackdriver anyway, I think this is safe.