### PR TITLE
(GPII-4431) Add display_image_vulnerabilities rake task

### DIFF
--- a/shared/rakefiles/entrypoint_common.rake
+++ b/shared/rakefiles/entrypoint_common.rake
@@ -39,3 +39,8 @@ desc "[ONLY ADMIN] Display SCC findings"
 task :display_scc_findings => [:set_vars] do
   sh "#{@exekube_cmd} rake display_scc_findings"
 end
+
+desc "[ONLY ADMIN] Display Container Image Vulnerabilities"
+task :display_image_vulnerabilities => [:set_vars] do
+  sh "#{@exekube_cmd} rake display_image_vulnerabilities"
+end

--- a/shared/rakefiles/xk_util.rake
+++ b/shared/rakefiles/xk_util.rake
@@ -360,6 +360,15 @@ task :display_scc_findings => [:configure] do
   sh "gcloud alpha scc findings list #{ENV["ORGANIZATION_ID"]} --filter 'state = \"ACTIVE\"'"
 end
 
+# This task displays all containers with any critical vulnerability
+task :display_image_vulnerabilities => [:configure] do
+  sh "gcloud beta container images list --format='value(name)' \
+      | xargs -n1 -I '{}' gcloud beta container images list-tags '{}' \
+          --show-occurrences --format=json \
+          --filter='vuln_counts.CRITICAL > 0' \
+      | jq '.[] | {\"image\": .DISCOVERY[].resourceUrl, \"vuln_counts\": .vuln_counts }'"
+end
+
 # This task forwards Kiali port
 task :kiali_ui => [:configure] do
   sh "/rakefiles/scripts/kiali_ui.sh"


### PR DESCRIPTION
This PR adds `display_image_vulnerabilities` rake task to display container image vulnerabilities for images is the GCR registry.

Sample output:
```json
$ RAKE_REALLY_RUN_IN_PRD=true rake display_image_vulnerabilities
...
...
{
  "image": "https://gcr.io/gpii-common-prd/couchdb@sha256:26a1962d06a5e5be965e517c69d2452c82edf335208ed51360d3493724591e2c",
  "vuln_counts": {
    "CRITICAL": 2,
    "HIGH": 18,
    "LOW": 18,
    "MEDIUM": 87
  }
}
{
  "image": "https://gcr.io/gpii-common-prd/couchdb@sha256:b877af600e293895f04c59e49e685dee7fa7aaf4bcfafb516491ebd1d9152543",
  "vuln_counts": {
    "CRITICAL": 2,
```

**Changes introduced:**
- Add display_image_vulnerabilities rake task

**Testing:**
Tested in common PRD environment and local dev.

**Downtime:**
None expected, this is a zero-downtime change.