### PR TITLE
GPII-4414: Bump kube-state-metrics chart version to trigger update

### DIFF
--- a/shared/charts/kube-state-metrics/Chart.yaml
+++ b/shared/charts/kube-state-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-state-metrics
-version: v0.1.0
+version: v0.1.1
 appVersion: v1.9.5
 description: A Helm chart for kube-state-metrics
 home: https://github.com/kubernetes/kube-state-metrics


### PR DESCRIPTION
The change from https://github.com/gpii-ops/gpii-infra/pull/602 was not applied correctly, as the Terraform/Helm does not recognize when only default values change.

This should fix the issue and apply the change by increasing Helm chart version.

