### PR TITLE
GPII-4427 - GCS access logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
+  - image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -621,4 +621,24 @@ resource "google_storage_bucket" "project-tfstate" {
   versioning = {
     enabled = "true"
   }
+
+  logging {
+    log_bucket = "${google_storage_bucket.access-logs.name}"
+  }
+}
+
+resource "google_storage_bucket" "access-logs" {
+  project = "${google_project.project.project_id}"
+  name    = "${var.organization_name}-gcp-${var.project_name}-access-logs"
+
+  # Default region "US" should be fixed in favor of TF_VAR_infra_region for consistency:
+  # https://issues.gpii.net/browse/GPII-3707
+  # location = "${var.infra_region}"
+  location = "US"
+
+  force_destroy = false
+
+  versioning = {
+    enabled = "false"
+  }
 }

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.11-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/modules/gcp-stackdriver-export/main.tf
+++ b/gcp/modules/gcp-stackdriver-export/main.tf
@@ -64,5 +64,6 @@ module "gcp_stackdriver_export" {
   exported_logs_storage_region = "${var.infra_region}"
   exported_logs_expire_after   = "${var.exported_logs_expire_after}"
 
-  exported_logs_encryption_key = "${lookup(data.terraform_remote_state.secret-mgmt.encryption_keys, "gcp-stackdriver-export")}"
+  exported_logs_encryption_key    = "${lookup(data.terraform_remote_state.secret-mgmt.encryption_keys, "gcp-stackdriver-export")}"
+  exported_logs_access_log_bucket = "${var.project_id}-access-logs"
 }

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -8,7 +8,7 @@
 exekube:
   upstream:
     repository: gpii/exekube
-    tag: 0.9.11-google_gpii.0
+    tag: 0.9.12-google_gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/gpii__exekube
     sha: sha256:20131cdaa65075d337889f0fb501dfd20016721c88c35578099ec4c7cadb0e6d


### PR DESCRIPTION
This PR adds GCS access logs for GCS buckets.

**Changes introduced:**
- Bump exekube to 0.9.12 (Adds access logs support)
- Add GCS access logs for tfstate
- Add GCS access logs for SD exports

**Downtime:**
None expected this is a zero-downtime change.

**Testing:**
Tested in dev environment.