### PR TITLE
GPII-4476: Fix alert modification alert

### DIFF
--- a/gcp/modules/late-alerts/alert_workloads.tf
+++ b/gcp/modules/late-alerts/alert_workloads.tf
@@ -30,13 +30,11 @@ resource "google_monitoring_alert_policy" "k8s_workloads" {
       duration           = "300s"
 
       aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_NONE"
+        alignment_period = "60s"
       }
 
       denominator_aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_NONE"
+        alignment_period = "60s"
       }
     }
 
@@ -52,13 +50,11 @@ resource "google_monitoring_alert_policy" "k8s_workloads" {
       duration           = "300s"
 
       aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_NONE"
+        alignment_period = "60s"
       }
 
       denominator_aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_NONE"
+        alignment_period = "60s"
       }
     }
 


### PR DESCRIPTION
This PR fixes alert modification issue on every run. Terraform doesn't handle this quite correctly, on that note the Monitoring API behaves differently to other GCP APIs where the payload would typically be present with a default value.

**Changes introduced:**
- Fix alert modification alert

**Downtime:**
None expected this is a zero-downtime change.

**Testing:**
Tested in dev environment.