### PR TITLE
Deploy kube state metrics

### DIFF
--- a/gcp/live/dev/k8s/kube-system/kube-state-metrics/terraform.tfvars
+++ b/gcp/live/dev/k8s/kube-system/kube-state-metrics/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kube-state-metrics"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/live/prd/k8s/kube-system/kube-state-metrics/terraform.tfvars
+++ b/gcp/live/prd/k8s/kube-system/kube-state-metrics/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kube-state-metrics"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/live/stg/k8s/kube-system/kube-state-metrics/terraform.tfvars
+++ b/gcp/live/stg/k8s/kube-system/kube-state-metrics/terraform.tfvars
@@ -1,0 +1,16 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//kube-state-metrics"
+  }
+
+  dependencies {
+    paths = [
+      "../helm-initializer",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}

--- a/gcp/modules/kube-state-metrics/main.tf
+++ b/gcp/modules/kube-state-metrics/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  backend "gcs" {}
+}
+
+variable "secrets_dir" {}
+variable "charts_dir" {}
+variable "kube_state_metrics_repository" {}
+variable "kube_state_metrics_tag" {}
+variable "prometheus_to_sd_repository" {}
+variable "prometheus_to_sd_tag" {}
+
+data "template_file" "kube_state_metrics_values" {
+  template = "${file("values.yaml")}"
+
+  vars {
+    kube_state_metrics_repository = "${var.kube_state_metrics_repository}"
+    kube_state_metrics_tag        = "${var.kube_state_metrics_tag}"
+    prometheus_to_sd_repository   = "${var.prometheus_to_sd_repository}"
+    prometheus_to_sd_tag          = "${var.prometheus_to_sd_tag}"
+  }
+}
+
+module "kube-state-metrics" {
+  source           = "/exekube-modules/helm-release"
+  tiller_namespace = "kube-system"
+  client_auth      = "${var.secrets_dir}/kube-system/helm-tls"
+
+  release_name            = "kube-state-metrics"
+  release_namespace       = "kube-system"
+  release_values          = ""
+  release_values_rendered = "${data.template_file.kube_state_metrics_values.rendered}"
+
+  chart_name = "${var.charts_dir}/kube-state-metrics"
+}

--- a/gcp/modules/kube-state-metrics/values.yaml
+++ b/gcp/modules/kube-state-metrics/values.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: ${kube_state_metrics_repository}
+  tag: ${kube_state_metrics_tag}
+
+prometheus_to_sd:
+  image:
+    repository: ${prometheus_to_sd_repository}
+    tag: ${prometheus_to_sd_tag}

--- a/shared/charts/kube-state-metrics/.helmignore
+++ b/shared/charts/kube-state-metrics/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/shared/charts/kube-state-metrics/Chart.yaml
+++ b/shared/charts/kube-state-metrics/Chart.yaml
@@ -1,0 +1,12 @@
+name: kube-state-metrics
+version: v0.1.0
+appVersion: v1.9.5
+description: A Helm chart for kube-state-metrics
+home: https://github.com/kubernetes/kube-state-metrics
+keywords:
+  - kube-state-metrics
+  - k8s
+  - kubernetes
+  - metrics
+sources:
+  - https://github.com/kubernetes/kube-state-metrics

