### PR TITLE
GPII-4434: Fix StackDriver metadata agent running out of CPU

### DIFF
--- a/gcp/modules/stackdriver-gke/main.tf
+++ b/gcp/modules/stackdriver-gke/main.tf
@@ -13,6 +13,6 @@ resource "kubernetes_config_map" "metadata-agent-config" {
   }
 
   data = {
-    "NannyConfiguration" = "apiVersion: nannyconfig/v1alpha1\nkind: NannyConfiguration\nbaseMemory: 50Mi"
+    "NannyConfiguration" = "apiVersion: nannyconfig/v1alpha1\nkind: NannyConfiguration\nbaseMemory: 50Mi\nbaseCPU: 80m"
   }
 }


### PR DESCRIPTION
After fixing the Stackdriver metadata agent, so that is is is actually running, it started triggering CPU alerts.

This PR fixes the issue by increasing allocated resources by modifying the `stackdriver-metadata-agent` ConfigMap.

**Changes introduced:**
- Fix StackDriver metadata agent running out of CPU

**Testing:**
Tested in dev environment.

**Downtime:**
None expected, this is a zero-downtime change. Stackdriver metadata agent is already broken.