### PR TITLE
GPII-4349: Lift version check while GKE is being upgraded to new minor

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -24,7 +24,7 @@ variable "node_count" {
 }
 
 variable "expected_gke_version_prefix" {
-  default = "1.13"
+  default = "1.1"
 }
 
 variable "infra_region" {}


### PR DESCRIPTION
This PR lifts the version check to resolve error while GKE is being upgraded to new minor across zones. It won't have any other effect as the version is currently locked at `kubernetes_version = "1.13.11-gke.15"`.