### PR TITLE
GPII-4426: Fix StackDriver metadata agent

### DIFF
--- a/gcp/live/dev/k8s/stackdriver-gke/terraform.tfvars
+++ b/gcp/live/dev/k8s/stackdriver-gke/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//stackdriver-gke"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/prd/k8s/stackdriver-gke/terraform.tfvars
+++ b/gcp/live/prd/k8s/stackdriver-gke/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//stackdriver-gke"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/live/stg/k8s/stackdriver-gke/terraform.tfvars
+++ b/gcp/live/stg/k8s/stackdriver-gke/terraform.tfvars
@@ -1,0 +1,18 @@
+# ↓ Module metadata
+terragrunt = {
+  terraform {
+    source = "/project/modules//stackdriver-gke"
+  }
+
+  dependencies {
+    paths = [
+      "../cluster",
+    ]
+  }
+
+  include = {
+    path = "${find_in_parent_folders()}"
+  }
+}
+
+# ↓ Module configuration (empty means all default)

--- a/gcp/modules/gke-cluster/stackdriver-sync.tf
+++ b/gcp/modules/gke-cluster/stackdriver-sync.tf
@@ -1,0 +1,15 @@
+# GKE Stackdriver state needs to be synced right after the cluster is created
+# for the firs time and before istio module runs
+
+resource "null_resource" "sync_gke_stackdriver_state" {
+  depends_on = ["module.gke_cluster"]
+
+  provisioner "local-exec" {
+    command     = "/rakefiles/scripts/sync_gke_stackdriver_state.sh"
+    working_dir = "/project"
+
+    environment = {
+      ENV = "${var.env}"
+    }
+  }
+}

--- a/gcp/modules/stackdriver-gke/main.tf
+++ b/gcp/modules/stackdriver-gke/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "gcs" {}
+}
+
+resource "kubernetes_config_map" "metadata-agent-config" {
+  metadata = {
+    name      = "metadata-agent-config"
+    namespace = "kube-system"
+
+    labels = {
+      # This seems to be a bug with Terraform, object in fact  # has the labels below, but TF does not see them  #  "addonmanager.kubernetes.io/mode" = "EnsureExists",  #  "kubernetes.io/cluster-service"   = "true"
+    }
+  }
+
+  data = {
+    "NannyConfiguration" = "apiVersion: nannyconfig/v1alpha1\nkind: NannyConfiguration\nbaseMemory: 50Mi"
+  }
+}

--- a/shared/charts/kube-state-metrics/Chart.yaml
+++ b/shared/charts/kube-state-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-state-metrics
-version: v0.1.0
+version: v0.1.1
 appVersion: v1.9.5
 description: A Helm chart for kube-state-metrics
 home: https://github.com/kubernetes/kube-state-metrics

--- a/shared/rakefiles/scripts/sync_gke_stackdriver_state.sh
+++ b/shared/rakefiles/scripts/sync_gke_stackdriver_state.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+
+# This script goes through a list of StackDriver ConfigMaps ($STACKDRIVER_CONFIGMAPS) and tries to
+# import them into Terraform state in given Terragrunt module
+# ($STACKDRIVER_MODULE_DIR). This is intended to sync Terraform state with actual
+# state, as Stackdriver components on GKE are managed by Google.
+
+set -eou pipefail
+
+# enable debug output if $DEBUG is set to true
+[ "${DEBUG:=false}" = 'true' ] && set -x
+
+# get script name
+THIS_SCRIPT="$(basename "${0}")"
+
+# list of env variables - interface
+# required
+ENV=${ENV:?"Environment variable must be set"}
+# optional
+STACKDRIVER_MODULE_DIR=${STACKDRIVER_MODULE_DIR:="live/${ENV}/k8s/stackdriver-gke"}
+STACKDRIVER_CONFIGMAPS=${STACKDRIVER_CONFIGMAPS:="metadata-agent-config"}
+REQUIRED_BINARIES=${REQUIRED_BINARIES:="kubectl terragrunt jq"}
+
+# check the module does exist, otherwise silently exit
+if [ ! -d "${STACKDRIVER_MODULE_DIR}" ]
+then
+  echo "${THIS_SCRIPT}: Skipping Stackdriver ConfigMap state synchronization, module not found (${STACKDRIVER_MODULE_DIR})"
+  exit 0
+fi
+
+# check if we have all the dependencies
+for BIN in ${REQUIRED_BINARIES}; do
+  if [ ! -x "$(command -v "${BIN}")" ]
+  then
+    echo "${THIS_SCRIPT}: Required dependency ${BIN} not found in path"
+    exit 1
+  fi
+done
+
+# retrieve TF state, remove "o:" which is weird artifact added to output when
+# running terraform in terraform
+if ! RESOURCES="$(terragrunt state pull --terragrunt-working-dir "${STACKDRIVER_MODULE_DIR}" | sed 's/^o://g' | jq -ers '.[].modules[].resources')"
+then
+  echo "${THIS_SCRIPT}: Failed to retrieve or parse Terraform state"
+  exit 1
+fi
+
+# iterate through the list of HPAs
+for CM in ${STACKDRIVER_CONFIGMAPS}; do
+  # if configmap is not in state already
+  if ! echo "${RESOURCES}" | jq -ers ".[].\"kubernetes_config_map.${CM}\"" >/dev/null
+  then
+    # and if CM exists
+    if kubectl get configmap "${CM}" -n kube-system --request-timeout='5s' >/dev/null
+    then
+      echo "${THIS_SCRIPT}: Trying to import GKE Stackdriver ConfigMap - ${CM}"
+      # import it to TF state
+      terragrunt import "kubernetes_config_map.${CM}" "kube-system/${CM}" --terragrunt-working-dir "${STACKDRIVER_MODULE_DIR}"
+    fi
+  fi
+done
+
+echo "${THIS_SCRIPT}: Done"


### PR DESCRIPTION
Stackdriver metadata agent suffers from a known issue of being OOM killed - https://stackoverflow.com/questions/60541105/stackdriver-metadata-agent-cluster-level-gets-oomkilled

This PR fixes the issue by increasing allocated resources by modifying the `stackdriver-metadata-agent` ConfigMap.

**Changes introduced:**
- Add Stackdriver state sync shell script
- Add Stackdriver sync script trigger to `gke-cluster` module
- Add `stackdrver-gke` TF module - this manages the `stackdriver-metadata-agent` ConfigMap
- Deploy `stackdriver-gke` module in all envs

**Testing:**
Tested in dev environment.

**Downtime:**
None expected, this is a zero-downtime change. Stackdriver metadata agent is already broken.