### PR TITLE
CouchDB - fix StatefulSet manifest for assembler

### DIFF
--- a/shared/charts/couchdb/templates/statefulset.yaml
+++ b/shared/charts/couchdb/templates/statefulset.yaml
@@ -117,9 +117,9 @@ spec:
             mountPath: /opt/couchdb/data
         - name: couchdb-statefulset-assembler
           {{ if .Values.helperImage.sha }}
-          helperImage: "{{ .Values.helperImage.repository }}@{{ .Values.helperImage.sha }}"
+          image: "{{ .Values.helperImage.repository }}@{{ .Values.helperImage.sha }}"
           {{ else }}
-          helperImage: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          image: "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
           {{ end }}
           imagePullPolicy: {{ .Values.helperImage.pullPolicy }}
           env:


### PR DESCRIPTION
This fixes an issue that prevented new cluster creation after moving CouchDB Chart to SHAs - #614 .

**Changes introduced:**
- CouchDB chart - fix StatefulSet manifest for assembler

**Downtime:**
None expected this is a zero-downtime change.