### PR TITLE
Fix stackdriver-metadata-agent-cluster-level and reduce alerts

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -377,6 +377,15 @@ data "google_iam_policy" "combined" {
     ]
   }
 
+  # Needed by stackdriver-metadata-agent-cluster-level
+  binding {
+    role = "roles/stackdriver.resourceMetadata.writer"
+
+    members = [
+      "serviceAccount:${google_service_account.gke_cluster_node.email}",
+    ]
+  }
+
   binding {
     role = "roles/monitoring.viewer"
 

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -383,6 +383,9 @@ data "google_iam_policy" "combined" {
 
     members = [
       "serviceAccount:${google_service_account.gke_cluster_node.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_default.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_backup_exporter.email}",
+      "serviceAccount:${google_service_account.gke_cluster_pod_cert_manager.email}",
     ]
   }
 

--- a/gcp/live/dev/k8s/late-alerts/terraform.tfvars
+++ b/gcp/live/dev/k8s/late-alerts/terraform.tfvars
@@ -9,6 +9,7 @@ terragrunt = {
       "../cluster",
       "../stackdriver/monitoring",
       "../gpii/flowmanager",
+      "../kube-system/kube-state-metrics"
     ]
   }
 

--- a/gcp/live/prd/k8s/late-alerts/terraform.tfvars
+++ b/gcp/live/prd/k8s/late-alerts/terraform.tfvars
@@ -9,6 +9,7 @@ terragrunt = {
       "../cluster",
       "../stackdriver/monitoring",
       "../gpii/flowmanager",
+      "../kube-system/kube-state-metrics"
     ]
   }
 

--- a/gcp/live/stg/k8s/late-alerts/terraform.tfvars
+++ b/gcp/live/stg/k8s/late-alerts/terraform.tfvars
@@ -9,6 +9,7 @@ terragrunt = {
       "../cluster",
       "../stackdriver/monitoring",
       "../gpii/flowmanager",
+      "../kube-system/kube-state-metrics"
     ]
   }
 


### PR DESCRIPTION
This PR fixes **stackdriver-metadata-agent-cluster-level**, component that was crashin because insufficient permissions to submit metrics to Stackdriver, and also aims to eliminate some sales for ephemeral environments by introducing dependency.


**Changes introduced:**
- Add stackdriver.resourceMetadata.writer role to node - fixes stackdriver-metadata-agent-cluster-level
- Make alerts dependant on kube-state-metrics …


**Downtime:**
None expected this is a zero-downtime change.

**Testing:**
Tested in dev environment.