### PR TITLE
Fix IAM KMS missing permissions

### DIFF
--- a/common/modules/gcp-project/main.tf
+++ b/common/modules/gcp-project/main.tf
@@ -117,6 +117,7 @@ data "google_iam_policy" "combined" {
 
     members = [
       "${local.service_accounts}",
+      "${local.project_owners}",
     ]
   }
 


### PR DESCRIPTION
This PR should fix missing IAM permission in Staging org:
```
	* google_storage_bucket.exported-logs-custom-encryption: googleapi: Error 403: Permission denied on Cloud KMS key. Please ensure that your Cloud Storage service account has been authorized to use this key., forbidden
```

**Changes introduced:**
- Add `roles/cloudkms.cryptoKeyEncrypterDecrypter` to projectowner svc account

**Downtime:**
None expected this is a zero-downtime change.

**Testing:**
Tested in dev environment.