### PR TITLE
GPII-4414: Reduce number of collected metrics

### DIFF
--- a/shared/charts/kube-state-metrics/values.yaml
+++ b/shared/charts/kube-state-metrics/values.yaml
@@ -11,31 +11,9 @@ prometheus_to_sd:
     pullPolicy: IfNotPresent
 
 collectors:
-  - configmaps
-  - horizontalpodautoscalers
-  - namespaces
-  - pods
-  - ingresses
-  - limitranges
-  - nodes
-  - certificatesigningrequests
-  - cronjobs
   - deployments
-  - persistentvolumes
-  - jobs
-  - secrets
   - statefulsets
-  - persistentvolumeclaims
-  - services
-  - storageclasses
-  - poddisruptionbudgets
-  - volumeattachments
-  - daemonsets
-  - endpoints
-  - networkpolicies
   - replicasets
-  - replicationcontrollers
-  - resourcequotas
 
 metric_blacklist:
   - kube_pod_labels


### PR DESCRIPTION
Seems like Stackdriver metrics are expensive, reduce number of collected metrics only to those we plan to use.

**Changelog:**
- Reduce number of collected metrics by kube-state-metrics (GPII-4414).

**Testing:**
These changes have been tested in dev env.

**Downtime:**
This is a no-downtime change, no impact on services is expected.