### PR TITLE
NOJIRA: Fix stackdriver export dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 default_docker: &default_docker
   docker:
-  - image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
+  - image: gcr.io/gpii-common-prd/gpii__exekube:0.9.13-google_gpii.0
 
 version: 2
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ terraform-fmt-check:
   tags:
     - common
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0 -- terraform fmt --check=true
+    - docker run --rm -v "$(pwd):/data" -w /data gcr.io/gpii-common-prd/gpii__exekube:0.9.13-google_gpii.0 -- terraform fmt --check=true
   only:
     - master@gpii-ops/gpii-infra
 
@@ -58,7 +58,7 @@ gcp-unit-tests:
   tags:
     - gcp
   script:
-    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0 -- sh -c "bundle install --with test && rake"
+    - docker run --rm -v "$(pwd):/data" -w /data/shared/rakefiles/tests gcr.io/gpii-common-prd/gpii__exekube:0.9.13-google_gpii.0 -- sh -c "bundle install --with test && rake"
   only:
     - master@gpii-ops/gpii-infra
 

--- a/common/docker-compose.yaml
+++ b/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.13-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/gcp/docker-compose.yaml
+++ b/gcp/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   xk:
-    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.12-google_gpii.0
+    image: gcr.io/gpii-common-prd/gpii__exekube:0.9.13-google_gpii.0
     working_dir: /project
     environment:
       USER: ${USER:?err}

--- a/shared/versions.yml
+++ b/shared/versions.yml
@@ -8,7 +8,7 @@
 exekube:
   upstream:
     repository: gpii/exekube
-    tag: 0.9.12-google_gpii.0
+    tag: 0.9.13-google_gpii.0
   generated:
     repository: gcr.io/gpii-common-prd/gpii__exekube
     sha: sha256:5e4e792ea41e83fc62c2a775fbf6d65ddb1523760e6c8733aab41d853854c055


### PR DESCRIPTION
Bumps exekube version

https://github.com/gpii-ops/exekube/releases/tag/0.9.13-google_gpii.0