### PR TITLE
Upgrade K8s to 1.15

### DIFF
--- a/gcp/modules/gke-cluster/main.tf
+++ b/gcp/modules/gke-cluster/main.tf
@@ -24,7 +24,7 @@ variable "node_count" {
 }
 
 variable "expected_gke_version_prefix" {
-  default = "1.14"
+  default = "1.15"
 }
 
 variable "infra_region" {}


### PR DESCRIPTION
This PR upgrades K8s/GKE version to 1.15 as it's now the default and GKE version 1.14 will be deprecated in R26 [1].

**Changes introduced:**
- Upgrade k8s to 1.15

**Downtime:**
None expected this is a zero-downtime change.

**Testing:**
Tested in dev environment.


[1]: https://cloud.google.com/kubernetes-engine/docs/release-notes#coming-soon-20200722