--- a/shared/charts/kube-state-metrics/README.md
+++ b/shared/charts/kube-state-metrics/README.md
@@ -1,0 +1,42 @@
+# kube-state-metrics chart
+
+Kube-state-metrics is an add-on agent to generate and expose cluster-level metrics.
+
+See https://github.com/kubernetes/kube-state-metrics for usage details.
+
+## Configuration
+
+The following table lists the configurable parameters of the chart and their
+default values.
+
+| Parameter                           | Description                       | Default                                     |
+|-------------------------------------|-----------------------------------|---------------------------------------------|
+| `image.repository`                  | container image repository        | `quay.io/coreos/kube-state-metrics`         |
+| `image.pullPolicy`                  | container image pullPolicy        | `IfNotPresent`                              |
+| `image.tag`                         | container image tag               | `v1.9.5`                                    |
+| `prometheus-to-sd.image.repository` | prometheus-to-sd image repository | `gcr.io/google-containers/prometheus-to-sd` |
+| `prometheus-to-sd.image.pullPolicy` | prometheus-to-sd image pullPolicy | `IfNotPresent`                              |
+| `prometheus-to-sd.image.tag`        | prometheus-to-sd image tag        | `v0.9.2`                                    |
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release path_to_chart/kube-state-metrics
+```
+
+The command deploys kube-state-metrics on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
+
+## Un-installing the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.

--- a/shared/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/shared/charts/kube-state-metrics/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-state-metrics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-state-metrics.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-state-metrics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/shared/charts/kube-state-metrics/templates/_helpers.tpl
+++ b/shared/charts/kube-state-metrics/templates/_helpers.tpl
@@ -30,3 +30,8 @@ Create chart name and version as used by the chart label.
 {{- define "kube-state-metrics.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "helm-toolkit.utils.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/shared/charts/kube-state-metrics/templates/deployment.yaml
+++ b/shared/charts/kube-state-metrics/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kube-state-metrics.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+    helm.sh/chart: {{ include "kube-state-metrics.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "kube-state-metrics.fullname" . }}
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        args:
+          - '--collectors=configmaps,horizontalpodautoscalers,namespaces,pods,ingresses,limitranges,nodes,certificatesigningrequests,cronjobs,deployments,persistentvolumes,jobs,secrets,statefulsets,persistentvolumeclaims,services,storageclasses,poddisruptionbudgets,volumeattachments,daemonsets,endpoints,networkpolicies,replicasets,replicationcontrollers,resourcequotas'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        securityContext:
+          runAsUser: 65534
+      - name: prometheus-to-sd
+        image: "{{ .Values.prometheus_to_sd.image.repository }}:{{ .Values.prometheus_to_sd.image.tag }}"
+        imagePullPolicy: {{ .Values.prometheus_to_sd.image.pullPolicy }}
+        command:
+          - /monitor
+          - --stackdriver-prefix=custom.googleapis.com
+          - --source=kube-state-metrics:http://localhost:8080
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/shared/charts/kube-state-metrics/templates/deployment.yaml
+++ b/shared/charts/kube-state-metrics/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
-          - '--collectors=configmaps,horizontalpodautoscalers,namespaces,pods,ingresses,limitranges,nodes,certificatesigningrequests,cronjobs,deployments,persistentvolumes,jobs,secrets,statefulsets,persistentvolumeclaims,services,storageclasses,poddisruptionbudgets,volumeattachments,daemonsets,endpoints,networkpolicies,replicasets,replicationcontrollers,resourcequotas'
+        - "--collectors={{ include "helm-toolkit.utils.joinListWithComma" .Values.collectors }}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/shared/charts/kube-state-metrics/templates/deployment.yaml
+++ b/shared/charts/kube-state-metrics/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         args:
         - "--collectors={{ include "helm-toolkit.utils.joinListWithComma" .Values.collectors }}"
+        - "--metric-blacklist={{ include "helm-toolkit.utils.joinListWithComma" .Values.metric_blacklist }}"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/shared/charts/kube-state-metrics/templates/role.yaml
+++ b/shared/charts/kube-state-metrics/templates/role.yaml
@@ -1,0 +1,121 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "kube-state-metrics.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+    helm.sh/chart: {{ include "kube-state-metrics.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+

--- a/shared/charts/kube-state-metrics/templates/role_binding.yaml
+++ b/shared/charts/kube-state-metrics/templates/role_binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kube-state-metrics.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+    helm.sh/chart: {{ include "kube-state-metrics.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kube-state-metrics.fullname" . }}

--- a/shared/charts/kube-state-metrics/templates/service_account.yaml
+++ b/shared/charts/kube-state-metrics/templates/service_account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-state-metrics.name" . }}
+    helm.sh/chart: {{ include "kube-state-metrics.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/shared/charts/kube-state-metrics/values.yaml
+++ b/shared/charts/kube-state-metrics/values.yaml
@@ -1,0 +1,11 @@
+# Default values for certmerge-operator
+image:
+  repository: quay.io/coreos/kube-state-metrics
+  tag: v1.9.5
+  pullPolicy: IfNotPresent
+
+prometheus_to_sd:
+  image:
+    repository: gcr.io/google-containers/prometheus-to-sd
+    tag: v0.5.1
+    pullPolicy: IfNotPresent

--- a/shared/charts/kube-state-metrics/values.yaml
+++ b/shared/charts/kube-state-metrics/values.yaml
@@ -36,3 +36,6 @@ collectors:
   - replicasets
   - replicationcontrollers
   - resourcequotas
+
+metric_blacklist:
+  - kube_pod_labels

--- a/shared/charts/kube-state-metrics/values.yaml
+++ b/shared/charts/kube-state-metrics/values.yaml
@@ -9,3 +9,30 @@ prometheus_to_sd:
     repository: gcr.io/google-containers/prometheus-to-sd
     tag: v0.5.1
     pullPolicy: IfNotPresent
+
+collectors:
+  - configmaps
+  - horizontalpodautoscalers
+  - namespaces
+  - pods
+  - ingresses
+  - limitranges
+  - nodes
+  - certificatesigningrequests
+  - cronjobs
+  - deployments
+  - persistentvolumes
+  - jobs
+  - secrets
+  - statefulsets
+  - persistentvolumeclaims
+  - services
+  - storageclasses
+  - poddisruptionbudgets
+  - volumeattachments
+  - daemonsets
+  - endpoints
+  - networkpolicies
+  - replicasets
+  - replicationcontrollers
+  - resourcequotas

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -157,3 +157,11 @@ kiali:
     repository: gcr.io/gpii-common-prd/quay.io__kiali__kiali
     sha: sha256:8304fc943df04168c68f0e6098b968337c36229c6dc9341286a27179d03b2767
     tag: v1.5.0
+kube_state_metrics:
+  upstream:
+    repository: quay.io/coreos/kube-state-metrics
+    tag: v1.9.5
+  generated:
+    repository: quay.io/coreos/kube-state-metrics
+    tag: v1.9.5
+    sha: sha256:8304fc943df04168c68f0e6098b968337c36229c6dc9341286a27179d03b2767

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -72,7 +72,7 @@ couchdb_prometheus_exporter:
 prometheus_to_sd:
   upstream:
     repository: gcr.io/google-containers/prometheus-to-sd
-    tag: v0.5.1
+    tag: v0.9.2
   generated:
     repository: gcr.io/gpii-common-prd/gcr.io__google-containers__prometheus-to-sd
     sha: sha256:14f37ba6eef9ca91cb1ffa71a7a23550f3b074003b60fc0974b4206dc81e0d85


### PR DESCRIPTION
This PR deploys **kube state metrics** add-on to the clusters. This add-on expores additional Kubernetes cluster-level metrics to Stacdriver. Example of these metrics can be `kube_deployment_spec_replicas` or `kube_pod_status_ready`.

**Changelog:**
- Add kube-state-metrics chart
- Add kube-state-metrics TF module
- Deploy kube-state-metrics module across environments
- Update prometheus-to-sd-exporter to v0.9.2
- Add kube-state-metrics docker image to versions

**Testing:**
These changes have been tested in dev env, both updating existing and creating new cluster from scratch.

**Downtime:**
This is a no-downtime change, no impact on services is expected.

**_~Note: This is WIP~_**
There is couple of error messages from the prometheus-to-sd I want to look at prior to merging:
```
E0312 16:49:11.237915       1 stackdriver.go:97] Error in attempt to update metric descriptor googleapi: Error 400: Field labels had an invalid value: When creating metric custom.googleapis.com/kube-state-metrics/kube_pod_labels: the metric has more than 10 labels., badRequest
W0312 16:49:11.238549       1 translator.go:199] Metric process_start_time_seconds invalid or not defined. Using 1970-01-01 00:00:01 +0000 UTC instead. Cumulative metrics might be inaccurate.
```
^ the above was resolved by disabling the kube_pod_labels metric.