### PR TITLE
GPII-4282: Propagate TLS cert update

### DIFF
--- a/gcp/modules/certmerge-operator-crd/values.yaml
+++ b/gcp/modules/certmerge-operator-crd/values.yaml
@@ -4,3 +4,7 @@ secretLists:
   secretlist:
   - name: flowmanager-tls
     namespace: gpii
+  notify:
+  - name: istio-ingressgateway
+    namespace: istio-system
+    type: deployment

--- a/shared/charts/certmerge-operator-crd/Chart.yaml
+++ b/shared/charts/certmerge-operator-crd/Chart.yaml
@@ -1,6 +1,6 @@
 name: certmerge-operator-crd
-version: v0.1.0
-appVersion: v0.0.3
+version: v0.2.0
+appVersion: v0.0.3-gpii.2
 description: A Helm chart for certmerge-operator - CRD
 home: https://github.com/prune998/certmerge-operator
 keywords:

--- a/shared/charts/certmerge-operator-crd/templates/cert_merge-secretlist.yaml
+++ b/shared/charts/certmerge-operator-crd/templates/cert_merge-secretlist.yaml
@@ -16,4 +16,10 @@ spec:
   - name: {{ .name | quote }}
     namespace: {{ .namespace | quote }}
   {{- end }}
+  notify:
+  {{- range .notify }}
+  - name: {{ .name | quote }}
+    namespace: {{ .namespace | quote }}
+    type: {{ .type | quote }}
+  {{- end }}
 {{- end }}

--- a/shared/charts/certmerge-operator-crd/values.yaml
+++ b/shared/charts/certmerge-operator-crd/values.yaml
@@ -6,4 +6,8 @@ secretLists:
 #   secretlist:
 #   - name:
 #     namespace:
+#   norify:
+#   - name:
+#     namespace:
+#     type:
 # - ...

--- a/shared/charts/certmerge-operator/Chart.yaml
+++ b/shared/charts/certmerge-operator/Chart.yaml
@@ -1,6 +1,6 @@
 name: certmerge-operator
-version: v0.1.0
-appVersion: v0.0.3
+version: v0.2.0
+appVersion: v0.0.3-gpii.2
 description: A Helm chart for certmerge-operator
 home: https://github.com/prune998/certmerge-operator
 keywords:

--- a/shared/charts/certmerge-operator/templates/crd.yaml
+++ b/shared/charts/certmerge-operator/templates/crd.yaml
@@ -14,4 +14,142 @@ spec:
     plural: certmerges
     singular: certmerge
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CertMerge is the Schema for the certmerges API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertMergeSpec defines the desired state of CertMerge
+          properties:
+            name:
+              type: string
+            namespace:
+              type: string
+            notify:
+              items:
+                description: NotifySpec defines resources to notify on cert update
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - name
+                - namespace
+                - type
+                type: object
+              type: array
+            secretlist:
+              items:
+                description: SecretDefinition defines the parameters to search for
+                  secrets by name
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              type: array
+            selector:
+              items:
+                description: SecretSelector defines the needed parameters to search
+                  for secrets by Label
+                properties:
+                  labelselector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  namespace:
+                    type: string
+                required:
+                - labelselector
+                - namespace
+                type: object
+              type: array
+          required:
+          - name
+          - namespace
+          type: object
+        status:
+          description: CertMergeStatus defines the observed state of CertMerge
+          properties:
+            items:
+              items:
+                type: string
+              type: array
+            updatedTimestamp:
+              format: date-time
+              type: string
+            uptodate:
+              type: boolean
+            version:
+              type: string
+          required:
+          - uptodate
+          type: object
+      type: object
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/shared/charts/certmerge-operator/templates/role.yaml
+++ b/shared/charts/certmerge-operator/templates/role.yaml
@@ -30,3 +30,9 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -24,7 +24,7 @@ cert_manager:
 certmerge_operator:
   upstream:
     repository: gpii/certmerge-operator
-    tag: 0.0.3-gpii.1
+    tag: v0.0.3-gpii.2
   generated:
     repository: gcr.io/gpii-common-prd/gpii__certmerge-operator
     sha: sha256:0b794c687b07b078b6f10d451c81c2fb83bd3c93cf7540fe863910fac1a6d101


### PR DESCRIPTION
This PR adds mechanism to notify Istio Ingress Gateway when  TLS certificates are updated.

**Changes introduced:**
- Update certmerge-operator to v0.0.3-gpii.2
- Update certmerge-operator Chart - CRD and role permissions
- Update certmerge-operator-crd Chart - add support for notify
- Add notification for istio-ingress-gateway

**Downtime:**
This is a no-downtime change and is not expected to have any impact on services.

**Testing:**
Done in dev env - both upgrade of existing and spinning up a new one.