### PR TITLE
GPII-4466: Fix egress TLS traffic

### DIFF
--- a/shared/charts/istio-gke-helper/Chart.yaml
+++ b/shared/charts/istio-gke-helper/Chart.yaml
@@ -1,5 +1,5 @@
 name: istio-gke-helper
-version: v0.2.0
+version: v0.3.0
 description: A Helm chart for GKE Istio support resources
 home: https://github.com/istio/istio
 keywords:

--- a/shared/charts/istio-gke-helper/templates/destination_rule.yaml
+++ b/shared/charts/istio-gke-helper/templates/destination_rule.yaml
@@ -13,13 +13,4 @@ spec:
   host: istio-egressgateway.istio-system.svc.cluster.local
   subsets:
   - name: tls-{{ $host | replace "." "-" }}
-    trafficPolicy:
-      loadBalancer:
-        simple: ROUND_ROBIN
-      portLevelSettings:
-      - port:
-          number: 443
-        tls:
-          mode: ISTIO_MUTUAL
-          sni: {{ $host }}
 {{- end }}

--- a/shared/charts/istio-gke-helper/templates/gateway.yaml
+++ b/shared/charts/istio-gke-helper/templates/gateway.yaml
@@ -22,8 +22,5 @@ spec:
       number: 443
       protocol: TLS
     tls:
-      caCertificates: /etc/certs/root-cert.pem
-      mode: MUTUAL
-      privateKey: /etc/certs/key.pem
-      serverCertificate: /etc/certs/cert-chain.pem
+      mode: PASSTHROUGH
 {{- end }}

--- a/shared/charts/istio-gke-helper/templates/virtual_service.yaml
+++ b/shared/charts/istio-gke-helper/templates/virtual_service.yaml
@@ -15,17 +15,6 @@ spec:
   - mesh
   hosts:
   - {{ $host }}
-  tcp:
-  - match:
-    - gateways:
-      - istio-egressgateway
-      port: 443
-    route:
-    - destination:
-        host: {{ $host }}
-        port:
-          number: 443
-      weight: 100
   tls:
   - match:
     - gateways:
@@ -39,4 +28,16 @@ spec:
         port:
           number: 443
         subset: tls-{{ $host | replace "." "-" }}
+  - match:
+    - gateways:
+      - istio-egressgateway
+      port: 443
+      sni_hosts:
+      - {{ $host }}
+    route:
+    - destination:
+        host: {{ $host }}
+        port:
+          number: 443
+      weight: 100
 {{- end }}


### PR DESCRIPTION
Egress TLS config is different for Istio 1.2.x. This PR fixes broken TLS  passthrough traffic.

**Changes introduced:**
- Fix egress TLS traffic - move to Istio PASSTHROUGH config possible with 1.2.x+

**Testing:**
Tested in local dev.

**Downtime:**
None expected, this is a zero-downtime change.