### PR TITLE
GPII-4302: Imrove container restart alert

### DIFF
--- a/gcp/modules/late-alerts/alert_container_restart_rate.tf
+++ b/gcp/modules/late-alerts/alert_container_restart_rate.tf
@@ -1,16 +1,16 @@
 resource "google_monitoring_alert_policy" "container_restart_rate" {
   depends_on   = ["null_resource.wait_for_lbms"]
-  display_name = "K8s containers does not restart more often than 2 times per minute"
+  display_name = "K8s Workloads"
   combiner     = "OR"
 
-  conditions {
-    condition_threshold {
+  conditions = {
+    condition_threshold = {
       filter          = "metric.type=\"kubernetes.io/container/restart_count\" resource.type=\"k8s_container\""
       comparison      = "COMPARISON_GT"
-      threshold_value = 2
-      duration        = "0s"
+      threshold_value = 3
+      duration        = "300s"
 
-      aggregations {
+      aggregations = {
         alignment_period   = "60s"
         per_series_aligner = "ALIGN_DELTA"
       }
@@ -18,9 +18,12 @@ resource "google_monitoring_alert_policy" "container_restart_rate" {
       denominator_filter = ""
     }
 
-    display_name = "K8s container restarting more often than 2 times per minute"
+    display_name = "Pod does not restart too often"
   }
 
-  notification_channels = ["${data.terraform_remote_state.alert_notification_channel.slack_notification_channel}", "${data.terraform_remote_state.alert_notification_channel.mail_notification_channel}"]
-  enabled               = "true"
+  notification_channels = [
+    "${data.terraform_remote_state.alert_notification_channel.slack_notification_channel}",
+    "${data.terraform_remote_state.alert_notification_channel.mail_notification_channel}"
+  ]
+  enabled = "true"
 }

--- a/gcp/modules/late-alerts/alert_container_restart_rate.tf
+++ b/gcp/modules/late-alerts/alert_container_restart_rate.tf
@@ -23,7 +23,8 @@ resource "google_monitoring_alert_policy" "container_restart_rate" {
 
   notification_channels = [
     "${data.terraform_remote_state.alert_notification_channel.slack_notification_channel}",
-    "${data.terraform_remote_state.alert_notification_channel.mail_notification_channel}"
+    "${data.terraform_remote_state.alert_notification_channel.mail_notification_channel}",
   ]
+
   enabled = "true"
 }


### PR DESCRIPTION
This PR improves existing alert on container restart rate, which would actually almost never trigger (there's very little chance that there will be 3 restarts even if the container is in the `CrashLoopBackOff`f state due to exponential back-off starting at 10s).

After going through the past monitoring data, alerting on 3+ restarts over 5m seems reasonable. It will catch containers in `CrashLoopBackOf` and still should not alert if there are 1-2 restarts because of node upgrade.

**Changes introduced:**
- Improve container restart alert

**Downtime:**
This is a no-downtime change.

**Testing:**
Testing was done in dev cluster, alert catches failing container.