### PR TITLE
GPII-4471: Update CouchDB chart to use SHAs

### DIFF
--- a/gcp/modules/couchdb/main.tf
+++ b/gcp/modules/couchdb/main.tf
@@ -14,11 +14,11 @@ variable "secrets_dir" {}
 variable "charts_dir" {}
 variable "nonce" {}
 variable "couchdb_helper_repository" {}
-variable "couchdb_helper_tag" {}
+variable "couchdb_helper_checksum" {}
 variable "couchdb_init_repository" {}
-variable "couchdb_init_tag" {}
+variable "couchdb_init_checksum" {}
 variable "couchdb_repository" {}
-variable "couchdb_tag" {}
+variable "couchdb_checksum" {}
 
 # Terragrunt variables
 
@@ -59,11 +59,11 @@ data "template_file" "couchdb_values" {
     couchdb_admin_password    = "${var.secret_couchdb_admin_password}"
     couchdb_auth_cookie       = "${var.secret_couchdb_auth_cookie}"
     couchdb_helper_repository = "${var.couchdb_helper_repository}"
-    couchdb_helper_tag        = "${var.couchdb_helper_tag}"
+    couchdb_helper_sha        = "${var.couchdb_helper_checksum}"
     couchdb_init_repository   = "${var.couchdb_init_repository}"
-    couchdb_init_tag          = "${var.couchdb_init_tag}"
+    couchdb_init_sha          = "${var.couchdb_init_checksum}"
     couchdb_repository        = "${var.couchdb_repository}"
-    couchdb_tag               = "${var.couchdb_tag}"
+    couchdb_sha               = "${var.couchdb_checksum}"
     replica_count             = "${var.replica_count}"
     requests_cpu              = "${var.requests_cpu}"
     requests_memory           = "${var.requests_memory}"

--- a/gcp/modules/couchdb/values.yaml
+++ b/gcp/modules/couchdb/values.yaml
@@ -6,15 +6,15 @@ cookieAuthSecret: ${couchdb_auth_cookie}
 
 helperImage:
   repository: ${couchdb_helper_repository}
-  tag: ${couchdb_helper_tag}
+  sha: ${couchdb_helper_sha}
 
 initImage:
   repository: ${couchdb_init_repository}
-  tag: ${couchdb_init_tag}
+  sha: ${couchdb_init_sha}
 
 image:
   repository: ${couchdb_repository}
-  tag: ${couchdb_tag}
+  sha: ${couchdb_sha}
 
 persistentVolume:
   enabled: true

--- a/shared/charts/couchdb/Chart.yaml
+++ b/shared/charts/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.4.0
+version: 1.4.1
 appVersion: 2.3.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -23,7 +23,11 @@ spec:
     spec:
       initContainers:
         - name: init-copy
+          {{ if .Values.initImage.sha }}
+          image: "{{ .Values.initImage.repository }}@{{ .Values.initImage.sha }}"
+          {{ else }}
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          {{ end }}
           command: ['sh','-c','cp /tmp/chart.ini /default.d; ls -lrt /default.d;']
           volumeMounts:
           - name: config
@@ -32,7 +36,11 @@ spec:
             mountPath: /default.d
       containers:
         - name: couchdb
+          {{ if .Values.image.sha }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.sha }}"
+          {{ else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{ end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http-couchdb
@@ -108,7 +116,11 @@ spec:
           - name: database-storage
             mountPath: /opt/couchdb/data
         - name: couchdb-statefulset-assembler
-          image: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          {{ if .Values.helperImage.sha }}
+          helperImage: "{{ .Values.helperImage.repository }}@{{ .Values.helperImage.sha }}"
+          {{ else }}
+          helperImage: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          {{ end }}
           imagePullPolicy: {{ .Values.helperImage.pullPolicy }}
           env:
             - name: COUCHDB_CLUSTER_SIZE

--- a/shared/charts/couchdb/values.yaml
+++ b/shared/charts/couchdb/values.yaml
@@ -48,17 +48,23 @@ image:
   repository: couchdb
   tag: 2.2.0
   pullPolicy: IfNotPresent
+  # If sha is specified, it till take precedence 
+  # sha:
 
 ## Sidecar that connects the individual Pods into a cluster
 helperImage:
   repository: kocolosk/couchdb-statefulset-assembler
   tag: 1.1.0
   pullPolicy: IfNotPresent
+  # If sha is specified, it till take precedence 
+  # sha:
 
 ## Init container for placing config files
 initImage:
   repository: busybox
   tag: latest
+  # If sha is specified, it till take precedence 
+  # sha:
 
 ## CouchDB is happy to spin up cluster nodes in parallel, but if you encounter
 ## problems you can try setting podManagementPolicy to the StatefulSet default


### PR DESCRIPTION
This PR moves the CouchDB chart to use SHAs instead of tags, to enforce consistent versions of images used by CouchDB. CouchDB images fairly often get updated, while keeping the same tag and currently this results in inconsistent images across our environments.

**Changes introduced:**
- CouchDB chart: Add support for shas
- CouchDB module: switch to using SHAs

**Testing:**
Tested in local dev.

**Downtime:**
None expected this is a zero-downtime change.